### PR TITLE
Merge git helper functions into one

### DIFF
--- a/src/builder/builder.go
+++ b/src/builder/builder.go
@@ -239,9 +239,10 @@ func (b *Builder) UpdateRepo(ver string, allbundles bool) {
 			os.Exit(1)
 		}
 		os.Chdir(b.Bundledir)
-		helpers.GitInit()
-		helpers.GitAdd()
-		helpers.GitCommit("Initial Mix version " + b.Mixver)
+		helpers.Git("init")
+		helpers.Git("add", ".")
+		commitMsg := fmt.Sprintf("Initial Mix Version %s from Clear Version %s", b.Mixver, b.Clearver)
+		helpers.Git("commit", "-m", commitMsg)
 		os.Chdir(curr)
 	}
 

--- a/src/helpers/helpers.go
+++ b/src/helpers/helpers.go
@@ -180,39 +180,14 @@ func GetDirContents(dirname string) []os.FileInfo {
 	return files
 }
 
-// GitInit attempts to initialize an empty git repository in the current
-// directory, or exits on failure.
-func GitInit() {
-	gitcmd := exec.Command("git", "init")
-	gitcmd.Stdout = os.Stdout
-	err := gitcmd.Run()
+// Git runs git with arguments and exit in case of failure.
+func Git(args ...string) {
+	cmd := exec.Command("git", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
 	if err != nil {
-		PrintError(err)
-		fmt.Println("Failed to init git repo, exiting...")
-		os.Exit(1)
-	}
-}
-
-// GitAdd performs a 'git add .' in the current directory
-func GitAdd() {
-	gitcmd := exec.Command("git", "add", ".")
-	gitcmd.Stdout = os.Stdout
-	err := gitcmd.Run()
-	if err != nil {
-		PrintError(err)
-		fmt.Println("Failed to add to git repo, exiting...")
-		os.Exit(1)
-	}
-}
-
-// GitCommit commits to a repo with a passed in string as the commit message
-func GitCommit(commitmsg string) {
-	gitcmd := exec.Command("git", "commit", "-m", commitmsg)
-	gitcmd.Stdout = os.Stdout
-	err := gitcmd.Run()
-	if err != nil {
-		PrintError(err)
-		fmt.Println("Failed to commit to git repo, exiting...")
+		fmt.Fprintf(os.Stderr, "ERROR: failed to run git %s: %v\n", strings.Join(args, " "), err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
And also dump the Stderr of the command to os.Stderr. Without a git
failure might not give enough information about what gone wrong,
e.g. when trying to call "git commit" without a user.email configured.

The commit message was changed to include the Clear version from which
the Mix was based off.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>