### PR TITLE
Update the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ gopath:
 	@echo "Code already in existing GOPATH=${GOPATH}"
 endif
 
-.PHONY: all compliant build install clean
+.PHONY: all compliant build install clean check
 
 .DEFAULT_GOAL := all
 all: compliant build
@@ -51,6 +51,9 @@ install: gopath
 	install -m 00755 pack-maker.sh $(DESTDIR)/usr/bin/mixer-pack-maker.sh
 	install -m 00755 superpack-maker.sh $(DESTDIR)/usr/bin/mixer-superpack-maker.sh
 	install -D -m 00644 yum.conf.in $(DESTDIR)/usr/share/defaults/mixer/yum.conf.in
+
+check: gopath
+	go test ${GO_PACKAGE_PREFIX}/...
 
 clean:
 ifeq (,${LOCAL_GOPATH})

--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,15 @@ else
 endif
 	rm -f mixer-tools-*.tar.gz
 
-VERSION = 3.2.0
 release:
 	@if [ ! -d .git ]; then \
 		echo "Release needs to be used from a git repository"; \
 		exit 1; \
 	fi
-	git archive --format=tar.gz --verbose -o mixer-tools-$(VERSION).tar.gz HEAD --prefix=mixer-tools-$(VERSION)/
+	@VERSION=$$(grep -e 'const Version' mixer/main.go | cut -d '"' -f 2) ; \
+	if [ -z "$$VERSION" ]; then \
+		echo "Couldn't extract version number from the source code"; \
+		exit 1; \
+	fi; \
+	git archive --format=tar.gz --verbose -o mixer-tools-$$VERSION.tar.gz HEAD --prefix=mixer-tools-$$VERSION/
 

--- a/mixer/main.go
+++ b/mixer/main.go
@@ -13,6 +13,8 @@ import (
 	"github.com/clearlinux/mixer-tools/helpers"
 )
 
+const Version = "3.2.0"
+
 type Command struct {
 	Name        string
 	Description string
@@ -62,7 +64,7 @@ func CheckDeps() error {
 }
 
 func main() {
-	fmt.Println("Mixer 3.2.0")
+	fmt.Printf("Mixer %s\n", Version)
 	os.Setenv("LD_PRELOAD", "/usr/lib64/nosync/nosync.so")
 
 	if len(os.Args) == 1 {


### PR DESCRIPTION
Update the Makefile to work when we are outside a GOPATH. Note that developers are still encouraged to be inside a GOPATH. The Makefile is mostly intended for package creation.

Fixes #40.

This also fixes the recent regression of "make" not working with release tarballs.