### PR TITLE
Save Mixer Upstream URL and Version

### DIFF
--- a/src/builder/builder.go
+++ b/src/builder/builder.go
@@ -34,6 +34,7 @@ type Builder struct {
 	Versiondir  string
 	Yumconf     string
 	Yumtemplate string
+	Upstreamurl string
 
 	Signing int
 	Bump    int
@@ -141,6 +142,14 @@ func (b *Builder) ReadVersions() {
 	}
 	b.Clearver = strings.TrimSpace(string(ver))
 	b.Clearver = strings.Replace(b.Clearver, "\n", "", -1)
+
+	ver, err = ioutil.ReadFile(b.Versiondir + "/.clearurl")
+	if err != nil {
+		helpers.PrintError(err)
+		os.Exit(1)
+	}
+	b.Upstreamurl = strings.TrimSpace(string(ver))
+	b.Upstreamurl = strings.Replace(b.Upstreamurl, "\n", "", -1)
 }
 
 // SignManifestMOM will sign the Manifest.Mom file in in place based on the Mix
@@ -302,24 +311,30 @@ func (b *Builder) AddBundles(bundles []string, force bool, git bool) int {
 
 // InitMix will initialise a new swupd-client consumable "mix" with the given
 // based Clear Linux version and specified mix version.
-func (b *Builder) InitMix(clearver string, mixver string, all bool) error {
+func (b *Builder) InitMix(clearver string, mixver string, all bool, upstreamurl string) error {
 	if clearver == "0" || mixver == "0" {
 		fmt.Println("ERROR: Please supply -clearver and -mixver")
 		os.Exit(1)
 	}
-	err := ioutil.WriteFile(b.Versiondir+"/.clearversion", []byte(clearver), 0644)
+	err := ioutil.WriteFile(b.Versiondir+"/.clearurl", []byte(upstreamurl), 0644)
 	if err != nil {
 		helpers.PrintError(err)
 		os.Exit(1)
 	}
-	b.Mixver = mixver
+	b.Upstreamurl = upstreamurl
+	err = ioutil.WriteFile(b.Versiondir+"/.clearversion", []byte(clearver), 0644)
+	if err != nil {
+		helpers.PrintError(err)
+		os.Exit(1)
+	}
+	b.Clearver = clearver
 
 	err = ioutil.WriteFile(b.Versiondir+"/.mixversion", []byte(mixver), 0644)
 	if err != nil {
 		helpers.PrintError(err)
 		os.Exit(1)
 	}
-	b.Clearver = clearver
+	b.Mixver = mixver
 
 	b.UpdateRepo(clearver, all)
 
@@ -357,7 +372,10 @@ func (b *Builder) BuildChroots(template *x509.Certificate, privkey *rsa.PrivateK
 			cmd.Run()
 
 		} else {
-			cmd := exec.Command("m4", "-D", "MIXER_REPO", "-D", "MIXER_REPOPATH="+b.Repodir, b.Yumtemplate)
+			cmd := exec.Command("m4", "-D", "MIXER_REPO",
+				"-D", "MIXER_REPOPATH="+b.Repodir,
+				"-D", "UPSTREAM_URL="+b.Upstreamurl,
+				b.Yumtemplate)
 			cmd.Stdout = outfile
 			cmd.Run()
 		}
@@ -442,6 +460,21 @@ func (b *Builder) setVersion(publish bool) {
 	}
 
 	err = ioutil.WriteFile(b.Statedir+"/image/LAST_VER", []byte(b.Mixver), 0644)
+	if err != nil {
+		helpers.PrintError(err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Saving the upstream version URL " + b.Upstreamurl)
+	upstream_url := b.Statedir + "/www/" + b.Mixver + "/upstream_url"
+	err = ioutil.WriteFile(upstream_url, []byte(b.Upstreamurl), 0644)
+	if err != nil {
+		helpers.PrintError(err)
+		os.Exit(1)
+	}
+	fmt.Println("Saving the upstream version " + b.Clearver)
+	upstream_ver := b.Statedir + "/www/" + b.Mixver + "/upstream_ver"
+	err = ioutil.WriteFile(upstream_ver, []byte(b.Clearver), 0644)
 	if err != nil {
 		helpers.PrintError(err)
 		os.Exit(1)

--- a/src/mixer/main.go
+++ b/src/mixer/main.go
@@ -227,14 +227,15 @@ func cmdAddBundles(args []string) {
 func cmdInitMix(args []string) {
 	initcmd := flag.NewFlagSet("init-mix", flag.ExitOnError)
 	allflag := initcmd.Bool("all", false, "Create a mix with all Clear bundles included")
-	clearflag := initcmd.Int("clearver", 0, "Supply the Clear version to compose the mix from")
+	clearflag := initcmd.Int("clearver", 1, "Supply the Clear version to compose the mix from")
 	mixflag := initcmd.Int("mixver", 0, "Supply the Mix version to build")
 	initconf := initcmd.String("config", "", "Supply a specific builder.conf to use for mixing")
+	upstreamurl := initcmd.String("upstreamurl", "https://download.clearlinux.org", "Supply an upstream URL to use for mixing")
 	initcmd.Parse(args)
 	b := builder.New()
 	b.LoadBuilderConf(*initconf)
 	b.ReadBuilderConf()
-	b.InitMix(strconv.Itoa(*clearflag), strconv.Itoa(*mixflag), *allflag)
+	b.InitMix(strconv.Itoa(*clearflag), strconv.Itoa(*mixflag), *allflag, *upstreamurl)
 }
 
 func cmdHelp(args []string) {

--- a/yum.conf.in
+++ b/yum.conf.in
@@ -13,7 +13,7 @@ reposdir=/root/mash
 [clear]
 name=Clear
 failovermethod=priority
-baseurl=https://download.clearlinux.org/releases/$releasever/clear/x86_64/os/
+baseurl=UPSTREAM_URL/releases/$releasever/clear/x86_64/os/
 enabled=1
 gpgcheck=0
 


### PR DESCRIPTION
In order to known if there have been format bumps of the
version of ClearLinux this mix is based upon (upstream),
both the source URL and version will be needed.

See https://github.com/clearlinux/mixer-tools/issues/30

Signed-off-by: Mark Horn <mark.d.horn@intel.com>