### PR TITLE
Exporting more Hash related functions

### DIFF
--- a/swupd/hash.go
+++ b/swupd/hash.go
@@ -20,7 +20,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"hash"
-	"io/ioutil"
+	"io"
 	"os"
 	"syscall"
 )
@@ -58,87 +58,19 @@ func HashEquals(h1 Hashval, h2 Hashval) bool {
 
 // Hashcalc returns the swupd hash for the given file
 func Hashcalc(filename string) (Hashval, error) {
-	var info syscall.Stat_t
-	var err error
-	var data []byte
-	if err = syscall.Lstat(filename, &info); err != nil {
-		return 0, fmt.Errorf("error statting file '%s' %v", filename, err)
+	r, err := GetHashForFile(filename)
+	if err != nil {
+		return 0, err
 	}
-	// Get magic constants out of /usr/include/bits/stat.h
-	switch info.Mode & syscall.S_IFMT {
-	case syscall.S_IFREG: // Regular file
-		data, err = ioutil.ReadFile(filename)
-		if err != nil {
-			return 0, fmt.Errorf("read error for '%s' %v", filename, err)
-		}
-	case syscall.S_IFDIR: // Directory
-		info.Size = 0
-		data = []byte("DIRECTORY") // fixed magic string
-	case syscall.S_IFLNK:
-		info.Mode = 0
-		target, err := os.Readlink(filename)
-		if err != nil {
-			return 0, fmt.Errorf("error readlink file '%s' %v", filename, err)
-		}
-		data = []byte(target)
-	default:
-		return 0, fmt.Errorf("%s is not a file, directory or symlink %o", filename, info.Mode&syscall.S_IFMT)
-	}
-	r := internHash(genHash(info, data))
-	return r, nil
+	return internHash(r), nil
 }
 
-// genHash generates hash string from butchered Stat_t and data
-// Expects that its callers have validated the arguments
-func genHash(info syscall.Stat_t, data []byte) string {
-	key := hmacComputeKey(info)
-	result := hmacSha256ForData(key, data)
-	return string(result[:])
-}
-
-// hmacSha256ForData returns an array of 64 ascii hex digits
-func hmacSha256ForData(key []byte, data []byte) []byte {
-	var result [64]byte
-
-	mac := hmac.New(sha256.New, key)
-	_, _ = mac.Write(data)
-	hex.Encode(result[:], mac.Sum(nil))
-	return result[:]
-}
-
-// This is what I want to have for the key
-// type updatestat struct {
-// 	st_mode uint64
-// 	st_uid  uint64
-// 	st_gid  uint64
-// 	st_rdev uint64
-// 	st_size uint64
-// }
-
-// set fills in a buffer with an int in little endian order
+// set fills in a buffer with an int in little endian order.
 func set(out []byte, in int64) {
 	for i := range out {
 		out[i] = byte(in & 0xff)
 		in >>= 8
 	}
-}
-
-// hmacComputeKey returns what should be an ascii string as an array of byte
-// it is really ugly to be compatible with the C implementation. It is not portable
-// as the C version isn't portable.
-// The syscall.Stat_t has been butchered
-func hmacComputeKey(info syscall.Stat_t) []byte {
-	// Create the key
-	updatestat := [40]byte{}
-	set(updatestat[0:8], int64(info.Mode))
-	set(updatestat[8:16], int64(info.Uid))
-	set(updatestat[16:24], int64(info.Gid))
-	// 24:32 is rdev, but this is always zero
-	set(updatestat[24:32], 0)
-	set(updatestat[32:40], int64(info.Size))
-	// fmt.Printf("key is %v\n", updatestat)
-	key := hmacSha256ForData(updatestat[:], nil)
-	return key
 }
 
 // HashFileInfo contains the metadata of a file that is included as
@@ -217,7 +149,7 @@ func NewHash(info *HashFileInfo) (*Hash, error) {
 		hmac: hmac.New(sha256.New, key[:]),
 	}
 
-	// Pre-write data we known so that directories and symbolic
+	// Pre-write data we know so that directories and symbolic
 	// links don't need further data from the caller.
 	if data != nil {
 		_, err = h.hmac.Write(data)
@@ -240,4 +172,64 @@ func (h *Hash) Sum() string {
 	var result [64]byte
 	hex.Encode(result[:], h.hmac.Sum(nil))
 	return string(result[:])
+}
+
+// GetHashForFile calculate the swupd hash for a file in the disk.
+func GetHashForFile(filename string) (string, error) {
+	var info syscall.Stat_t
+	var err error
+	if err = syscall.Lstat(filename, &info); err != nil {
+		return "", fmt.Errorf("error statting file '%s' %v", filename, err)
+	}
+
+	hashInfo := &HashFileInfo{
+		Mode: info.Mode,
+		UID:  info.Uid,
+		GID:  info.Gid,
+		Size: info.Size,
+	}
+
+	if info.Mode&syscall.S_IFMT == syscall.S_IFLNK {
+		var link string
+		link, err = os.Readlink(filename)
+		if err != nil {
+			return "", err
+		}
+		hashInfo.Linkname = link
+	}
+
+	h, err := NewHash(hashInfo)
+	if err != nil {
+		return "", fmt.Errorf("error creating hash for file %s: %s", filename, err)
+	}
+
+	if info.Mode&syscall.S_IFMT == syscall.S_IFREG {
+		f, err := os.Open(filename)
+		if err != nil {
+			return "", fmt.Errorf("read error for file %s: %s", filename, err)
+		}
+		_, err = io.Copy(h, f)
+		_ = f.Close()
+		if err != nil {
+			return "", fmt.Errorf("error hashing file %s: %s", filename, err)
+		}
+	}
+
+	return h.Sum(), nil
+}
+
+// GetHashForBytes calculate the hash for data already in memory and the
+// associated metadata.
+func GetHashForBytes(info *HashFileInfo, data []byte) (string, error) {
+	h, err := NewHash(info)
+	if err != nil {
+		return "", err
+	}
+	if data != nil {
+		_, err = h.Write(data)
+		if err != nil {
+			return "", err
+		}
+	}
+	return h.Sum(), nil
 }


### PR DESCRIPTION
Following new functionality is exported:
- Calculate swupd hashes without having a file on the disk
- Calculate swupd hashes without having a the whole data in memory

Exports a type containing exactly the metadata used by the swupd hash.

Doesn't change anything in the Hashval or interning, everything should work as before.
