### PR TITLE
mixer init

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -222,7 +222,7 @@ func (b *Builder) UpdateRepo(ver string, allbundles bool) {
 				os.Exit(1)
 			}
 			for _, file := range files {
-				if err := helpers.CopyFile(bundles+"/"+file.Name(), clrbundles+file.Name()); err != nil {
+				if err := helpers.CopyFile(bundles+"/"+file.Name(), clrbundles+file.Name(), true); err != nil {
 					helpers.PrintError(err)
 					os.Exit(1)
 				}
@@ -230,22 +230,22 @@ func (b *Builder) UpdateRepo(ver string, allbundles bool) {
 		} else {
 			// Install only a minimal set of bundles
 			fmt.Println("Adding os-core, os-core-update, kernel-native, bootloader to mix-bundles...")
-			if err := helpers.CopyFile(bundles+"/os-core", clrbundles+"os-core"); err != nil {
+			if err := helpers.CopyFile(bundles+"/os-core", clrbundles+"os-core", true); err != nil {
 				helpers.PrintError(err)
 				os.Exit(1)
 			}
 
-			if err := helpers.CopyFile(bundles+"/os-core-update", clrbundles+"os-core-update"); err != nil {
+			if err := helpers.CopyFile(bundles+"/os-core-update", clrbundles+"os-core-update", true); err != nil {
 				helpers.PrintError(err)
 				os.Exit(1)
 			}
 
-			if err := helpers.CopyFile(bundles+"/kernel-native", clrbundles+"kernel-native"); err != nil {
+			if err := helpers.CopyFile(bundles+"/kernel-native", clrbundles+"kernel-native", true); err != nil {
 				helpers.PrintError(err)
 				os.Exit(1)
 			}
 
-			if err := helpers.CopyFile(bundles+"/bootloader", clrbundles+"bootloader"); err != nil {
+			if err := helpers.CopyFile(bundles+"/bootloader", clrbundles+"bootloader", true); err != nil {
 				helpers.PrintError(err)
 				os.Exit(1)
 			}
@@ -333,7 +333,7 @@ func (b *Builder) AddBundles(bundles []string, force bool, allbundles bool, git 
 			}
 
 			fmt.Printf("Adding bundle %q\n", bundle)
-			if err = helpers.CopyFile(bundledir+bundle, clrbundledir+bundle); err != nil {
+			if err = helpers.CopyFile(bundledir+bundle, clrbundledir+bundle, true); err != nil {
 				helpers.PrintError(err)
 				os.Exit(1)
 			}
@@ -484,7 +484,7 @@ func (b *Builder) BuildChroots(template *x509.Certificate, privkey *rsa.PrivateK
 		}
 		chrootcert := certdir + "/Swupd_Root.pem"
 		fmt.Println("Copying Certificate into chroot...")
-		if err = helpers.CopyFile(chrootcert, b.Cert); err != nil {
+		if err = helpers.CopyFile(chrootcert, b.Cert, true); err != nil {
 			helpers.PrintError(err)
 			return err
 		}
@@ -665,7 +665,7 @@ func (b *Builder) AddRPMList(rpms []os.FileInfo) {
 		fmt.Printf("Hardlinking %s to repodir\n", rpm.Name())
 		err := os.Link(b.Rpmdir+"/"+rpm.Name(), b.Repodir+"/"+rpm.Name())
 		if err != nil {
-			if err = helpers.CopyFile(b.Repodir+"/"+rpm.Name(), b.Rpmdir+"/"+rpm.Name()); err != nil {
+			if err = helpers.CopyFile(b.Repodir+"/"+rpm.Name(), b.Rpmdir+"/"+rpm.Name(), true); err != nil {
 				helpers.PrintError(err)
 				os.Exit(1)
 			}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -222,15 +222,33 @@ func (b *Builder) UpdateRepo(ver string, allbundles bool) {
 				os.Exit(1)
 			}
 			for _, file := range files {
-				helpers.CopyFile(bundles+"/"+file.Name(), clrbundles+file.Name())
+				if err := helpers.CopyFile(bundles+"/"+file.Name(), clrbundles+file.Name()); err != nil {
+					helpers.PrintError(err)
+					os.Exit(1)
+				}
 			}
 		} else {
 			// Install only a minimal set of bundles
 			fmt.Println("Adding os-core, os-core-update, kernel-native, bootloader to mix-bundles...")
-			helpers.CopyFile(bundles+"/os-core", clrbundles+"os-core")
-			helpers.CopyFile(bundles+"/os-core-update", clrbundles+"os-core-update")
-			helpers.CopyFile(bundles+"/kernel-native", clrbundles+"kernel-native")
-			helpers.CopyFile(bundles+"/bootloader", clrbundles+"bootloader")
+			if err := helpers.CopyFile(bundles+"/os-core", clrbundles+"os-core"); err != nil {
+				helpers.PrintError(err)
+				os.Exit(1)
+			}
+
+			if err := helpers.CopyFile(bundles+"/os-core-update", clrbundles+"os-core-update"); err != nil {
+				helpers.PrintError(err)
+				os.Exit(1)
+			}
+
+			if err := helpers.CopyFile(bundles+"/kernel-native", clrbundles+"kernel-native"); err != nil {
+				helpers.PrintError(err)
+				os.Exit(1)
+			}
+
+			if err := helpers.CopyFile(bundles+"/bootloader", clrbundles+"bootloader"); err != nil {
+				helpers.PrintError(err)
+				os.Exit(1)
+			}
 		}
 
 		// Save current dir so we can get back to it
@@ -466,8 +484,7 @@ func (b *Builder) BuildChroots(template *x509.Certificate, privkey *rsa.PrivateK
 		}
 		chrootcert := certdir + "/Swupd_Root.pem"
 		fmt.Println("Copying Certificate into chroot...")
-		err = helpers.CopyFile(chrootcert, b.Cert)
-		if err != nil {
+		if err = helpers.CopyFile(chrootcert, b.Cert); err != nil {
 			helpers.PrintError(err)
 			return err
 		}
@@ -648,8 +665,7 @@ func (b *Builder) AddRPMList(rpms []os.FileInfo) {
 		fmt.Printf("Hardlinking %s to repodir\n", rpm.Name())
 		err := os.Link(b.Rpmdir+"/"+rpm.Name(), b.Repodir+"/"+rpm.Name())
 		if err != nil {
-			err = helpers.CopyFile(b.Repodir+"/"+rpm.Name(), b.Rpmdir+"/"+rpm.Name())
-			if err != nil {
+			if err = helpers.CopyFile(b.Repodir+"/"+rpm.Name(), b.Rpmdir+"/"+rpm.Name()); err != nil {
 				helpers.PrintError(err)
 				os.Exit(1)
 			}

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -137,14 +137,19 @@ func GetIncludedBundles(filename string) ([]string, error) {
 
 // CopyFile is used during the build process to copy a given file to the target
 // instead of dealing with the particulars of hardlinking.
-func CopyFile(dest string, src string) error {
+func CopyFile(dest string, src string, overwrite bool) error {
 	source, err := os.Open(src)
 	if err != nil {
 		return err
 	}
 	defer source.Close()
 
-	destination, err := os.Create(dest)
+	flags := os.O_RDWR | os.O_CREATE
+	if !overwrite {
+		flags |= os.O_EXCL
+	}
+
+	destination, err := os.OpenFile(dest, flags, 0666)
 	if err != nil {
 		return err
 	}

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -140,27 +140,23 @@ func GetIncludedBundles(filename string) ([]string, error) {
 func CopyFile(dest string, src string) error {
 	source, err := os.Open(src)
 	if err != nil {
-		PrintError(err)
 		return err
 	}
 	defer source.Close()
 
 	destination, err := os.Create(dest)
 	if err != nil {
-		PrintError(err)
 		return err
 	}
 	defer destination.Close()
 
 	_, err = io.Copy(destination, source)
 	if err != nil {
-		PrintError(err)
 		return err
 	}
 
 	err = destination.Sync()
 	if err != nil {
-		PrintError(err)
 		return err
 	}
 

--- a/mixer/main.go
+++ b/mixer/main.go
@@ -240,6 +240,8 @@ func cmdInitMix(args []string) {
 	upstreamurl := initcmd.String("upstreamurl", "https://download.clearlinux.org", "Supply an upstream URL to use for mixing")
 	initcmd.Parse(args)
 	b := builder.New()
+	b.CreateDefaultConfig(*initconf)
+	b.CreateRpmDirs()
 	b.LoadBuilderConf(*initconf)
 	b.ReadBuilderConf()
 	b.InitMix(strconv.Itoa(*clearflag), strconv.Itoa(*mixflag), *allflag, *upstreamurl)


### PR DESCRIPTION
This patchset is separated into 2 dependent parts.

The first two commits are focused on changing the CopyFile helper function so the code can be reused in the following patch. The main change here is the addition of a selective O_EXCL flag when creating the destination file. This allows the copy to fail if the target file already exists. The error handling was also removed from the function and now the caller decides what to do with the error. Proper error handling was added where missing. Note that this changes the behavior of the program. Previously the program would print the error and keep running if CopyFile failed to execute. Now the execution is terminated with an error code.

The second part adds a new command: `mixer init`. The first patch adds the basic functionality which creates and initializes `builder.conf` and the `rpms` and `local` directories. The second patch extends this functionality a bit further and integrates `init-mix` into the `init` command. 

Right now the configuration of `builder.conf` is done by string replacing as there is no proper parsing for the TOML conf file. Ideally the builder object should be able to load and save itself to file format, so there would be no need to copy the template from a hardcoded path nor use regex to load/save `builder.conf` . I plan to work on this next.