### PR TITLE
Add pack-maker.sh to install

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,8 @@ dist_bin_SCRIPTS = \
 	build-chroots.sh \
 	init-mix.sh \
 	init-versions.sh \
-	update-bundles.sh
+	update-bundles.sh \
+	pack-maker.sh
 
 configdir = $(datadir)/defaults/mixer
 dist_config_DATA = yum.conf.in

--- a/pack-maker.sh
+++ b/pack-maker.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 # usage:
-#	pack_maker.sh <to version> <back_count>
-#	pack_maker.sh 2820 2
-#	pack_maker.sh 2730 3
+#	mixer-pack-maker.sh <to version> <back_count>
+#	mixer-pack-maker.sh 2820 2
+#	mixer-pack-maker.sh 2730 3
 #
 # For each bundle changed as of the Manifest.MoM at the <to version>,
 # create version-pair packs going back <back_count>


### PR DESCRIPTION
- Rename pack_maker.sh to pack-maker.sh for consistency with other
  scripts
- Add pack-maker.sh to Makefile.am

This change is necessary to allow future scripts to call
mixer-pack-maker.sh without providing a path to the local repo,
which could change from environment to environment.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>