### PR TITLE
Write three more tests for manifest creation

### DIFF
--- a/swupd/config.go
+++ b/swupd/config.go
@@ -161,6 +161,16 @@ func readLastVerFile(path string) (uint32, error) {
 	return uint32(parsed), nil
 }
 
+func appendUnique(ss []string, s string) []string {
+	for _, e := range ss {
+		if e == s {
+			return ss
+		}
+	}
+
+	return append(ss, s)
+}
+
 func readIncludesFile(path string) ([]string, error) {
 	if !exists(path) {
 		return []string{}, nil
@@ -172,10 +182,11 @@ func readIncludesFile(path string) ([]string, error) {
 		return []string{}, err
 	}
 
-	includes := strings.Split(string(allIncludes), "\n")
-	if includes[len(includes)-1] == "" {
-		// remove trailing empty string caused by trailing newline
-		includes = includes[:len(includes)-1]
+	includes := []string{}
+	for _, s := range strings.Split(string(allIncludes), "\n") {
+		if s != "" {
+			includes = appendUnique(includes, s)
+		}
 	}
 
 	return includes, nil

--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -304,3 +304,23 @@ func TestCreateManifestIncludesDeduplicate(t *testing.T) {
 		t.Error("includes not deduplicated for version 20")
 	}
 }
+
+func TestCreateManifestDeletes(t *testing.T) {
+	testDir := mustSetupTestDir(t, "deletes")
+	defer removeIfNoErrors(t, testDir)
+	mustInitStandardTest(t, testDir, "0", "10", []string{"test-bundle"})
+	mustGenFile(t, testDir, "10", "test-bundle", "test", "test")
+	if err := CreateManifests(10, false, 1, testDir); err != nil {
+		t.Fatal(err)
+	}
+
+	mustInitStandardTest(t, testDir, "10", "20", []string{"test-bundle"})
+	if err := CreateManifests(20, false, 1, testDir); err != nil {
+		t.Fatal(err)
+	}
+
+	deletedLine := []byte(".d..\t" + AllZeroHash + "\t20\t/test")
+	if !fileContains(filepath.Join(testDir, "www/20/Manifest.test-bundle"), deletedLine) {
+		t.Error("file not properly deleted")
+	}
+}

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 	"text/template"
 )
@@ -140,6 +141,18 @@ func mustInitOSRelease(t *testing.T, testDir, ver string) {
 func mustSetLatestVer(t *testing.T, testDir, ver string) {
 	err := ioutil.WriteFile(filepath.Join(testDir, "image/LAST_VER"), []byte(ver), 0644)
 	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustInitIncludesFile(t *testing.T, testDir, ver, bundle string, includes []string) {
+	noshipDir := filepath.Join(testDir, "image", ver, "noship")
+	if err := os.MkdirAll(noshipDir, os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	ib := []byte(strings.Join(includes, "\n") + "\n")
+	if err := ioutil.WriteFile(filepath.Join(noshipDir, bundle+"-includes"), ib, 0644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -400,6 +400,7 @@ func (m *Manifest) newDeleted(oldManifest *Manifest) int {
 			df.Status = statusDeleted
 			df.Modifier = modifierUnset
 			df.Type = typeUnset
+			df.Hash = internHash(AllZeroHash)
 			m.Files = append(m.Files, df)
 			m.DeletedFiles = append(m.DeletedFiles, df)
 			deleted++


### PR DESCRIPTION
* Deduplicate bundle includes list and add test 
* Set deleted file hash to AllZeroHash 
  When a file is deleted set its hash to all zeros. Add a test to confirm this.
* Restructure processBundles to perform tasks in correct order 
  An added test identified issues with how processBundles was adding, removing, and changing files. Certain steps need to happen to *all* bundles before the next group of steps can be completed. For instance, all manifest.Files manipulation must be done before subtracting included bundles, which in turn must be done before detecting if a file has changed.