### PR TITLE
Simplify the hardlink command invocation

### DIFF
--- a/create-update.sh
+++ b/create-update.sh
@@ -127,7 +127,7 @@ if [ $ZEROPACKS -eq 1 ]; then
 fi
 
 # step 4: hardlink relevant dirs
-sudo -E "hardlink" -f "$STATE_DIR/image/$MIXVER"/*
+sudo -E "hardlink" -f "$STATE_DIR/image/$MIXVER"/
 
 # step 5: update latest version
 if [ $NOPUBLISH -eq 0 ]; then


### PR DESCRIPTION
Because the intent is to create hardlinks where possible within the
image/MIXVER directory tree, only the toplevel directory name needs to
be given. This avoids arbitrarily long command lines when the glob is
expanded by the shell.

Signed-off-by: Patrick McCarty <patrick.mccarty@intel.com>