### PR TITLE
Generate new content for files older than minVersion

### DIFF
--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -197,10 +197,10 @@ func mustNotExist(t *testing.T, name string) {
 }
 
 func mustCreateManifestsStandard(t *testing.T, ver uint32, testDir string) {
-	mustCreateManifests(t, ver, false, 1, testDir)
+	mustCreateManifests(t, ver, 0, 1, testDir)
 }
 
-func mustCreateManifests(t *testing.T, ver uint32, minVer bool, format uint, testDir string) {
+func mustCreateManifests(t *testing.T, ver uint32, minVer uint32, format uint, testDir string) {
 	if err := CreateManifests(ver, minVer, format, testDir); err != nil {
 		t.Fatal(err)
 	}

--- a/swupd/manifest_test.go
+++ b/swupd/manifest_test.go
@@ -402,7 +402,7 @@ func TestLinkPeersAndChange(t *testing.T) {
 	// by name.
 	mNew.sortFilesName()
 	mOld.sortFilesName()
-	changed, added, deleted := mNew.linkPeersAndChange(&mOld)
+	changed, added, deleted := mNew.linkPeersAndChange(&mOld, 0)
 	if changed != 1 {
 		t.Errorf("%v files detected as changed when 1 was expected", changed)
 	}


### PR DESCRIPTION
When a file is older than the minVersion passed to CreateManifests do
not use the old file in the new update. Instead record the file version
as the current version so that new content is generated (via fullfiles
and packs). Add tests for this functionality.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>

This PR will have commits from #82 until #82 is merged.