### PR TITLE
builder: clean up BuildUpdate

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -222,18 +222,6 @@ func Download(filename string, url string) (err error) {
 	return nil
 }
 
-// GetDirContents is an an assert-style helper to get the contents of a
-// directory, or to exit on failure.
-func GetDirContents(dirname string) []os.FileInfo {
-	files, err := ioutil.ReadDir(dirname)
-	if err != nil {
-		PrintError(err)
-		os.Exit(1)
-	}
-
-	return files
-}
-
 // Git runs git with arguments and exits in case of failure.
 // IMPORTANT: the 'args' passed to this function _must_ be validated,
 // as to avoid cases where input is received from a third party source.

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -86,7 +86,7 @@ var buildUpdateCmd = &cobra.Command{
 		b := builder.NewFromConfig(config)
 		err := b.BuildUpdate(buildFlags.prefix, buildFlags.minVersion, buildFlags.format, buildFlags.noSigning, !buildFlags.noPublish, buildFlags.keepChroot)
 		if err != nil {
-			return errors.Wrap(err, "Error building update")
+			return errors.Wrap(err, "couldn't build update")
 		}
 
 		if buildFlags.increment {


### PR DESCRIPTION
Main changes:

- Rename parameters to reflect better their intention. In particular
  "signflag" -> "skipSigning"

- Remove unnecessary Stat check for dir creation: MkdirAll will do
  that and not fail if the directory already exists.

- Changed commands to do like the swupd_create_update and their output
  the error directly to the os.Stdout/os.Stderr.

- Changed most of file path building to use filepath.Join.

- Inline setVersion, since these two steps make sense at build
  update level.

- Only create upstreamver file if we create an upstreamurl file, and do
  that before the final publishing step.

- Added comments to clarify some of the steps.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>