### PR TITLE
Do not enforce a specific cyclomatic complexity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ lint: gopath
 	--enable=vet \
 	--enable=ineffassign \
 	--enable=gofmt \
-	--enable=gocyclo --cyclo-over=10 \
+	$${CYCLO_MAX:+--enable=gocyclo --cyclo-over=$${CYCLO_MAX}} \
 	--enable=golint \
 	--enable=deadcode \
 	--enable=varcheck \


### PR DESCRIPTION
Some sequential series of steps are better handled in a long function
than in multiple small functions. Forcing a low number might make
those functions "pass the test" but less readable in the end.
    
The gocyclo can be an useful tool but it shouldn't be used to enforce
a certain limit.
