### PR TITLE
Add -all flag to mixer add-bundles

### DIFF
--- a/src/builder/builder.go
+++ b/src/builder/builder.go
@@ -232,8 +232,9 @@ func (b *Builder) UpdateRepo(ver string, allbundles bool) {
 // Linux version to the mix-bundles directory
 // bundles: array slice of bundle names
 // force: override bundle in mix-dir when present
+// all: include all CLR bundles. Overrides bundles.
 // git: automatically git commit with bundles added
-func (b *Builder) AddBundles(bundles []string, force bool, git bool) int {
+func (b *Builder) AddBundles(bundles []string, force bool, allbundles bool, git bool) int {
 	var bundleAddCount int
 
 	bundledir := b.Bundledir
@@ -254,6 +255,24 @@ func (b *Builder) AddBundles(bundles []string, force bool, git bool) int {
 		b.UpdateRepo(b.Clearver, false)
 	}
 
+	// Add all bundles if -all passed
+	if allbundles {
+		files, err := ioutil.ReadDir(clrbundledir)
+		if err != nil {
+			helpers.PrintError(err)
+			os.Exit(1)
+		}
+
+		// Clear out bundles if not empty
+		if len(bundles) > 0 {
+			bundles = make([]string, len(files))
+		}
+
+		for _, file := range files {
+			bundles = append(bundles, file.Name())
+		}
+	}
+
 	var includes []string
 	for _, bundle := range bundles {
 		// Check if bundle exists in clrbundledir
@@ -263,16 +282,21 @@ func (b *Builder) AddBundles(bundles []string, force bool, git bool) int {
 		}
 		// Check if bundle exists in mix bundles dir
 		if _, err := os.Stat(bundledir + bundle); os.IsNotExist(err) || force {
-			// Parse bundle to get all includes
-			if ib, err := helpers.GetIncludedBundles(clrbundledir + bundle); err != nil {
-				helpers.PrintError(errors.New("Cannot parse bundle " + bundle + " from CLR version " + b.Clearver))
-				os.Exit(1)
-			} else if len(ib) > 0 {
-				includes = append(includes, ib...)
+			if !allbundles {
+				// Parse bundle to get all includes
+				if ib, err := helpers.GetIncludedBundles(clrbundledir + bundle); err != nil {
+					helpers.PrintError(errors.New("Cannot parse bundle " + bundle + " from CLR version " + b.Clearver))
+					os.Exit(1)
+				} else if len(ib) > 0 {
+					includes = append(includes, ib...)
+				}
 			}
 
 			fmt.Printf("Adding bundle %q\n", bundle)
-			helpers.CopyFile(bundledir+bundle, clrbundledir+bundle)
+			if err = helpers.CopyFile(bundledir+bundle, clrbundledir+bundle); err != nil {
+				helpers.PrintError(err)
+				os.Exit(1)
+			}
 			bundleAddCount++
 		} else {
 			fmt.Printf("Warning: bundle %q already exists; skipping.\n", bundle)
@@ -280,7 +304,7 @@ func (b *Builder) AddBundles(bundles []string, force bool, git bool) int {
 	}
 	// Recurse on included bundles
 	if len(includes) > 0 {
-		bundleAddCount += b.AddBundles(includes, force, false)
+		bundleAddCount += b.AddBundles(includes, force, false, false)
 	}
 
 	if git && bundleAddCount > 0 {
@@ -294,7 +318,7 @@ func (b *Builder) AddBundles(bundles []string, force bool, git bool) int {
 		os.Chdir(bundledir)
 		helpers.Git("add", ".")
 		commitMsg := fmt.Sprintf("Added bundles from Clear Version %s\n\nBundles added: %v", b.Clearver, bundles)
-		helpers.Git("commit", "-m", commitMsg)
+		helpers.Git("commit", "-q", "-m", commitMsg)
 		os.Chdir(curr)
 	}
 	return bundleAddCount

--- a/src/mixer/main.go
+++ b/src/mixer/main.go
@@ -210,18 +210,23 @@ func cmdAddBundles(args []string) {
 	flags := flag.NewFlagSet("add-bundles", flag.ExitOnError)
 	bundlesarg := flags.String("bundles", "", "Comma-separated list of bundles to add")
 	force := flags.Bool("force", false, "Override bundles that already exist")
+	all := flags.Bool("all", false, "Add all bundles from CLR; takes precedence over -bundles")
 	git := flags.Bool("git", false, "Automatically apply new git commit")
 	conf := flags.String("config", "", "Supply a specific builder.conf to use for mixing")
 	flags.Parse(args)
 
-	if len(*bundlesarg) == 0 {
-		flags.Usage()
-		os.Exit(1)
+	var bundles []string
+	if !*all {
+		if len(*bundlesarg) == 0 {
+			flags.Usage()
+			os.Exit(1)
+		} else {
+			bundles = strings.Split(*bundlesarg, ",")
+		}
 	}
 
 	b := builder.NewFromConfig(*conf)
-	bundles := strings.Split(*bundlesarg, ",")
-	b.AddBundles(bundles, *force, *git)
+	b.AddBundles(bundles, *force, *all, *git)
 }
 
 func cmdInitMix(args []string) {


### PR DESCRIPTION
Adds support for an '-all' flag to mixer add-bundles.
This flag takes precedence over the list passed with
the '-bundles' flag, and still supports '-force' and
'-git' options.

Note: this commit also passes the '-q' ('--quiet')
flag to git when making a commit, supressing the
potentially long output.