### PR TITLE
Propogate repodir location to pack maker if set

### DIFF
--- a/create-update.sh
+++ b/create-update.sh
@@ -96,7 +96,11 @@ sudo -E "$PREFIX"swupd_make_fullfiles -S "$STATE_DIR" $MIXVER
 
 # step 3: create zero packs
 if [ $ZEROPACKS -eq 1 ]; then
-	sudo -E mixer-pack-maker.sh --to $MIXVER -S "$STATE_DIR"
+	if [ -z "$PREFIX" ]; then
+		sudo -E mixer-pack-maker.sh --to $MIXVER -S "$STATE_DIR"
+	else
+		sudo -E mixer-pack-maker.sh --to $MIXVER -S "$STATE_DIR" --repodir "$PREFIX"
+	fi
 fi
 
 # step 4: hardlink relevant dirs


### PR DESCRIPTION
Since create-update supports a custom location for the swupd-server
binaries, if that option is passed, it should be propogated to the
pack-maker, which also calls swupd_make_pack.

Signed-off-by: Patrick McCarty <patrick.mccarty@intel.com>