### PR TITLE
build-chroot: honor system's proxy

### DIFF
--- a/build-chroots.sh
+++ b/build-chroots.sh
@@ -34,9 +34,6 @@ BUILDTYPE="mix"
 # Desperately needs a fix in Clear...
 export LANG="en_US.utf8"
 
-unset http_proxy
-unset https_proxy
-
 check_dep() {
     type $1 &> /dev/null
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
We should follow the system's proxy configuration instead of working
around it.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>