### PR TITLE
Add mixer add-bundles command

### DIFF
--- a/src/helpers/helpers.go
+++ b/src/helpers/helpers.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -110,6 +111,28 @@ func ReadFileAndSplit(filename string) ([]string, error) {
 	lines := strings.Split(data, "\n")
 
 	return lines, nil
+}
+
+// GetIncludedBundles parses a bundle definition file and returns a list of all
+// bundles it includes.
+func GetIncludedBundles(filename string) ([]string, error) {
+	lines, err := ReadFileAndSplit(filename)
+	if err != nil {
+		PrintError(err)
+		return nil, err
+	}
+
+	// Note: Matches lines like "include(os-core-update)", pulling out
+	// the string between the parens. The "\" needs to be escaped due to
+	// Go's string literal parsing, so "\\(" matches "("
+	r := regexp.MustCompile("^include\\(([A-Za-z0-9-]+)\\)$")
+	var includes []string
+	for _, line := range lines {
+		if matches := r.FindStringSubmatch(line); len(matches) > 1 {
+			includes = append(includes, matches[1])
+		}
+	}
+	return includes, nil
 }
 
 // CopyFile is used during the build process to copy a given file to the target

--- a/src/mixer/main.go
+++ b/src/mixer/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 
 	"builder"
 	"helpers"
@@ -28,6 +29,7 @@ func init() {
 		{"build-image", "Build an image from the mix content", cmdBuildImage},
 		{"add-rpms", "Add rpms to local yum repository", cmdAddRPMs},
 		{"get-bundles", "Get the clr-bundles from upstream", cmdGetBundles},
+		{"add-bundles", "Add clr-bundles to your mix", cmdAddBundles},
 		{"init-mix", "Initialize the mixer and workspace", cmdInitMix},
 		{"help", "Show help options", cmdHelp},
 	}
@@ -200,6 +202,24 @@ func cmdGetBundles(args []string) {
 	b := builder.NewFromConfig(*bundleconf)
 	fmt.Println("Getting clr-bundles for version " + b.Clearver)
 	b.UpdateRepo(b.Clearver, false)
+}
+
+func cmdAddBundles(args []string) {
+	flags := flag.NewFlagSet("add-bundles", flag.ExitOnError)
+	bundlesarg := flags.String("bundles", "", "Comma-separated list of bundles to add")
+	force := flags.Bool("force", false, "Override bundles that already exist")
+	git := flags.Bool("git", false, "Automatically apply new git commit")
+	conf := flags.String("config", "", "Supply a specific builder.conf to use for mixing")
+	flags.Parse(args)
+
+	if len(*bundlesarg) == 0 {
+		flags.Usage()
+		os.Exit(1)
+	}
+
+	b := builder.NewFromConfig(*conf)
+	bundles := strings.Split(*bundlesarg, ",")
+	b.AddBundles(bundles, *force, *git)
 }
 
 func cmdInitMix(args []string) {


### PR DESCRIPTION
Implements Issue https://github.com/clearlinux/mixer-tools/issues/32

Adds new "mixer add-bundles" command to automate the
addition of bundles to the mix-bundles/ directory.

Currently, adding bundles to your mix means copying
them manually from the pulled
clear-bundles/clear-bundles-&lt;VER&gt;/bundles/ dir to your
mix-bundles/ dir. This is a manual process, and thus
following bundle dependencies (i.e., “include
(other-bundle)”) is a manual process.

This new command parses the requested bundle definitions
and recursively copies bundles into your mix dir. Skips
(with warning) by default if present, or overwrites with
optional "-force" flag. Also optionally auto git commits
new bundle addition with "-git" flag.

Example usage:
```
$ mixer add-bundles -help
Mixer 3.1.0
Usage of add-bundles:
  -bundles string
    	Comma-separated list of bundles to add
  -config string
    	Supply a specific builder.conf to use for mixing
  -force
    	Override bundles that already exist
  -git
    	Automatically apply new git commit
```