### PR TITLE
 Maximize file version in Manifest.full

### DIFF
--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -158,10 +158,6 @@ func processBundles(ui UpdateInfo, c config) ([]*Manifest, error) {
 		// detect modifier flag for all files in the manifest
 		// must happen after finding newDeleted files to catch ghosted files.
 		bundle.applyHeuristics()
-		// sort manifest by version (then by filename)
-		// this must be done after subtractManifests has been done for all manifests
-		// because subtractManifests sorts the file lists by filename alone
-		bundle.sortFilesVersionName()
 		// Assign final FileCount based on the files that made it this far
 		bundle.Header.FileCount = uint32(len(bundle.Files))
 		// If we made it this far, this bundle has a change and should be written
@@ -258,6 +254,14 @@ func CreateManifests(version uint32, minVersion bool, format uint, statedir stri
 
 	// write manifests then add them to the MoM
 	for _, bMan := range newManifests {
+		// full is just another manifest, grab it from here and maximize versions
+		if bMan.Name == "full" {
+			maximizeFull(bMan, newManifests)
+		}
+
+		// sort by version then by filename, previously to this sort these bundles
+		// were sorted by file name only to make processing easier
+		bMan.sortFilesVersionName()
 		manPath := filepath.Join(verOutput, "Manifest."+bMan.Name)
 		if err = bMan.WriteManifestFile(manPath); err != nil {
 			return err

--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -368,3 +368,22 @@ func TestCreateManifestsMoM(t *testing.T) {
 	}
 	checkManifestContains(t, testDir, "40", "MoM", subs...)
 }
+
+func TestCreateManifestMaximizeFull(t *testing.T) {
+	testDir := mustSetupTestDir(t, "max-full")
+	defer removeIfNoErrors(t, testDir)
+	bundles := []string{"test-bundle1", "test-bundle2"}
+	mustInitStandardTest(t, testDir, "0", "10", bundles)
+	mustGenFile(t, testDir, "10", "test-bundle1", "foo", "foo")
+	mustCreateManifestsStandard(t, 10, testDir)
+
+	checkManifestContains(t, testDir, "10", "full", "10\t/foo\n")
+
+	mustInitStandardTest(t, testDir, "10", "20", bundles)
+	mustGenFile(t, testDir, "20", "test-bundle1", "foo", "foo")
+	mustGenFile(t, testDir, "20", "test-bundle2", "foo", "foo")
+	mustCreateManifestsStandard(t, 20, testDir)
+
+	checkManifestContains(t, testDir, "20", "full", "20\t/foo\n")
+	checkManifestNotContains(t, testDir, "20", "full", "10\t/foo\n")
+}

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -531,3 +531,38 @@ func getManifestVerFromMoM(mom *Manifest, b *Manifest) uint32 {
 
 	return 0
 }
+
+// maxFullFromManifest maximizes all file entries in mf that are also in bundle
+func maxFullFromManifest(mf *Manifest, bundle *Manifest) {
+	mf.sortFilesName()
+	bundle.sortFilesName()
+	i := 0
+	j := 0
+
+	for i < len(mf.Files) && j < len(bundle.Files) {
+		ff := mf.Files[i]
+		bf := bundle.Files[j]
+		if ff.Name == bf.Name {
+			// files match, maximize versions if appropriate
+			if bf.Status != statusDeleted && bf.Version > ff.Version {
+				ff.Version = bf.Version
+			}
+			// advance both indices
+			i++
+			j++
+		} else if ff.Name < bf.Name {
+			// check next filename in mf
+			i++
+		} else {
+			// check next filename in bundle
+			j++
+		}
+	}
+}
+
+// maximizeFull maximizes all file entries in mf for each bundle in bundles
+func maximizeFull(mf *Manifest, bundles []*Manifest) {
+	for _, b := range bundles {
+		maxFullFromManifest(mf, b)
+	}
+}


### PR DESCRIPTION
When a file exists in one bundle, then is added to another bundle as
well, Manifest.full should report the file version as the most recent
changed version. Add test for this case as well.

This PR is based on #80. Once that PR is merged this will contain one commit containing the Manifest.full maximize changes only.