### PR TITLE
helpers: check http.Get status code

### DIFF
--- a/src/builder/builder.go
+++ b/src/builder/builder.go
@@ -182,7 +182,7 @@ func (b *Builder) UpdateRepo(ver string, allbundles bool) {
 	URL := "https://github.com/clearlinux/clr-bundles/archive/" + ver + ".tar.gz"
 	err := helpers.Download(repo, URL)
 	if err != nil {
-		fmt.Println("ERROR: Failed to download new clr-bundles, make sure the version is valid")
+		fmt.Fprintf(os.Stderr, "ERROR: Failed to download clr-bundles, make sure the version is valid: %s\n", err)
 		os.Exit(1)
 	}
 

--- a/src/helpers/helpers.go
+++ b/src/helpers/helpers.go
@@ -171,14 +171,16 @@ func CopyFile(dest string, src string) error {
 func Download(filename string, url string) (err error) {
 	infile, err := http.Get(url)
 	if err != nil {
-		PrintError(err)
 		return err
 	}
 	defer infile.Body.Close()
 
+	if infile.StatusCode != http.StatusOK {
+		return fmt.Errorf("Get %s replied: %d (%s)", url, infile.StatusCode, http.StatusText(infile.StatusCode))
+	}
+
 	out, err := os.Create(filename)
 	if err != nil {
-		PrintError(err)
 		return err
 	}
 	defer out.Close()
@@ -186,7 +188,6 @@ func Download(filename string, url string) (err error) {
 	_, err = io.Copy(out, infile.Body)
 	if err != nil {
 		os.RemoveAll(filename)
-		PrintError(err)
 		return err
 	}
 


### PR DESCRIPTION
Also change the caller code to show what error happened: useful to
distinguish 404 from timeouts.

Fix the issue of writing invalid files (without error) if the
.clearversion do not exist. The contents would have the actual error
code.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>