### PR TITLE
Fix error message for mixer init-mix

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -394,11 +394,6 @@ func (b *Builder) AddBundles(bundles []string, force bool, allbundles bool, git 
 // InitMix will initialise a new swupd-client consumable "mix" with the given
 // based Clear Linux version and specified mix version.
 func (b *Builder) InitMix(clearver string, mixver string, all bool, upstreamurl string) error {
-	if clearver == "0" || mixver == "0" {
-		fmt.Println("ERROR: Please supply -clearver and -mixver")
-		os.Exit(1)
-	}
-
 	err := ioutil.WriteFile(b.Versiondir+"/.clearurl", []byte(upstreamurl), 0644)
 	if err != nil {
 		helpers.PrintError(err)

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -136,6 +136,10 @@ func init() {
 	initCmd.Flags().StringVar(&config, "config", "", "Supply a specific builder.conf to use for mixing")
 	initCmd.Flags().StringVar(&initFlags.upstreamurl, "upstream-url", "https://download.clearlinux.org", "Supply an upstream URL to use for mixing")
 
+	// mark required flags
+	_ = cobra.MarkFlagRequired(initCmd.Flags(), "clear-version")
+	_ = cobra.MarkFlagRequired(initCmd.Flags(), "mix-version")
+
 	externalDeps[initCmd] = []string{
 		"git",
 	}


### PR DESCRIPTION
Fixes #97
Print the correct error message with the correct flag names
--clear-version or --mix-version is not supplied.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>