### PR TITLE
Use new swupd package in mixer

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -31,6 +31,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+// UseNewSwupdServer controls whether to use the new implementation of
+// swupd-server (package swupd) when possible. This is an experimental feature.
+var UseNewSwupdServer = false
+
 // A Builder contains all configurable fields required to perform a full mix
 // operation, and is used to encapsulate life time data.
 type Builder struct {

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -581,25 +581,6 @@ func (b *Builder) BuildUpdate(prefixflag string, minVersion int, format string, 
 	}
 	timer.Stop()
 
-	// Clean up the bundle chroots as only the full chroot is needed from this point on.
-	if !keepChroots {
-		var files []os.FileInfo
-		files, err = ioutil.ReadDir(b.Bundledir)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Ignored error when cleaning bundle chroots: %s", err)
-		}
-		basedir := filepath.Join(b.Statedir, "image", b.Mixver)
-		for _, f := range files {
-			if f.Name() == "full" {
-				continue
-			}
-			err = os.RemoveAll(filepath.Join(basedir, f.Name()))
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Ignored error when cleaning bundle chroots: %s", err)
-			}
-		}
-	}
-
 	// Sign the Manifest.MoM that was just created.
 	if !skipSigning {
 		err = b.SignManifestMoM()
@@ -704,6 +685,25 @@ func (b *Builder) BuildUpdate(prefixflag string, minVersion int, format string, 
 		}
 	}
 	timer.Stop()
+
+	// Clean up the bundle chroots as only the full chroot is needed from this point on.
+	if !keepChroots {
+		var files []os.FileInfo
+		files, err = ioutil.ReadDir(b.Bundledir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Ignored error when cleaning bundle chroots: %s", err)
+		}
+		basedir := filepath.Join(b.Statedir, "image", b.Mixver)
+		for _, f := range files {
+			if f.Name() == "full" {
+				continue
+			}
+			err = os.RemoveAll(filepath.Join(basedir, f.Name()))
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Ignored error when cleaning bundle chroots: %s", err)
+			}
+		}
+	}
 
 	// Hardlink the duplicate files. This helps when keeping the bundle chroots.
 	timer.Start("hardlink")

--- a/builder/stopwatch.go
+++ b/builder/stopwatch.go
@@ -1,0 +1,65 @@
+package builder
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+// stopWatch keeps track of a sequence of durations. Use Start and Stop to mark the sections, then
+// write the final result with WriteSummary.
+type stopWatch struct {
+	entries []stopWatchEntry
+	t       time.Time
+	w       io.Writer
+}
+
+type stopWatchEntry struct {
+	name string
+	d    time.Duration
+	used bool
+}
+
+func (sw *stopWatch) Start(name string) {
+	if sw.w != nil {
+		if len(sw.entries) > 0 {
+			fmt.Println()
+		}
+		fmt.Fprintf(sw.w, "=> %s\n", name)
+	}
+	sw.entries = append(sw.entries, stopWatchEntry{name: name})
+	sw.t = time.Now()
+}
+
+func (sw *stopWatch) Stop() {
+	if len(sw.entries) == 0 {
+		return
+	}
+	last := len(sw.entries) - 1
+	if sw.entries[last].used {
+		sw.entries = append(sw.entries, sw.entries[last])
+		last++
+	}
+	e := &sw.entries[last]
+	e.used = true
+	e.d = time.Since(sw.t)
+}
+
+func (sw *stopWatch) WriteSummary(w io.Writer) {
+	if len(sw.entries) == 0 {
+		return
+	}
+	max := 0
+	for _, e := range sw.entries {
+		if len(e.name) > max {
+			max = len(e.name)
+		}
+	}
+	var sum time.Duration
+	fmt.Fprintf(w, "\nTIMINGS\n")
+	for _, e := range sw.entries {
+		fmt.Fprintf(w, "  %-*s %s\n", max, e.name, e.d.Truncate(time.Millisecond))
+		sum += e.d
+	}
+	fmt.Fprintf(w, "TOTAL: %s\n", sum.Truncate(time.Millisecond))
+}

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -180,6 +180,7 @@ func init() {
 		"mixer-pack-maker.sh",
 		"openssl",
 		"parallel", // Used by pack-maker.
+		"xz",
 	}
 	externalDeps[buildImageCmd] = []string{
 		"ister.py",

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -102,6 +102,9 @@ func Execute() {
 }
 
 func init() {
+	// TODO: Remove this once we migrate to new implementation.
+	RootCmd.PersistentFlags().BoolVar(&builder.UseNewSwupdServer, "new-swupd", false, "EXPERIMENTAL: Use new implementation of swupd-server when possible")
+
 	RootCmd.AddCommand(initCmd)
 	RootCmd.Flags().BoolVar(&rootCmdFlags.version, "version", false, "Print version information and quit")
 	RootCmd.Flags().BoolVar(&rootCmdFlags.check, "check", false, "Check all dependencies needed by mixer and quit")

--- a/swupd/cmd/create-pack/main.go
+++ b/swupd/cmd/create-pack/main.go
@@ -125,20 +125,8 @@ func main() {
 			}
 			fmt.Println()
 		}
-
-		// TODO: Move this to the info structure itself?
-		fullfiles := 0
-		deltas := 0
-		for _, e := range info.Entries {
-			switch e.State {
-			case swupd.PackedFullfile:
-				fullfiles++
-			case swupd.PackedDelta:
-				deltas++
-			}
-		}
-		fmt.Printf("  Fullfiles in pack: %d\n", fullfiles)
-		fmt.Printf("  Deltas in pack: %d\n", deltas)
+		fmt.Printf("  Fullfiles in pack: %d\n", info.FullfileCount)
+		fmt.Printf("  Deltas in pack: %d\n", info.DeltaCount)
 	}
 }
 

--- a/swupd/cmd/create-pack/main.go
+++ b/swupd/cmd/create-pack/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -31,7 +30,6 @@ func main() {
 	log.SetFlags(0)
 
 	cpuProfile := flag.String("cpuprofile", "", "write CPU profile to a file")
-	outputDir := flag.String("o", "", "output directory, creates temporary if not specified")
 	useChroot := flag.Bool("chroot", false, "use chroot to speed up pack generation")
 	allBundles := flag.Bool("all", false, "create packs for all bundles new in TO version")
 	force := flag.Bool("f", false, "rewrite packs that already exist")
@@ -74,153 +72,74 @@ func main() {
 		}
 	}
 
-	if *outputDir == "" {
-		tempDir, err := ioutil.TempDir(".", "packs-")
-		if err != nil {
-			log.Fatalf("couldn't create output directory: %s", err)
-		}
-		*outputDir = tempDir
-	}
-	log.Printf("Output directory: %s", *outputDir)
+	var err error
+	var bundles map[string]*swupd.BundleToPack
 
-	// If we are handling a single bundle, its name is taken directly from the command line.
-	if !*allBundles {
+	if *allBundles {
+		// Collect the corresponding bundle versions. Note that the code below will create packs on
+		// different directories, based on the version that each bundle is in the Manifest.MoM for
+		// the specified toVersion.
+		bundles, err = swupd.FindBundlesToPack(fromVersionUint, toVersionUint, stateDir)
+		if err != nil {
+			log.Fatalf("couldn't find the bundles to pack: %s", err)
+		}
+	} else {
+		// If we are handling a single bundle, its name is taken directly from the command line.
 		name := flag.Arg(3)
 		if name == "full" || name == "MoM" || name == "" {
 			log.Fatalf("invalid bundle name %q", name)
 		}
-		bundle := &bundleToPack{
-			name: name,
-			from: fromVersionUint,
-			to:   toVersionUint,
+		bundle := &swupd.BundleToPack{
+			Name:        name,
+			FromVersion: fromVersionUint,
+			ToVersion:   toVersionUint,
 		}
-		pack(stateDir, chrootDir, *outputDir, bundle, *force)
-		return
-	}
-
-	//
-	// Collect the corresponding bundle versions. Note that the code below will create packs on
-	// different directories, based on the version that each bundle is in the Manifest.MoM for
-	// the specified toVersion.
-	//
-	toDir := filepath.Join(stateDir, "www", toVersion)
-	toMoM, err := swupd.ParseManifestFile(filepath.Join(toDir, "Manifest.MoM"))
-	if err != nil {
-		log.Fatalf("couldn't read MoM of TO_VERSION (%s): %s", toVersion, err)
-	}
-
-	bundles := make(map[string]*bundleToPack, len(toMoM.Files))
-	for _, f := range toMoM.Files {
-		bundles[f.Name] = &bundleToPack{f.Name, 0, f.Version}
-	}
-
-	// If this is not a zero pack, we might be able to skip some bundles.
-	if fromVersionUint > 0 {
-		fromDir := filepath.Join(stateDir, "www", fromVersion)
-		fromMoM, err := swupd.ParseManifestFile(filepath.Join(fromDir, "Manifest.MoM"))
-		if err != nil {
-			log.Fatalf("couldn't read MoM of FROM_VERSION (%s): %s", fromVersion, err)
-		}
-
-		for _, f := range fromMoM.Files {
-			e, ok := bundles[f.Name]
-			if !ok {
-				// Bundle doesn't exist in new version, no pack needed.
-				continue
-			}
-			if e.to == f.Version {
-				// Versions match, so no pack required.
-				delete(bundles, f.Name)
-				continue
-			}
-			if e.to < f.Version {
-				log.Fatalf("invalid bundle versions for bundle %s, check the MoMs", f.Name)
-			}
-			e.from = f.Version
-		}
+		bundles["name"] = bundle
 	}
 
 	// TODO: Use goroutines.
 	for _, b := range bundles {
-		pack(stateDir, chrootDir, *outputDir, b, *force)
-	}
-}
-
-type bundleToPack struct {
-	name string
-	from uint32
-	to   uint32
-}
-
-func pack(stateDir, chrootDir string, outputDir string, bundle *bundleToPack, force bool) {
-	toDir := filepath.Join(outputDir, "www", fmt.Sprint(bundle.to))
-	err := os.MkdirAll(toDir, 0755)
-	if err != nil {
-		log.Fatal(err)
-	}
-	outputFilename := filepath.Join(toDir, fmt.Sprintf("pack-%s-from-%d.tar", bundle.name, bundle.from))
-
-	// If we are not forcing, skip the packs already on disk.
-	if !force {
-		_, err = os.Stat(outputFilename)
-		if err == nil {
-			fmt.Printf("Pack already exists for %s from %d to %d\n", bundle.name, bundle.from, bundle.to)
-			return
+		// Unless we are forcing, skip the packs already on disk.
+		if !*force {
+			_, err := os.Lstat(filepath.Join(stateDir, "www", fmt.Sprint(b.ToVersion), swupd.GetPackFilename(b.Name, b.FromVersion)))
+			if err == nil {
+				fmt.Printf("Pack already exists for %s from %d to %d\n", b.Name, b.FromVersion, b.ToVersion)
+				continue
+			}
+			if !os.IsNotExist(err) {
+				log.Fatal(err)
+			}
 		}
-		if !os.IsNotExist(err) {
+
+		fmt.Printf("Packing %s from %d to %d...\n", b.Name, b.FromVersion, b.ToVersion)
+
+		info, err := swupd.CreatePack(b.Name, b.FromVersion, b.ToVersion, filepath.Join(stateDir, "www"), chrootDir)
+		if err != nil {
 			log.Fatal(err)
 		}
-	}
 
-	fmt.Printf("Packing %s from %d to %d...\n", bundle.name, bundle.from, bundle.to)
-
-	m, err := swupd.ParseManifestFile(filepath.Join(stateDir, "www", fmt.Sprint(bundle.to), "Manifest."+bundle.name))
-	if err != nil {
-		log.Fatal(err)
-	}
-	m.Name = bundle.name
-
-	//
-	// Create the file and write the pack to it.
-	//
-	output, err := os.Create(outputFilename)
-	if err != nil {
-		log.Fatal(err)
-	}
-	info, err := swupd.WritePack(output, m, bundle.from, filepath.Join(stateDir, "www"), chrootDir)
-	if err != nil {
-		_ = os.RemoveAll(outputFilename)
-		log.Fatal(err)
-	}
-	err = output.Close()
-	if err != nil {
-		_ = os.RemoveAll(outputFilename)
-		log.Fatal(err)
-	}
-
-	//
-	// Output information about the pack produced.
-	//
-	if len(info.Warnings) > 0 {
-		fmt.Println("Warnings during pack:")
-		for _, w := range info.Warnings {
-			fmt.Printf("  %s\n", w)
+		if len(info.Warnings) > 0 {
+			fmt.Println("Warnings during pack:")
+			for _, w := range info.Warnings {
+				fmt.Printf("  %s\n", w)
+			}
+			fmt.Println()
 		}
-		fmt.Println()
-	}
-	// TODO: Move this to the info structure itself?
-	fullfiles := 0
-	deltas := 0
-	for _, e := range info.Entries {
-		switch e.State {
-		case swupd.PackedFullfile:
-			fullfiles++
-		case swupd.PackedDelta:
-			deltas++
+
+		// TODO: Move this to the info structure itself?
+		fullfiles := 0
+		deltas := 0
+		for _, e := range info.Entries {
+			switch e.State {
+			case swupd.PackedFullfile:
+				fullfiles++
+			case swupd.PackedDelta:
+				deltas++
+			}
 		}
+		fmt.Printf("  Fullfiles in pack: %d\n", fullfiles)
+		fmt.Printf("  Deltas in pack: %d\n", deltas)
 	}
-	fmt.Printf("  Fullfiles in pack: %d\n", fullfiles)
-	fmt.Printf("  Deltas in pack: %d\n", deltas)
 }
 
 func parseUint32(s string) uint32 {

--- a/swupd/external_test.go
+++ b/swupd/external_test.go
@@ -18,7 +18,7 @@ func TestExternalWriter(t *testing.T) {
 	}
 
 	var output bytes.Buffer
-	w, err := newExternalWriter(&output, tr, "e", "a")
+	w, err := NewExternalWriter(&output, tr, "e", "a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestExternalReader(t *testing.T) {
 	input := "Hello, world!"
 	expected := strings.Replace(input, "e", "a", -1)
 
-	r, err := newExternalReader(strings.NewReader(input), tr, "e", "a")
+	r, err := NewExternalReader(strings.NewReader(input), tr, "e", "a")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swupd/fullfiles.go
+++ b/swupd/fullfiles.go
@@ -329,7 +329,7 @@ func getHeaderFromFileInfo(fi os.FileInfo) (*tar.Header, error) {
 
 func externalCompressFunc(program string, args ...string) compressFunc {
 	return func(dst io.Writer, src io.Reader) error {
-		w, err := newExternalWriter(dst, program, args...)
+		w, err := NewExternalWriter(dst, program, args...)
 		if err != nil {
 			return err
 		}

--- a/swupd/fullfiles.go
+++ b/swupd/fullfiles.go
@@ -20,7 +20,6 @@ var fullfileCompressors = []struct {
 	Name string
 	Func compressFunc
 }{
-	{"gzip", compressGzip},
 	{"external-bzip2", externalCompressFunc("bzip2")},
 	{"external-gzip", externalCompressFunc("gzip")},
 	{"external-xz", externalCompressFunc("xz")},
@@ -333,13 +332,4 @@ func externalCompressFunc(program string, args ...string) compressFunc {
 		}
 		return w.Close()
 	}
-}
-
-func compressGzip(dst io.Writer, src io.Reader) error {
-	gw := gzip.NewWriter(dst)
-	_, err := io.Copy(gw, src)
-	if err != nil {
-		return err
-	}
-	return gw.Close()
 }

--- a/swupd/fullfiles.go
+++ b/swupd/fullfiles.go
@@ -27,7 +27,7 @@ var fullfileCompressors = []struct {
 }
 
 // CreateFullfiles creates full file compressed tars for files in chrootDir and places them
-// in outputDir
+// in outputDir. It doesn't regenerate full files that already exist.
 func CreateFullfiles(m *Manifest, chrootDir, outputDir string) error {
 	// TODO: Parametrize or pick a better value based on system.
 	const GoroutineCount = 3
@@ -48,6 +48,12 @@ func CreateFullfiles(m *Manifest, chrootDir, outputDir string) error {
 			// NOTE: to make life simpler for the client, always use .tar extension even
 			// if the file could be compressed.
 			output := filepath.Join(outputDir, name+".tar")
+
+			// Don't regenerate if file exists.
+			if _, err := os.Stat(output); err == nil {
+				// TODO: Should we validate it?
+				continue
+			}
 
 			var err error
 			switch f.Type {

--- a/swupd/packs.go
+++ b/swupd/packs.go
@@ -47,7 +47,8 @@ type PackEntry struct {
 
 // PackInfo contains detailed information about a pack written.
 type PackInfo struct {
-	// TODO: Add stats.
+	FullfileCount uint64
+	DeltaCount    uint64
 
 	// Entries contains all the files considered for packing and details about its presence in
 	// the pack.
@@ -139,6 +140,7 @@ func WritePack(w io.Writer, m *Manifest, fromVersion uint32, outputDir, chrootDi
 		// TODO: Pack deltas when available.
 		entry.State = PackedFullfile
 		entry.Reason = "from fullfile"
+		info.FullfileCount++
 		if chrootDir != "" {
 			var fallback bool
 			fallback, err = copyFromChrootFile(tw, chrootDir, f)

--- a/swupd/packs.go
+++ b/swupd/packs.go
@@ -83,7 +83,7 @@ func WritePack(w io.Writer, m *Manifest, fromVersion uint32, outputDir, chrootDi
 		Entries: make([]PackEntry, len(m.Files)),
 	}
 
-	xw, err := newExternalWriter(w, "xz")
+	xw, err := NewExternalWriter(w, "xz")
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +273,7 @@ func newCompressedTarReader(rs io.ReadSeeker) (*compressedTarReader, error) {
 		result.compressionCloser = gr
 		result.Reader = tar.NewReader(gr)
 	case bytes.HasPrefix(h[:], xzMagic):
-		xr, err := newExternalReader(rs, "unxz")
+		xr, err := NewExternalReader(rs, "unxz")
 		if err != nil {
 			return nil, fmt.Errorf("couldn't decompress using xz: %s", err)
 		}


### PR DESCRIPTION
Add a global flag --new-swupd to enable use of the new swupd package.
When using that flag, swupd.CreateFullfiles will be called.
See individual commit messages for the details.

This PR depends on #74.

