### PR TITLE
swupd: return MoM from CreateManifests

### DIFF
--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -48,7 +48,7 @@ func TestInitBuildDirs(t *testing.T) {
 }
 
 func TestCreateManifestsBadMinVersion(t *testing.T) {
-	if err := CreateManifests(10, 20, 1, "testdir"); err == nil {
+	if _, err := CreateManifests(10, 20, 1, "testdir"); err == nil {
 		t.Error("No error raised with invalid minVersion (20) for version 10")
 	}
 }

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -201,7 +201,7 @@ func mustCreateManifestsStandard(t *testing.T, ver uint32, testDir string) {
 }
 
 func mustCreateManifests(t *testing.T, ver uint32, minVer uint32, format uint, testDir string) {
-	if err := CreateManifests(ver, minVer, format, testDir); err != nil {
+	if _, err := CreateManifests(ver, minVer, format, testDir); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -50,10 +50,17 @@ type Manifest struct {
 	DeletedFiles []*File
 }
 
-// MoM is a manifest of manifests with the same header information
+// MoM is a manifest that holds references to bundle manifests.
 type MoM struct {
-	Header       ManifestHeader
-	SubManifests []*Manifest
+	Manifest
+
+	// UpdatedBundles has the manifests of bundles that are new to this
+	// version. To get a list of all the bundles, use Files from embedded
+	// Manifest struct.
+	UpdatedBundles []*Manifest
+
+	// FullManifest contains information about all the files in this version.
+	FullManifest *Manifest
 }
 
 // readManifestFileHeaderLine Read a header line from a manifest


### PR DESCRIPTION
CreateManifests does a lot of bookkeeping that will be useful for
later steps of BuildUpdate, so make it return all this information.

Changed the MoM struct to contain
- The Manifest itself (that list all the bundles), embedded
- The list of updated bundles and their manifests
- The full manifest

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>