### PR TITLE
[RFC don't merge] swupd: Do not print to stderr from library calls

### DIFF
--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -176,10 +176,6 @@ func CreateManifests(version uint32, minVersion bool, format uint, statedir stri
 	var err error
 	var c config
 	c, err = getConfig(statedir)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Found server.ini, but was unable to read it. "+
-			"Continuing with default configuration\n")
-	}
 
 	if err = initBuildEnv(c); err != nil {
 		return err


### PR DESCRIPTION
If this is indeed a library, then we should remove all printing to stdout/stderr and return proper errors, or don't return anything in cases like this where it's going to continue anyways. Libraries should not print to console at any time.


Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>