### PR TITLE
Add new args for build-image

### DIFF
--- a/src/builder/builder.go
+++ b/src/builder/builder.go
@@ -526,14 +526,19 @@ func (b *Builder) BuildUpdate(prefixflag string, minvflag int, formatflag string
 
 // BuildImage will now proceed to build the full image with the previously
 // validated configuration.
-func (b *Builder) BuildImage(format string) {
+func (b *Builder) BuildImage(format string, template string) {
 	// If the user did not pass in a format, default to builder.conf
 	if format == "" {
 		format = b.Format
 	}
 
+	// If the user did not pass in a template, default to release-image-config.json
+	if template == "" {
+		template = "release-image-config.json"
+	}
+
 	content := "file://" + b.Statedir + "/www"
-	imagecmd := exec.Command("ister.py", "-t", "release-image-config.json", "-V", content, "-C", content, "-f", format, "-s", b.Cert)
+	imagecmd := exec.Command("ister.py", "-t", template, "-V", content, "-C", content, "-f", format, "-s", b.Cert)
 	imagecmd.Stdout = os.Stdout
 	imagecmd.Stderr = os.Stderr
 

--- a/src/mixer/main.go
+++ b/src/mixer/main.go
@@ -175,11 +175,13 @@ func cmdBuildUpdate(args []string) {
 func cmdBuildImage(args []string) {
 	imagecmd := flag.NewFlagSet("build-image", flag.ExitOnError)
 	imageformat := imagecmd.String("format", "", "Supply the format used for the Mix")
+	conf := imagecmd.String("config", "", "Supply a specific builder.conf to use for mixing")
+	imagetemplate := imagecmd.String("template", "", "Path to tempalte file to use")
 
 	imagecmd.Parse(args)
 
-	b := builder.NewFromConfig("")
-	b.BuildImage(*imageformat)
+	b := builder.NewFromConfig(*conf)
+	b.BuildImage(*imageformat, *imagetemplate)
 }
 
 func cmdAddRPMs(args []string) {


### PR DESCRIPTION
build-image wants a builder.conf file, but the -config option was
missing from this command.

build-image assumed the template file was a hard coded name; added
functionality to pass through with new -template argument.

Signed-off-by: Mark Horn <mark.d.horn@intel.com>