### PR TITLE
helpers: fix error handling for dependency checks

### DIFF
--- a/helpers
+++ b/helpers
@@ -20,11 +20,13 @@ REPODIR=
 RPMDIR=
 
 check_dep() {
+    set +e
     type $1 &> /dev/null
     if [ $? -ne 0 ]; then
         echo "$1 program not found... Unable to continue"
         exit 1
     fi
+    set -e
 }
 
 check_deps() {


### PR DESCRIPTION
Because 'set -e' is enabled for init-mix.sh, the exit status of 'type'
is not checked, so an error raised by 'type' would exit immediately, not
running the $? conditional logic.

To fix, disable 'set -e' for the dependency check function.