### PR TITLE
build-chroots: fail by default for errors

### DIFF
--- a/build-chroots.sh
+++ b/build-chroots.sh
@@ -4,6 +4,7 @@ if [ ! -f /usr/share/mixer-tools/helpers ]; then
     exit
 fi
 source /usr/share/mixer-tools/helpers
+set -e
 
 while [[ $# > 0 ]]
 do


### PR DESCRIPTION
The rest of the mixer-tools scripts (excluding the pack makers) already
set this shell option, so add it to the build-chroots script too.