### PR TITLE
Improve clr-bundles branch updates

### DIFF
--- a/helpers
+++ b/helpers
@@ -54,15 +54,14 @@ update_repo() {
 		git pull origin master
 	fi
 	set +e
-	# checkout the tag relating to the clear version used to build against
-	git checkout tags/"$CLRVER"
-	local branch="${CLRVER}_mix"
-	git rev-parse --verify "$branch"
+	# Ensure that CLRVER exists and is a tag
+	git rev-parse --verify "${CLRVER}^{tag}" &> /dev/null
 	if [ $? -eq 0 ]; then
-		git checkout "$branch"
-		git pull
-		else
-		git checkout -b "$branch"
+		# Always reset the _mix branch to be based off the tag
+		git checkout -B "${CLRVER}_mix" "${CLRVER}"
+	else
+		echo "ERROR: invalid CLEAR_VERSION in builder.conf (${CLRVER})"
+		exit 1
 	fi
 	set -e
 	cd ..

--- a/helpers
+++ b/helpers
@@ -55,10 +55,10 @@ update_repo() {
 	fi
 	set +e
 	# Ensure that CLRVER exists and is a tag
-	git rev-parse --verify "${CLRVER}^{tag}" &> /dev/null
+	git rev-parse --verify "refs/tags/${CLRVER}^{tag}" &> /dev/null
 	if [ $? -eq 0 ]; then
 		# Always reset the _mix branch to be based off the tag
-		git checkout -B "${CLRVER}_mix" "${CLRVER}"
+		git checkout -B "${CLRVER}_mix" "refs/tags/${CLRVER}"
 	else
 		echo "ERROR: invalid CLEAR_VERSION in builder.conf (${CLRVER})"
 		exit 1


### PR DESCRIPTION
With the current workflow, the "mix-bundles" repo is used for
mix-specific bundle changes, and the "clr-bundles" repo is treated as
read-only.

So in clr-bundles, the CLRVER_mix branches should always point to the
commit tagged with CLRVER. To make this handling more robust, first
verify that CLRVER exists and is a tag. Then create the CLRVER_mix
branch based on CLRVER, or if the branch already exists, reset it
appropriately.

Since this is the best place to detect invalid CLEAR_VERSION numbers
passed in the builder.conf, I've added that error handling too.