### PR TITLE
Makefile: add a 'make lint' to run gometalinter.v1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,4 @@ before_install:
     - gometalinter.v1 --install
 
 script:
-    - gometalinter.v1 --deadline=10m --tests --vendor --disable-all --enable=misspell --enable=vet --enable=ineffassign --enable=gofmt --enable=gocyclo --cyclo-over=10 --enable=golint --enable=deadcode --enable=varcheck --enable=structcheck --enable=unused ./...
-
+    - make lint

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,21 @@ install: gopath
 check: gopath
 	go test ${GO_PACKAGE_PREFIX}/...
 
+.PHONY: lint
+lint: gopath
+	@gometalinter.v1 --deadline=10m --tests --vendor --disable-all \
+	--enable=misspell \
+	--enable=vet \
+	--enable=ineffassign \
+	--enable=gofmt \
+	--enable=gocyclo --cyclo-over=10 \
+	--enable=golint \
+	--enable=deadcode \
+	--enable=varcheck \
+	--enable=structcheck \
+	--enable=unused \
+	./...
+
 clean:
 ifeq (,${LOCAL_GOPATH})
 	go clean -i -x


### PR DESCRIPTION
Make easy to run the same checks as travis.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>