### PR TITLE
Create super packs to save disk space

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,8 @@ dist_bin_SCRIPTS = \
 	init-mix.sh \
 	init-versions.sh \
 	update-bundles.sh \
-	pack-maker.sh
+	pack-maker.sh \
+	superpack-maker.sh
 
 configdir = $(datadir)/defaults/mixer
 dist_config_DATA = yum.conf.in

--- a/create-update.sh
+++ b/create-update.sh
@@ -5,9 +5,6 @@ PREFIX=
 LOG_DIR="$PWD/logs"
 NOPUBLISH=0
 ZEROPACKS=1
-BACK_COUNT=30       # Number of packs to create backward from current version
-DELTA_PACK_COUNT=5  # Number of those packs to keep as delta packs, the rest
-                    # will become symlinks to a superpack
 
 # Strip the trailing and leading whitespace on variables to sanitize them
 function strip_whitespace {
@@ -133,10 +130,6 @@ if [ $NOPUBLISH -eq 0 ]; then
 	sudo cp "$PWD/.mix-version" "$STATE_DIR/www/version/format$FORMAT/latest"
 fi
 
-# step 6: create delta packs and super packs
-sudo mixer-pack-maker.sh $MIXVER $BACK_COUNT
-sudo mixer-superpack-maker.sh $MIXVER $DELTA_PACK_COUNT $STATE_DIR
-
-# step 7: archive the swupd-server logs for this mix build
+# step 6: archive the swupd-server logs for this mix build
 mkdir -p "$LOG_DIR/$MIXVER"
 mv -f "$PWD"/swupd-*-$MIXVER.log "$LOG_DIR/$MIXVER/"

--- a/create-update.sh
+++ b/create-update.sh
@@ -5,6 +5,9 @@ PREFIX=
 LOG_DIR="$PWD/logs"
 NOPUBLISH=0
 ZEROPACKS=1
+BACK_COUNT=30       # Number of packs to create backward from current version
+DELTA_PACK_COUNT=5  # Number of those packs to keep as delta packs, the rest
+                    # will become symlinks to a superpack
 
 # Strip the trailing and leading whitespace on variables to sanitize them
 function strip_whitespace {
@@ -130,6 +133,10 @@ if [ $NOPUBLISH -eq 0 ]; then
 	sudo cp "$PWD/.mix-version" "$STATE_DIR/www/version/format$FORMAT/latest"
 fi
 
-# step 6: archive the swupd-server logs for this mix build
+# step 6: create delta packs and super packs
+sudo mixer-pack-maker.sh $MIXVER $BACK_COUNT
+sudo mixer-superpack-maker.sh $MIXVER $DELTA_PACK_COUNT $STATE_DIR
+
+# step 7: archive the swupd-server logs for this mix build
 mkdir -p "$LOG_DIR/$MIXVER"
 mv -f "$PWD"/swupd-*-$MIXVER.log "$LOG_DIR/$MIXVER/"

--- a/pack-maker.sh
+++ b/pack-maker.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 # usage:
-#	mixer-pack-maker.sh <to version> <back_count>
+#	mixer-pack-maker.sh <to version> <back_count> [<state_dir>]
 #	mixer-pack-maker.sh 2820 2
-#	mixer-pack-maker.sh 2730 3
+#	mixer-pack-maker.sh 2730 3 /home/clr/mix/update
 #
 # For each bundle changed as of the Manifest.MoM at the <to version>,
 # create version-pair packs going back <back_count>
@@ -11,6 +11,8 @@
 # "editors" last two change points were 2550 and 2260 and thus create a
 # 2550-to-2650 and a 2260-to-2650 version pair pack for the "editors"
 # bundle.
+#
+# state_dir defaults to /var/lib/update if not provided
 
 #NOTE: fullfiles must be created before calling this script
 #NOTE: zero packs need similarly created
@@ -22,8 +24,6 @@
 
 SWUPDREPO=${SWUPDREPO:-"/usr/src/clear-projects/swupd-server"}
 BUNDLEREPO=${BUNDLEREPO:-"/usr/src/clear-projects/clr-bundles"}
-UPDATEDIR=${UPDATEDIR:-"/var/lib/update"}
-SWUPDWEBDIR="${UPDATEDIR}/www"
 SWUPD_CERTS_DIR=${SWUPD_CERTS_DIR=:-"/root/swupd-certs"}
 
 export XZ_DEFAULTS="--threads 0"
@@ -36,6 +36,7 @@ export PASSPHRASE="${SWUPD_CERTS_DIR}/passphrase"
 
 VER=$1
 BACK_COUNT=$2
+STATE_DIR=$3
 
 if [ "${BACK_COUNT}" == "" ]; then
 	echo "missing to pack count"
@@ -46,6 +47,14 @@ if [ "${VER}" == "" ]; then
 	echo "missing to version"
 	exit 1
 fi
+
+if [ "${STATE_DIR}" == "" ]; then
+	echo "missing state dir, default is /var/lib/update"
+	STATE_DIR="/var/lib/update"
+fi
+
+UPDATEDIR=${STATE_DIR}
+SWUPDWEBDIR="${UPDATEDIR}/www"
 
 MOM=${SWUPDWEBDIR}/${VER}/Manifest.MoM
 if [ ! -e ${MOM} ]; then

--- a/superpack-maker.sh
+++ b/superpack-maker.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Create super packs
+#
+# usage:
+#
+#	mixer-superpack-maker.sh <to version> <delta pack count> [<update directory>]
+#
+#	mixer-superpack-maker.sh 2820 5 /home/clr/mix/update
+#		Creates superpack for version 2820. The superpack will replace the
+#		oldest pack in that directory, excluding zero packs. 5 delta packs will
+#		remain unchanged, the remaining delta packs will by symlinked to the
+#		superpack. This script will use /home/clr/mix/update for the update
+#		directory.
+#
+#	mixer-superpack-maker.sh 2820 5
+#		Same as above except the update dir will default to /var/lib/update
+
+# NOTE: delta packs must be created by calling mixer-pack-maker.sh before
+#       calling this script.
+
+if [ -z "$1" ]; then
+	echo "$0 - missing to version"
+	exit 1
+fi
+
+if [ -z "$2" ]; then
+	echo "$0 - missing delta pack count"
+	exit 1
+fi
+
+TO_VER=$1                           # $MIXVER in create_update.sh
+DELTA_PACK_COUNT=$2                 # $DELTA_PACK_COUNT in create_update.sh
+UPDATE_DIR=${3:-"/var/lib/update"}  # Defaults to /var/lib/update
+
+WORK_DIR=$UPDATE_DIR/www/$TO_VER
+CUR_DIR=$PWD
+
+# Measure size of all packs before superpack created, report to stdout
+INIT_SIZE=`sudo du -sck $WORK_DIR/pack* | tail -1 | awk {'print $1'}`
+echo "Initial size before super pack created: $INIT_SIZE kB"
+
+# Get a list of all bundles
+MOM=$WORK_DIR/Manifest.MoM
+BUNDLE_LIST=$(cat ${MOM} | awk -v V=${TO_VER} '$1 ~ /^M\./ && $3 == V { print $4 }')
+
+for BUNDLE in $BUNDLE_LIST; do
+	#SUPERPACK=""
+	echo "Creating superpack for $BUNDLE"
+	VER_LIST=()
+
+	# Get a list of all packs except 0 pack
+	VER_LIST=`ls $WORK_DIR | egrep -o "pack-$BUNDLE-from-[0-9]+.tar" | egrep -o '[1-9][0-9]*0'`
+	# Store in temporary file so we can version sort
+	for v in ${VER_LIST[@]}; do echo $v >> $WORK_DIR/tempver; done
+
+	if [ -e ${WORK_DIR}/tempver ]; then
+		VER_LIST=`sort --version-sort $WORK_DIR/tempver`
+		sudo rm $WORK_DIR/tempver
+	fi
+	VER_LIST=($VER_LIST)
+
+	# Make the super pack
+	# untar into superpack/delta and superpack/staged directory
+	# all delta files have different names to they won't be overwritten
+	# duplicate fullfiles are overwritten - this is where we save space
+	sudo mkdir -p "$WORK_DIR/superpack"/{"delta","staged"}
+	sudo mkdir $WORK_DIR/tmp
+	for v in ${VER_LIST[@]}; do
+		# untar into a tmp directory so we can move everything over
+		sudo tar -xf "$WORK_DIR/pack-$BUNDLE-from-$v.tar" -C $WORK_DIR/tmp
+		mv "$WORK_DIR/tmp/delta"/* "$WORK_DIR/superpack/delta" 2>/dev/null
+		mv "$WORK_DIR/tmp/staged"/* "$WORK_DIR/superpack/staged" 2>/dev/null
+	done
+	sudo rm -rf $WORK_DIR/tmp
+
+	# tar everything in the superpack into a tar file named for the oldest
+	# existing delta pack in the directory.
+	cd $WORK_DIR/superpack
+	sudo tar -cf "pack-$BUNDLE-from-${VER_LIST[0]}.tar" *
+	sudo mv "pack-$BUNDLE-from-${VER_LIST[0]}.tar" $WORK_DIR/
+	cd $CUR_DIR
+	sudo rm -rf $WORK_DIR/superpack
+
+	# remove unnecessary delta packs and create symlinks to the superpack with
+	# the same name as the removed delta pack.
+	let "NUM_PACKS = ${#VER_LIST[@]}"
+	let "END_BRIDGE = $NUM_PACKS - $DELTA_PACK_COUNT"
+	SUPERPACK="$WORK_DIR/pack-$BUNDLE-from-${VER_LIST[0]}.tar"
+	i=1
+	for v in ${VER_LIST[@]:1}; do
+		if [ $i -lt $END_BRIDGE ] && [ $NUM_PACKS -gt 1 ]; then
+			sudo rm "$WORK_DIR/pack-$BUNDLE-from-$v.tar"
+			sudo ln -s "$SUPERPACK" "$WORK_DIR/pack-$BUNDLE-from-$v.tar"
+		fi
+		let "i++"
+	done
+
+	# finally, compress the superpack and remove the .xz extension
+	sudo xz $SUPERPACK
+	sudo mv "$SUPERPACK.xz" $SUPERPACK
+done
+
+# report end size and delta size
+END_SIZE=`sudo du -sck $WORK_DIR/pack* | tail -1 | awk {'print $1'}`
+echo "Pack size after super pack created: $END_SIZE kB"
+
+let "DELTA_SIZE = $END_SIZE - $INIT_SIZE"
+echo "Total delta: $DELTA_SIZE kB"

--- a/superpack-maker.sh
+++ b/superpack-maker.sh
@@ -44,7 +44,6 @@ MOM=$WORK_DIR/Manifest.MoM
 BUNDLE_LIST=$(cat ${MOM} | awk -v V=${TO_VER} '$1 ~ /^M\./ && $3 == V { print $4 }')
 
 for BUNDLE in $BUNDLE_LIST; do
-	#SUPERPACK=""
 	echo "Creating superpack for $BUNDLE"
 	VER_LIST=()
 


### PR DESCRIPTION
- superpack-maker.sh

  Create superpacks for each bundle in an update version. The
  superpack replaces oldest pack in that directory (excluding
  zero packs) and is a superset of updates needed for all newer
  packs. Leaves a defined number of newest delta packs unchanged.
  The remaining delta packs are symlinked to the superpack.

- create-update.sh

  Define variables for superpack-maker.sh, call pack-maker.sh, and
  call superpack-maker.sh

- Makefile.am

  Install superpack-maker.sh

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>