### PR TITLE
Ensure update-ca directory is created

### DIFF
--- a/src/builder/builder.go
+++ b/src/builder/builder.go
@@ -347,7 +347,13 @@ func (b *Builder) BuildChroots(template *x509.Certificate, privkey *rsa.PrivateK
 
 	// Only copy the certificate into the mix if it exists
 	if _, err := os.Stat(b.Cert); err == nil {
-		chrootcert := b.Statedir + "/image/" + b.Mixver + "/os-core-update/usr/share/clear/update-ca/Swupd_Root.pem"
+		certdir := b.Statedir + "/image/" + b.Mixver + "/os-core-update/usr/share/clear/update-ca"
+		err = os.MkdirAll(certdir, 0755)
+		if err != nil {
+			helpers.PrintError(err)
+			return err
+		}
+		chrootcert := certdir + "/Swupd_Root.pem"
 		fmt.Println("Copying Certificate into chroot...")
 		err = helpers.CopyFile(chrootcert, b.Cert)
 		if err != nil {


### PR DESCRIPTION
Starting with swupd-client v3.8.3, the update-ca directory is no longer
created for the build, so the cert copy is failing. Fix the issue by
creating the directory before the copy operation.