### PR TITLE
Swupd performance + maximize full

### DIFF
--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -148,7 +148,6 @@ func processBundles(ui UpdateInfo, c config) ([]*Manifest, error) {
 		oldMPath := filepath.Join(c.outputDir, fmt.Sprint(ver), "Manifest."+bundle.Name)
 		oldM := getOldManifest(oldMPath)
 		changedIncludes := compareIncludes(bundle, oldM)
-		bundle.sortFilesName()
 		oldM.sortFilesName()
 		changedFiles, added, deleted := bundle.linkPeersAndChange(oldM)
 		// if nothing changed, skip

--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -158,10 +158,6 @@ func processBundles(ui UpdateInfo, c config) ([]*Manifest, error) {
 		// detect modifier flag for all files in the manifest
 		// must happen after finding newDeleted files to catch ghosted files.
 		bundle.applyHeuristics()
-		// sort manifest by version (then by filename)
-		// this must be done after subtractManifests has been done for all manifests
-		// because subtractManifests sorts the file lists by filename alone
-		bundle.sortFilesVersionName()
 		// Assign final FileCount based on the files that made it this far
 		bundle.Header.FileCount = uint32(len(bundle.Files))
 		// If we made it this far, this bundle has a change and should be written
@@ -258,6 +254,14 @@ func CreateManifests(version uint32, minVersion bool, format uint, statedir stri
 
 	// write manifests then add them to the MoM
 	for _, bMan := range newManifests {
+		// full is just another manifest, grab it from here and maximize versions
+		if bMan.Name == "full" {
+			maximizeFull(bMan, newManifests)
+		}
+
+		// sort by version then by filename, previously to this sort these bundles
+		// were sorted by file name only to make processing easier
+		bMan.sortFilesVersionName()
 		manPath := filepath.Join(verOutput, "Manifest."+bMan.Name)
 		if err = bMan.WriteManifestFile(manPath); err != nil {
 			return err

--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -112,13 +112,6 @@ func processBundles(ui UpdateInfo, c config) ([]*Manifest, error) {
 			bundle.removeDebuginfo(c.debuginfo)
 		}
 
-		oldMPath := filepath.Join(c.outputDir, fmt.Sprint(ui.lastVersion), "Manifest."+bundle.Name)
-		oldM := getOldManifest(oldMPath)
-		// add old deleted files if the format has incremented
-		if ui.oldFormat == ui.format {
-			bundle.addDeleted(oldM)
-		}
-
 		bundle.sortFilesName()
 		tmpManifests = append(tmpManifests, bundle)
 	}

--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -147,9 +147,7 @@ func processBundles(ui UpdateInfo, c config) ([]*Manifest, error) {
 		oldMPath := filepath.Join(c.outputDir, fmt.Sprint(ver), "Manifest."+bundle.Name)
 		oldM := getOldManifest(oldMPath)
 		changedIncludes := compareIncludes(bundle, oldM)
-		changedFiles := bundle.linkPeersAndChange(oldM)
-		added := bundle.filesAdded(oldM)
-		deleted := bundle.newDeleted(oldM)
+		changedFiles, added, deleted := bundle.linkPeersAndChange(oldM)
 		// if nothing changed, skip
 		if changedFiles == 0 && added == 0 && deleted == 0 && !changedIncludes {
 			continue

--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -72,8 +72,8 @@ func TestCreateManifests(t *testing.T) {
 		".d..\t",
 	}
 	checkManifestNotContains(t, testDir, "10", "test-bundle", nExpSubs...)
+	checkManifestNotContains(t, testDir, "10", "MoM", "10\tManifest.full")
 
-	// set last version to 10
 	mustInitStandardTest(t, testDir, "10", "20", []string{"test-bundle"})
 	mustGenFile(t, testDir, "20", "test-bundle", "foo", "new content")
 	mustCreateManifestsStandard(t, 20, testDir)
@@ -88,6 +88,7 @@ func TestCreateManifests(t *testing.T) {
 	}
 	checkManifestContains(t, testDir, "20", "test-bundle", expSubs...)
 	checkManifestNotContains(t, testDir, "20", "test-bundle", "10\t/foo")
+	checkManifestNotContains(t, testDir, "20", "MoM", "20\tManifest.full")
 }
 
 func TestCreateManifestsDeleteNoVerBump(t *testing.T) {
@@ -160,7 +161,7 @@ func TestCreateManifestFormat(t *testing.T) {
 }
 
 func TestCreateManifestGhosted(t *testing.T) {
-	testDir := mustSetupTestDir(t, "format")
+	testDir := mustSetupTestDir(t, "ghosted")
 	defer removeIfNoErrors(t, testDir)
 	mustInitStandardTest(t, testDir, "0", "10", []string{"test-bundle"})
 	mustGenFile(t, testDir, "10", "test-bundle", "usr/lib/kernel/bar", "bar")

--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -408,3 +408,28 @@ func TestCreateManifestResurrect(t *testing.T) {
 	checkManifestContains(t, testDir, "30", "test-bundle", AllZeroHash+"\t30\t/foo1\n")
 	checkManifestContains(t, testDir, "30", "test-bundle", "\t30\t/foo\n")
 }
+
+func TestCreateManifestsManifestVersion(t *testing.T) {
+	testDir := mustSetupTestDir(t, "manifest-version")
+	defer removeIfNoErrors(t, testDir)
+	mustInitStandardTest(t, testDir, "0", "10", []string{"test-bundle"})
+	mustGenFile(t, testDir, "10", "test-bundle", "foo", "foo")
+	mustCreateManifestsStandard(t, 10, testDir)
+
+	mustInitStandardTest(t, testDir, "10", "20", []string{"test-bundle"})
+	// same file so no manifest for test-bundle
+	mustGenFile(t, testDir, "20", "test-bundle", "foo", "foo")
+	mustCreateManifestsStandard(t, 20, testDir)
+
+	mustNotExist(t, filepath.Join(testDir, "www/20/Manifest.test-bundle"))
+
+	mustInitStandardTest(t, testDir, "20", "30", []string{"test-bundle"})
+	// file changed so should have a manifest for this version
+	mustGenFile(t, testDir, "30", "test-bundle", "foo", "bar")
+	mustCreateManifestsStandard(t, 30, testDir)
+
+	mustExist(t, filepath.Join(testDir, "www/30/Manifest.test-bundle"))
+	// previous version should be 10, not 20, since there was no manifest
+	// generated for version 20
+	checkManifestContains(t, testDir, "30", "test-bundle", "previous:\t10\n")
+}

--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -388,3 +388,23 @@ func TestCreateManifestMaximizeFull(t *testing.T) {
 	checkManifestContains(t, testDir, "20", "full", "20\t/foo\n")
 	checkManifestNotContains(t, testDir, "20", "full", "10\t/foo\n")
 }
+
+func TestCreateManifestResurrect(t *testing.T) {
+	testDir := mustSetupTestDir(t, "resurrect-file")
+	defer removeIfNoErrors(t, testDir)
+	mustInitStandardTest(t, testDir, "0", "10", []string{"test-bundle"})
+	mustGenFile(t, testDir, "10", "test-bundle", "foo", "foo")
+	mustGenFile(t, testDir, "10", "test-bundle", "foo1", "foo1")
+	mustCreateManifestsStandard(t, 10, testDir)
+
+	mustInitStandardTest(t, testDir, "10", "20", []string{"test-bundle"})
+	mustGenFile(t, testDir, "20", "test-bundle", "foo1", "foo1")
+	mustCreateManifestsStandard(t, 20, testDir)
+
+	mustInitStandardTest(t, testDir, "20", "30", []string{"test-bundle"})
+	mustGenFile(t, testDir, "30", "test-bundle", "foo", "foo1")
+	mustCreateManifestsStandard(t, 30, testDir)
+
+	checkManifestContains(t, testDir, "30", "test-bundle", AllZeroHash+"\t30\t/foo1\n")
+	checkManifestContains(t, testDir, "30", "test-bundle", "\t30\t/foo\n")
+}

--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -368,3 +368,22 @@ func TestCreateManifestsMoM(t *testing.T) {
 	}
 	checkManifestContains(t, testDir, "40", "MoM", subs...)
 }
+
+func TestCreateManifestMaximizeFull(t *testing.T) {
+	testDir := mustSetupTestDir(t, "max-full")
+	defer removeIfNoErrors(t, testDir)
+	bundles := []string{"test-bundle1", "test-bundle2"}
+	mustInitStandardTest(t, testDir, "0", "10", bundles)
+	mustGenFile(t, testDir, "10", "test-bundle1", "foo", "foo")
+	mustCreateManifestsStandard(t, 10, testDir)
+
+	checkManifestContains(t, testDir, "10", "full", "10\t/foo\n")
+
+	mustInitStandardTest(t, testDir, "10", "20", bundles)
+	mustGenFile(t, testDir, "20", "test-bundle1", "foo", "foo")
+	mustGenFile(t, testDir, "20", "test-bundle2", "foo", "foo")
+	mustCreateManifestsStandard(t, 20, testDir)
+
+	checkManifestContains(t, testDir, "20", "full", "20\t/foo\n")
+	checkManifestNotContains(t, testDir, "20", "full", "10\t/foo\n")
+}

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -361,13 +361,13 @@ func (m *Manifest) linkPeersAndChange(oldManifest *Manifest) (int, int, int) {
 			// if something has changed update the version to current version and
 			// record that the file has changed
 			if of.Status == statusDeleted || of.Status == statusGhosted {
-				// don't worry about ghosted or deleted files
-				nx++
+				nf.Version = m.Header.Version
+				added = append(added, nf)
 				ox++
+				nx++
 				continue
 			}
-
-			// set up peers
+			// set up peers since old file exists
 			nf.DeltaPeer = of
 			of.DeltaPeer = nf
 			if !sameFile(nf, of) {

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -348,6 +348,9 @@ func (m *Manifest) sortFilesVersionName() {
 // if the file in the oldManifest is not deleted or ghosted.
 // Expects m and oldManifest files lists to be sorted by name only
 func (m *Manifest) linkPeersAndChange(oldManifest *Manifest) (int, int, int) {
+	// set previous version to oldManifest version
+	m.Header.Previous = oldManifest.Header.Version
+
 	var unchanged, changed, removed, added []*File
 	nx := 0 // new manifest file index
 	ox := 0 // old manifest file index

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -531,3 +531,38 @@ func getManifestVerFromMoM(mom *Manifest, b *Manifest) uint32 {
 
 	return 0
 }
+
+// maxFullFromManifest maximizes all file entries in mf that are also in bundle
+func maxFullFromManifest(mf *Manifest, bundle *Manifest) {
+	mf.sortFilesName()
+	bundle.sortFilesName()
+	i := 0
+	j := 0
+
+	for i < len(mf.Files) && j < len(bundle.Files) {
+		ff := mf.Files[i]
+		bf := bundle.Files[j]
+		if ff.Name == bf.Name {
+			// files match, maximize versions if appropriate
+			if bf.Status != statusDeleted && bf.Version > ff.Version {
+				ff.Version = bf.Version
+			}
+			// advance both indices
+			i++
+			j++
+		} else if ff.Name < bf.Name {
+			// check next filename in mf
+			i++
+		} else {
+			// check next filename in bundle
+			j++
+		}
+	}
+}
+
+// maximizeFull maximizes all file entries in mf for each bundle in bundles
+func maximizeFull(mf *Manifest, bundles []*Manifest) {
+	for _, b := range bundles {
+		maxFullFromManifest(mf, b)
+	}
+}

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -141,7 +141,7 @@ func readManifestFileEntry(fields []string, m *Manifest) error {
 	}
 
 	// add file to manifest
-	m.Files = append(m.Files, file)
+	m.appendFile(file)
 
 	// track deleted file
 	if file.Status == statusDeleted {
@@ -345,10 +345,18 @@ func (m *Manifest) sortFilesVersionName() {
 func (m *Manifest) addDeleted(oldManifest *Manifest) {
 	for _, df := range oldManifest.DeletedFiles {
 		if df.findFileNameInSlice(m.Files) == nil {
-			m.Files = append(m.Files, df)
+			m.appendFile(df)
 			m.DeletedFiles = append(m.DeletedFiles, df)
 		}
 	}
+}
+
+func (m *Manifest) appendFile(f *File) {
+	m.Files = append(m.Files, f)
+}
+
+func (m *Manifest) prependFile(f *File) {
+	m.Files = append([]*File{f}, m.Files...)
 }
 
 // linkPeersAndChange
@@ -401,7 +409,7 @@ func (m *Manifest) newDeleted(oldManifest *Manifest) int {
 			df.Modifier = modifierUnset
 			df.Type = typeUnset
 			df.Hash = internHash(AllZeroHash)
-			m.Files = append(m.Files, df)
+			m.appendFile(df)
 			m.DeletedFiles = append(m.DeletedFiles, df)
 			deleted++
 		}

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -342,15 +342,6 @@ func (m *Manifest) sortFilesVersionName() {
 	})
 }
 
-func (m *Manifest) addDeleted(oldManifest *Manifest) {
-	for _, df := range oldManifest.DeletedFiles {
-		if df.findFileNameInSlice(m.Files) == nil {
-			m.appendFile(df)
-			m.DeletedFiles = append(m.DeletedFiles, df)
-		}
-	}
-}
-
 func (m *Manifest) appendFile(f *File) {
 	m.Files = append(m.Files, f)
 }
@@ -455,8 +446,6 @@ func (m *Manifest) newDeleted(df *File) {
 	df.Hash = internHash(AllZeroHash)
 	// prepend so we don't re-process this file
 	m.prependFile(df)
-	// we aren't processing this so we can append
-	m.DeletedFiles = append(m.DeletedFiles, df)
 }
 
 func (m *Manifest) readIncludes(bundles []*Manifest, c config) error {

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -362,11 +362,9 @@ func (m *Manifest) prependFile(f *File) {
 // linkPeersAndChange
 // At this point Manifest m should only have the files that were present
 // in the chroot for that manifest. Link delta peers with the oldManifest
-// if the file in the oldManifest is not deleted or ghosted
+// if the file in the oldManifest is not deleted or ghosted.
+// Expects m and oldManifest files lists to be sorted by name only
 func (m *Manifest) linkPeersAndChange(oldManifest *Manifest) (int, int, int) {
-	m.sortFilesName()
-	oldManifest.sortFilesName()
-
 	changed := 0
 	added := 0
 	deleted := 0
@@ -442,6 +440,8 @@ func (m *Manifest) linkPeersAndChange(oldManifest *Manifest) (int, int, int) {
 		deleted++
 	}
 
+	// finally re-sort since we changed the order
+	m.sortFilesName()
 	// return the number of changed, added, or deleted files in this
 	// manifest
 	return changed, added, deleted
@@ -501,10 +501,9 @@ func (m *Manifest) hasUnsupportedTypeChanges() bool {
 	return false
 }
 
+// subtractManifestFromManifest removes all files present in m2 from m.
+// Expects m and m2 files lists to be sorted by name only
 func (m *Manifest) subtractManifestFromManifest(m2 *Manifest) {
-	m.sortFilesName()
-	m2.sortFilesName()
-
 	i := 0
 	j := 0
 	for i < len(m.Files) && j < len(m2.Files) {
@@ -582,9 +581,8 @@ func getManifestVerFromMoM(mom *Manifest, b *Manifest) uint32 {
 }
 
 // maxFullFromManifest maximizes all file entries in mf that are also in bundle
+// Expects mf and bundle file lists to be sorted by name only.
 func maxFullFromManifest(mf *Manifest, bundle *Manifest) {
-	mf.sortFilesName()
-	bundle.sortFilesName()
 	i := 0
 	j := 0
 
@@ -610,6 +608,7 @@ func maxFullFromManifest(mf *Manifest, bundle *Manifest) {
 }
 
 // maximizeFull maximizes all file entries in mf for each bundle in bundles
+// Expects mf and bundles file lists to be sorted by name only.
 func maximizeFull(mf *Manifest, bundles []*Manifest) {
 	for _, b := range bundles {
 		maxFullFromManifest(mf, b)

--- a/swupd/manifest_test.go
+++ b/swupd/manifest_test.go
@@ -435,6 +435,10 @@ func TestLinkPeersAndChange(t *testing.T) {
 		"6": {false, ""},
 	}
 
+	// linkPeersAndChange requires mNew and mOld to have file lists sorted
+	// by name.
+	mNew.sortFilesName()
+	mOld.sortFilesName()
 	changed, added, deleted := mNew.linkPeersAndChange(&mOld)
 	if changed != 1 {
 		t.Errorf("%v files detected as changed when only 1 was expected", changed)

--- a/swupd/manifest_test.go
+++ b/swupd/manifest_test.go
@@ -380,7 +380,7 @@ func TestLinkPeersAndChange(t *testing.T) {
 	mNew := Manifest{
 		Files: []*File{
 			{Name: "1", Status: statusUnset},
-			{Name: "2", Status: statusDeleted},
+			{Name: "2", Status: statusUnset},
 			{Name: "3", Status: statusUnset},
 			{Name: "5", Status: statusUnset, Hash: 2},
 			{Name: "6", Status: statusUnset},
@@ -404,10 +404,10 @@ func TestLinkPeersAndChange(t *testing.T) {
 	mOld.sortFilesName()
 	changed, added, deleted := mNew.linkPeersAndChange(&mOld)
 	if changed != 1 {
-		t.Errorf("%v files detected as changed when only 1 was expected", changed)
+		t.Errorf("%v files detected as changed when 1 was expected", changed)
 	}
-	if added != 1 {
-		t.Errorf("%v files detected as added when only 1 was expected", added)
+	if added != 3 {
+		t.Errorf("%v files detected as added when 3 were expected", added)
 	}
 	if deleted != 1 {
 		t.Errorf("%v files detected as deleted when only 1 was expected", deleted)

--- a/swupd/manifest_test.go
+++ b/swupd/manifest_test.go
@@ -366,43 +366,6 @@ func TestSortFilesVersionName(t *testing.T) {
 	}
 }
 
-func TestAddDeleted(t *testing.T) {
-	mOld := Manifest{
-		DeletedFiles: []*File{
-			{Name: "1"},
-			{Name: "2"},
-			{Name: "3"},
-			{Name: "4"},
-		},
-	}
-
-	mNew := Manifest{
-		Files: []*File{
-			{Name: "1"},
-			{Name: "3"},
-			{Name: "5"},
-		},
-	}
-
-	expectedFileNames := []string{"1", "2", "3", "4", "5"}
-	expectedDeletedFileNames := []string{"2", "4"}
-
-	mNew.addDeleted(&mOld)
-	// sort to easily compare
-	mNew.sortFilesName()
-	for i, f := range mNew.Files {
-		if f.Name != expectedFileNames[i] {
-			t.Errorf("%v did not match expected %v", f.Name, expectedFileNames[i])
-		}
-	}
-
-	for i, f := range mNew.DeletedFiles {
-		if f.Name != expectedDeletedFileNames[i] {
-			t.Errorf("%v did not match expected %v", f.Name, expectedDeletedFileNames[i])
-		}
-	}
-}
-
 func TestLinkPeersAndChange(t *testing.T) {
 	mOld := Manifest{
 		Files: []*File{

--- a/swupd/manifest_test.go
+++ b/swupd/manifest_test.go
@@ -435,8 +435,15 @@ func TestLinkPeersAndChange(t *testing.T) {
 		"6": {false, ""},
 	}
 
-	if changed := mNew.linkPeersAndChange(&mOld); changed != 1 {
+	changed, added, deleted := mNew.linkPeersAndChange(&mOld)
+	if changed != 1 {
 		t.Errorf("%v files detected as changed when only 1 was expected", changed)
+	}
+	if added != 1 {
+		t.Errorf("%v files detected as added when only 1 was expected", added)
+	}
+	if deleted != 1 {
+		t.Errorf("%v files detected as deleted when only 1 was expected", deleted)
 	}
 
 	for _, f := range mNew.Files {
@@ -452,53 +459,6 @@ func TestLinkPeersAndChange(t *testing.T) {
 					testCases[f.Name].expected)
 			}
 		}
-	}
-}
-
-func TestFilesAdded(t *testing.T) {
-	mOld := Manifest{
-		Files: []*File{
-			{Name: "1"},
-			{Name: "2"},
-			{Name: "4"},
-		},
-	}
-
-	mNew := Manifest{
-		Files: []*File{
-			{Name: "1"},
-			{Name: "2"},
-			{Name: "3"},
-			{Name: "4"},
-			{Name: "5"},
-		},
-	}
-
-	if added := mNew.filesAdded(&mOld); added != 2 {
-		t.Errorf("filesAdded detected %v added files when 2 was expected", added)
-	}
-}
-
-func TestNewDeleted(t *testing.T) {
-	mOld := Manifest{
-		Files: []*File{
-			{Name: "1"},
-			{Name: "2", Status: statusDeleted},
-			{Name: "4"},
-		},
-	}
-
-	mNew := Manifest{
-		Files: []*File{
-			{Name: "1"},
-			{Name: "2"},
-			{Name: "3"},
-		},
-	}
-
-	// file 1 is the only new deleted file
-	if deleted := mNew.newDeleted(&mOld); deleted != 1 {
-		t.Errorf("newDeleted detected %v new deleted files when 1 was expected", deleted)
 	}
 }
 

--- a/swupd/manifest_test.go
+++ b/swupd/manifest_test.go
@@ -442,7 +442,7 @@ func TestLinkPeersAndChange(t *testing.T) {
 	for _, f := range mNew.Files {
 		if testCases[f.Name].hasPeer {
 			if f.DeltaPeer == nil {
-				t.Errorf("File %v does not have delta peer when expected", f.Name)
+				t.Fatalf("File %v does not have delta peer when expected", f.Name)
 			}
 
 			if f.DeltaPeer.Name != testCases[f.Name].expected {


### PR DESCRIPTION
Maximize Manifest.full
* When a file exists in one bundle, then is added to another bundle as
well, Manifest.full should report the file version as the most recent
changed version. Add test for this case as well.

Make various performance fixes for manifest creation.
* Added an appendFile helper function to unset the Sorted field.
* Optimize linkPeersAndChange 
  Instead of an O(N^2) operation (N^3 counting the calling loop) walk each
manifest file list at the same time for a O(N) operation (N^2 counting
the calling loop). Fold filesAdded() and newDeleted() into
linkPeersAndChange so they can take advantage of the double list walk.

A couple minor test fixes
* Fix misnamed test from "format" to "ghosted"
* Change test error to fatal
  This test should be fatal so the f.DeltaPeer.Name is not checked when
f.DeltaPeer is nil.
  
  