### PR TITLE
Write update metadata to output directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ release:
 		echo "Release needs to be used from a git repository"; \
 		exit 1; \
 	fi
-	@VERSION=$$(grep -e 'const Version' mixer/cmd/root.go | cut -d '"' -f 2) ; \
+	@VERSION=$$(grep -e 'const Version' builder/builder.go | cut -d '"' -f 2) ; \
 	if [ -z "$$VERSION" ]; then \
 		echo "Couldn't extract version number from the source code"; \
 		exit 1; \

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -29,9 +29,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Version of Mixer. Also used by the Makefile for releases.
-const Version = "3.2.1"
-
 var config string
 
 // RootCmd represents the base command when called without any subcommands
@@ -54,7 +51,7 @@ var RootCmd = &cobra.Command{
 		// check for external programs.
 		if cmd.Parent() == nil { // This is RootCmd.
 			if rootCmdFlags.version {
-				fmt.Printf("Mixer %s\n", Version)
+				fmt.Printf("Mixer %s\n", builder.Version)
 				os.Exit(0)
 			}
 			if rootCmdFlags.check {


### PR DESCRIPTION
Instead of requiring the swupd-server code to create the "format" and
"swupd-server-src-version" metadata files enable BuildUpdate to do so.

Because the mixer version is now used instead of a swupd-server version
move the Version const to builder.go so it can be accessed trivially.
Update the Makefile parsing to point to builder.go and update the access
method in the top-level mixer/cmd/root.go.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>

RFC: should we change the name of `swupd-server-src-version` file to `mixer-src-version` or something similar?