### PR TITLE
When HTTP download fails, don't keep the file around

### DIFF
--- a/src/helpers/helpers.go
+++ b/src/helpers/helpers.go
@@ -146,13 +146,6 @@ func CopyFile(dest string, src string) error {
 
 // Download will attempt to download a from URL to the given filename
 func Download(filename string, url string) (err error) {
-	out, err := os.Create(filename)
-	if err != nil {
-		PrintError(err)
-		return err
-	}
-	defer out.Close()
-
 	infile, err := http.Get(url)
 	if err != nil {
 		PrintError(err)
@@ -160,8 +153,16 @@ func Download(filename string, url string) (err error) {
 	}
 	defer infile.Body.Close()
 
+	out, err := os.Create(filename)
+	if err != nil {
+		PrintError(err)
+		return err
+	}
+	defer out.Close()
+
 	_, err = io.Copy(out, infile.Body)
 	if err != nil {
+		os.RemoveAll(filename)
 		PrintError(err)
 		return err
 	}


### PR DESCRIPTION
Only create the file if the HTTP connection succeeds, and in case of
failure later on during download, remove the partial file.

This let the user retries the operation, otherwise the empty/partial
file will prevent the download. One of such cases is forgetting to set
the https_proxy.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>