### PR TITLE
builder: port chroot building to Go

### DIFF
--- a/builder/bundleset.go
+++ b/builder/bundleset.go
@@ -1,0 +1,188 @@
+package builder
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var (
+	validBundleNameRegex  = regexp.MustCompile(`^[A-Za-z0-9-_]+$`)
+	validPackageNameRegex = regexp.MustCompile(`^[A-Za-z0-9-_+.]+$`)
+)
+
+type bundle struct {
+	Name     string
+	Filename string
+
+	DirectIncludes []string
+	DirectPackages []string
+	AllPackages    []string
+}
+
+type bundleSet struct {
+	Bundles map[string]*bundle
+}
+
+// newBundleSet will take a list of files and create a bundle struct from the list of
+// files, doing all the required validation and processing.
+//
+// It currently implements parsing of the bundle files, ignoring comments and processing
+// "include()" directives the same way that m4 works.
+func newBundleSet(bundleFiles []string) (*bundleSet, error) {
+	bundles := make(map[string]*bundle, len(bundleFiles))
+
+	// First parse each bundle file in isolation.
+	for _, filename := range bundleFiles {
+		name := filepath.Base(filename)
+		b, exists := bundles[name]
+		if exists {
+			return nil, fmt.Errorf("bundle %q defined twice: in %s and %s", name, b.Filename, filename)
+		}
+		if !validBundleNameRegex.MatchString(name) {
+			return nil, fmt.Errorf("invalid bundle name %q derived from file %s", name, filename)
+		}
+
+		contents, err := ioutil.ReadFile(filename)
+		if err != nil {
+			return nil, err
+		}
+
+		includes, packages, err := parseBundle(contents)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't parse bundle file %s: %s", filename, err)
+		}
+
+		b = &bundle{
+			Name:           name,
+			DirectIncludes: includes,
+			DirectPackages: packages,
+			Filename:       filename,
+		}
+		bundles[name] = b
+	}
+
+	// Then check if there are missing includes.
+	for _, b := range bundles {
+		for _, include := range b.DirectIncludes {
+			_, exists := bundles[include]
+			if !exists {
+				return nil, fmt.Errorf("bundle %q includes bundle %q which is not available", b.Name, include)
+			}
+		}
+	}
+
+	// And finally sort the bundles so that all includes appear before a bundle, then
+	// calculate AllPackages for each bundle. Cycles are identified as part of sorting
+	// the bundles.
+	sortedBundles, err := sortBundles(bundles)
+	if err != nil {
+		return nil, err
+	}
+	for _, b := range sortedBundles {
+		var allPackages []string
+		allPackages = append(allPackages, b.DirectPackages...)
+		for _, include := range b.DirectIncludes {
+			allPackages = append(allPackages, bundles[include].AllPackages...)
+		}
+		// Remove redundant packages.
+		sort.Strings(allPackages)
+		for i, p := range allPackages {
+			if i != 0 && allPackages[i-1] == p {
+				continue
+			}
+			b.AllPackages = append(b.AllPackages, p)
+		}
+	}
+
+	return &bundleSet{Bundles: bundles}, nil
+}
+
+func sortBundles(bundles map[string]*bundle) ([]*bundle, error) {
+	// Traverse all the bundles, recursing to mark its included bundles as visited before mark
+	// the bundle itself as visited. VISITING state is used to identify cycles.
+	type state int
+	const (
+		NotVisited state = iota
+		Visiting
+		Visited
+	)
+	mark := make(map[*bundle]state, len(bundles))
+	sorted := make([]*bundle, 0, len(bundles))
+	visiting := make([]string, 0, len(bundles)) // Used to produce nice error messages.
+
+	var visit func(b *bundle) error
+	visit = func(b *bundle) error {
+		switch mark[b] {
+		case Visiting:
+			return fmt.Errorf("cycle found in bundles: %s -> %s", strings.Join(visiting, " -> "), b.Name)
+		case NotVisited:
+			mark[b] = Visiting
+			visiting = append(visiting, b.Name)
+			for _, inc := range b.DirectIncludes {
+				err := visit(bundles[inc])
+				if err != nil {
+					return err
+				}
+			}
+			visiting = visiting[:len(visiting)-1]
+			mark[b] = Visited
+			sorted = append(sorted, b)
+		}
+		return nil
+	}
+
+	for _, b := range bundles {
+		err := visit(b)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return sorted, nil
+
+}
+
+func parseBundle(contents []byte) (includes []string, packages []string, err error) {
+	scanner := bufio.NewScanner(bytes.NewReader(contents))
+
+	line := 0
+	for scanner.Scan() {
+		line++
+		text := scanner.Text()
+		comment := strings.Index(text, "#")
+		if comment > -1 {
+			text = text[:comment]
+		}
+		text = strings.TrimSpace(text)
+		if len(text) == 0 {
+			continue
+		}
+		if strings.HasPrefix(text, "include(") {
+			if !strings.HasSuffix(text, ")") {
+				return nil, nil, fmt.Errorf("missing end parenthesis in line %d: %q", line, text)
+			}
+			text = text[8 : len(text)-1]
+			if !validBundleNameRegex.MatchString(text) {
+				return nil, nil, fmt.Errorf("invalid bundle name %q in line %d", text, line)
+			}
+			includes = append(includes, text)
+		} else {
+			if !validPackageNameRegex.MatchString(text) {
+				return nil, nil, fmt.Errorf("invalid package name %q in line %d", text, line)
+			}
+			packages = append(packages, text)
+		}
+	}
+
+	if scanner.Err() != nil {
+		return nil, nil, scanner.Err()
+	}
+
+	return includes, packages, nil
+}

--- a/builder/bundleset_test.go
+++ b/builder/bundleset_test.go
@@ -1,0 +1,192 @@
+package builder
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseBundle(t *testing.T) {
+	tests := []struct {
+		Contents         []byte
+		ExpectedIncludes []string
+		ExpectedPackages []string
+		ShouldFail       bool
+	}{
+		{
+			Contents: []byte(`# Simple fake bundle
+include(a)
+include(b)
+pkg1     # Comment
+pkg2
+`),
+			ExpectedIncludes: []string{"a", "b"},
+			ExpectedPackages: []string{"pkg1", "pkg2"},
+		},
+
+		// Error cases.
+		{Contents: []byte(`include(`), ShouldFail: true},
+		{Contents: []byte(`()`), ShouldFail: true},
+		{Contents: []byte(`Include(`), ShouldFail: true},
+		{Contents: []byte(`include())`), ShouldFail: true},
+		{Contents: []byte(`include(abc))`), ShouldFail: true},
+	}
+
+	for _, tt := range tests {
+		includes, packages, err := parseBundle(tt.Contents)
+		failed := err != nil
+		if failed != tt.ShouldFail {
+			if tt.ShouldFail {
+				t.Errorf("unexpected success when parsing bundle\nCONTENTS:\n%s\nPARSED INCLUDES: %s\nPARSED PACKAGES:\n%s", tt.Contents, includes, packages)
+			} else {
+				t.Errorf("unexpected error parsing bundle: %s\nCONTENTS:\n%s", err, tt.Contents)
+			}
+			continue
+		}
+		if tt.ShouldFail {
+			continue
+		}
+
+		if !reflect.DeepEqual(includes, tt.ExpectedIncludes) {
+			t.Errorf("got wrong includes when parsing bundle\nCONTENTS:\n%s\nPARSED INCLUDES (%d): %s\nEXPECTED INCLUDES (%d): %s", tt.Contents, len(includes), includes, len(tt.ExpectedIncludes), tt.ExpectedIncludes)
+		}
+
+		if !reflect.DeepEqual(packages, tt.ExpectedPackages) {
+			t.Errorf("got wrong packages when parsing bundle\nCONTENTS:\n%s\nPARSED PACKAGES (%d):\n%s\nEXPECTED PACKAGES (%d):\n%s", tt.Contents, len(packages), packages, len(tt.ExpectedPackages), tt.ExpectedPackages)
+		}
+	}
+}
+
+func TestParseBundleSet(t *testing.T) {
+	type FilesMap map[string]string
+	type CountsMap map[string]int
+
+	// Repurpose empty CountsMap as error to make the test entries less verbose, since we can avoid
+	// putting the attribute names in the literal map.
+	Error := CountsMap{}
+
+	// Replace spaces with new lines.
+	Lines := func(s string) string {
+		return strings.Replace(s, " ", "\n", -1)
+	}
+
+	tests := []struct {
+		Name  string
+		Files FilesMap
+		// TODO: Replace this with the actual map.
+		ExpectedAllPackageCounts CountsMap
+	}{
+		{
+			"simple include",
+			FilesMap{
+				"a": Lines("A1 A2"),
+				"b": "include(a)",
+			},
+			CountsMap{
+				"a": 2,
+				"b": 2,
+			},
+		},
+		{
+			"redundant includes",
+			FilesMap{
+				"a": Lines("A1 A2 A3 A4"),
+				"b": Lines("include(a) B1 B2 B3 B4"),
+				"c": Lines("include(b) C1 C2 C3 C4"),
+				"d": Lines("include(a) include(b) include(c) A1 B1 C1 D1"),
+			},
+			CountsMap{
+				"a": 4,
+				"b": 8,
+				"c": 12,
+				"d": 13,
+			},
+		},
+
+		{
+			"all packages don't have duplicates",
+			FilesMap{
+				"a": Lines("A A A A"),
+				"b": Lines("include(a) A A A A"),
+				"c": Lines("include(b) A A A A include(a)"),
+				"d": Lines("A"),
+				"e": Lines("include(a) include(d) E"),
+			},
+			CountsMap{
+				"a": 1,
+				"b": 1,
+				"c": 1,
+				"d": 1,
+				"e": 2,
+			},
+		},
+
+		{"cyclic error two bundles",
+			FilesMap{"a": "include(b)", "b": "include(a)"}, Error},
+
+		{"cyclic error three bundles",
+			FilesMap{"a": "include(b)", "b": "include(c)", "c": "include(a)"}, Error},
+
+		{"bundle not available",
+			FilesMap{"a": "include(c)"}, Error},
+
+		{"bundle not available 2",
+			FilesMap{"a": "include(b)", "b": "include(c)"}, Error},
+	}
+
+	testDir, err := ioutil.TempDir("", "bundleset-test-")
+	if err != nil {
+		t.Fatalf("couldn't create temporary directory to write test cases: %s", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(testDir)
+	}()
+
+	for i, tt := range tests {
+		dir := filepath.Join(testDir, fmt.Sprint(i))
+		err = os.Mkdir(dir, 0700)
+		if err != nil {
+			t.Fatalf("couldn't create temporary directory to write test case: %s", err)
+		}
+
+		bundleFiles := make([]string, 0, len(tt.Files))
+		for name, contents := range tt.Files {
+			bundleFile := filepath.Join(dir, name)
+			err = ioutil.WriteFile(bundleFile, []byte(contents), 0600)
+			if err != nil {
+				t.Fatalf("couldn't create temporary file for test case: %s", err)
+			}
+			bundleFiles = append(bundleFiles, bundleFile)
+		}
+
+		var set *bundleSet
+		set, err = newBundleSet(bundleFiles)
+
+		shouldFail := (len(tt.ExpectedAllPackageCounts) == 0)
+		failed := err != nil
+
+		if failed != shouldFail {
+			if shouldFail {
+				t.Errorf("expected error but parsed bundle set from test case %q", tt.Name)
+			} else {
+				t.Errorf("unexpected error when parsing bundle set from test case %q: %s", tt.Name, err)
+			}
+			continue
+		}
+		if shouldFail {
+			continue
+		}
+
+		for _, b := range set.Bundles {
+			expectedCount := tt.ExpectedAllPackageCounts[b.Name]
+			count := len(b.AllPackages)
+			if count != expectedCount {
+				t.Errorf("got %d all packages but expected %d all packages in bundle %s for test case %q", count, expectedCount, b.Name, tt.Name)
+			}
+		}
+	}
+}

--- a/builder/chroots.go
+++ b/builder/chroots.go
@@ -1,0 +1,605 @@
+package builder
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/clearlinux/mixer-tools/helpers"
+	"github.com/go-ini/ini"
+	"github.com/pkg/errors"
+)
+
+// TODO: Move this to the more general configuration handling.
+type buildChrootsConfig struct {
+	// [Server] section.
+	HasServerSection bool
+	DebugInfoBanned  string
+	DebugInfoLib     string
+	DebugInfoSrc     string
+
+	// [swupd] section.
+	UpdateBundle string
+	ContentURL   string
+	VersionURL   string
+	// Format is already in b.Format.
+}
+
+// TODO: Move this to the more general configuration handling.
+func readBuildChrootsConfig(path string) (*buildChrootsConfig, error) {
+	iniFile, err := ini.InsensitiveLoad(path)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &buildChrootsConfig{}
+
+	// TODO: Validate early the fields we read.
+	server, err := iniFile.GetSection("Server")
+	if err == nil {
+		cfg.HasServerSection = true
+		cfg.DebugInfoBanned = server.Key("debuginfo_banned").Value()
+		cfg.DebugInfoLib = server.Key("debuginfo_lib").Value()
+		cfg.DebugInfoSrc = server.Key("debuginfo_src").Value()
+	}
+
+	swupd, err := iniFile.GetSection("swupd")
+	if err != nil {
+		return nil, fmt.Errorf("error in configuration file %s: %s", path, err)
+	}
+
+	getKey := func(section *ini.Section, name string) (string, error) {
+		key, kerr := section.GetKey(name)
+		if kerr != nil {
+			return "", fmt.Errorf("error in configuration file %s: %s", path, kerr)
+		}
+		return key.Value(), nil
+	}
+
+	cfg.UpdateBundle, err = getKey(swupd, "BUNDLE")
+	if err != nil {
+		return nil, err
+	}
+	cfg.ContentURL, err = getKey(swupd, "CONTENTURL")
+	if err != nil {
+		return nil, err
+	}
+	cfg.VersionURL, err = getKey(swupd, "VERSIONURL")
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+func (b *Builder) buildBundleChroots(set *bundleSet) error {
+	var err error
+
+	if b.Statedir == "" {
+		return errors.Errorf("invalid empty state dir")
+	}
+
+	chrootDir := filepath.Join(b.Statedir, "image")
+
+	// TODO: Remove remaining references to outputDir. Let "build update" take care of
+	// bootstraping or cleaning up.
+	outputDir := filepath.Join(b.Statedir, "www")
+
+	if _, ok := set.Bundles["os-core"]; !ok {
+		return fmt.Errorf("os-core bundle not found")
+	}
+
+	// Bootstrap the directories.
+	err = os.MkdirAll(filepath.Join(chrootDir, "0"), 0755)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(filepath.Join(outputDir, "0"), 0755)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Do not touch config code that is in flux at the moment, reparsing it here to grab
+	// information that previously Mixer didn't care about. Move that to the configuration part
+	// of Mixer.
+	cfg, err := readBuildChrootsConfig(b.Buildconf)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := set.Bundles[cfg.UpdateBundle]; !ok {
+		return fmt.Errorf("couldn't find bundle %q specified in configuration as the update bundle", cfg.UpdateBundle)
+	}
+
+	// Write INI files. These are used to communicate to the next step of mixing (build update).
+	var serverINI bytes.Buffer
+	fmt.Fprintf(&serverINI, `[Server]
+emptydir=%s/empty
+imagebase=%s/image/
+outputdir=%s/www/
+`, b.Statedir, b.Statedir, b.Statedir)
+	if cfg.HasServerSection {
+		fmt.Fprintf(&serverINI, `
+[Debuginfo]
+banned=%s
+lib=%s
+src=%s
+`, cfg.DebugInfoBanned, cfg.DebugInfoLib, cfg.DebugInfoSrc)
+	}
+	err = ioutil.WriteFile(filepath.Join(b.Statedir, "server.ini"), serverINI.Bytes(), 0644)
+	if err != nil {
+		return err
+	}
+	// TODO: If we are using INI files that are case insensitive, we need to be more restrictive
+	// in bundleset to check for that. See also readGroupsINI in swupd package.
+	var groupsINI bytes.Buffer
+	for _, bundle := range set.Bundles {
+		fmt.Fprintf(&groupsINI, "[%s]\ngroup=%s\n\n", bundle.Name, bundle.Name)
+	}
+	err = ioutil.WriteFile(filepath.Join(b.Statedir, "groups.ini"), groupsINI.Bytes(), 0644)
+	if err != nil {
+		return err
+	}
+
+	// Mixer is used to create both Clear Linux or a mix of it.
+	var version string
+	if b.Mixver != "" {
+		fmt.Printf("Creating chroots for version %s based on Clear Linux %s\n", b.Mixver, b.Clearver)
+		version = b.Mixver
+	} else {
+		fmt.Printf("Creating chroots for version %s\n", b.Clearver)
+		version = b.Clearver
+		// TODO: This validation should happen when reading the configuration.
+		if version == "" {
+			return errors.Errorf("no Mixver or Clearver set, unable to proceed")
+		}
+	}
+
+	chrootVersionDir := filepath.Join(chrootDir, version)
+	fmt.Printf("Preparing new %s\n", chrootVersionDir)
+	fmt.Printf("  and yum config: %s\n", b.Yumconf)
+
+	err = os.MkdirAll(chrootVersionDir, 0755)
+	if err != nil {
+		return err
+	}
+	for name, bundle := range set.Bundles {
+		// TODO: Should we embed this information in groups.ini? (Maybe rename it to bundles.ini)
+		var includes bytes.Buffer
+		for _, inc := range bundle.DirectIncludes {
+			fmt.Fprintf(&includes, "%s\n", inc)
+		}
+		err = ioutil.WriteFile(filepath.Join(chrootVersionDir, name+"-includes"), includes.Bytes(), 0644)
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Println("Creating os-core chroot")
+	osCoreDir := filepath.Join(chrootVersionDir, "os-core")
+	err = os.MkdirAll(filepath.Join(osCoreDir, "var/lib/rpm"), 0755)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Initializing RPM database")
+	err = helpers.RunCommandSilent(
+		"rpm",
+		"--root", osCoreDir,
+		"--initdb",
+	)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Check then change to always use dnf. See https://github.com/clearlinux/mixer-tools/issues/115.
+	yumCmd := []string{
+		"yum",
+		"--config=" + b.Yumconf,
+		"-y",
+		"--releasever=" + b.Clearver,
+	}
+	// When in Fedora, call dnf instead of yum.
+	if osInfo, oerr := readOSInfo(); oerr == nil {
+		if osInfo.ID == "fedora" {
+			// TODO: Simplify this when we can assume all Fedora users will be >= 22?
+			versionID, _ := strconv.Atoi(osInfo.VersionID)
+			if versionID >= 22 {
+				yumCmd[0] = "dnf"
+			}
+		}
+	}
+
+	fmt.Println("Installing filesystem package in os-core")
+	installArgs := merge(yumCmd,
+		"--installroot="+osCoreDir,
+		"install",
+		"filesystem",
+	)
+	err = helpers.RunCommandSilent(installArgs[0], installArgs[1:]...)
+	if err != nil {
+		return err
+	}
+
+	clearDir := filepath.Join(osCoreDir, "usr/share/clear")
+	err = os.MkdirAll(filepath.Join(clearDir, "bundles"), 0755)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Installing packages in os-core")
+	err = installPackagesToBundleChroot(yumCmd, chrootVersionDir, set.Bundles["os-core"])
+	if err != nil {
+		return err
+	}
+
+	// Writing special files identifying the version in os-core.
+	err = ioutil.WriteFile(filepath.Join(clearDir, "version"), []byte(version), 0644)
+	if err != nil {
+		return err
+	}
+	// TODO: This seems to be the only thing that makes two consecutive chroots of the same
+	// version to be different. Use SOURCE_DATE_EPOCH if available?
+	versionstamp := fmt.Sprint(time.Now().Unix())
+	err = ioutil.WriteFile(filepath.Join(clearDir, "versionstamp"), []byte(versionstamp), 0644)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Creating 'versions' file")
+	err = createVersionsFile(chrootVersionDir, yumCmd)
+	if err != nil {
+		return errors.Wrapf(err, "couldn't create the versions file")
+	}
+
+	err = fixOSRelease(filepath.Join(osCoreDir, "usr/lib/os-release"), version)
+	if err != nil {
+		return errors.Wrap(err, "couldn't fix os-release file")
+	}
+
+	fmt.Println("Creating chroots for bundles")
+	// TODO: Use goroutines.
+	for _, bundle := range set.Bundles {
+		if bundle.Name == "os-core" {
+			continue
+		}
+
+		fmt.Printf("Creating %s chroot\n", bundle.Name)
+		err = helpers.RunCommandSilent("cp", "-a", "--preserve=all", osCoreDir, filepath.Join(chrootVersionDir, bundle.Name))
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Installing packages to %s\n", bundle.Name)
+		err = installPackagesToBundleChroot(yumCmd, chrootVersionDir, bundle)
+		if err != nil {
+			return err
+		}
+
+		err = cleanBundleChroot(chrootVersionDir, bundle)
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("Adding swupd default values to '%s' bundle\n", cfg.UpdateBundle)
+	swupdDir := filepath.Join(chrootVersionDir, cfg.UpdateBundle, "usr/share/defaults/swupd")
+	err = os.MkdirAll(swupdDir, 0755)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(filepath.Join(swupdDir, "contenturl"), []byte(cfg.ContentURL), 0644)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(filepath.Join(swupdDir, "versionurl"), []byte(cfg.VersionURL), 0644)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(filepath.Join(swupdDir, "format"), []byte(b.Format), 0644)
+	if err != nil {
+		return err
+	}
+
+	// Cleaning os-core bundles after all the other bundles already used it for bootstrapping.
+	err = cleanBundleChroot(chrootVersionDir, set.Bundles["os-core"])
+	if err != nil {
+		return err
+	}
+
+	err = os.RemoveAll(filepath.Join(outputDir, version))
+	if err != nil {
+		return err
+	}
+
+	// TODO: Remove usage of noship directory. The image/NN is not shipped as part of the
+	// update, so the files can remain where they are.
+	fmt.Println("Copying files to noship/ directory")
+	noshipDir := filepath.Join(chrootVersionDir, "noship")
+	err = os.MkdirAll(noshipDir, 0755)
+	if err != nil {
+		return err
+	}
+	fis, err := ioutil.ReadDir(chrootVersionDir)
+	if err != nil {
+		return err
+	}
+	for _, fi := range fis {
+		name := fi.Name()
+		if !strings.HasPrefix(name, "packages-") && !strings.HasSuffix(name, "-includes") {
+			continue
+		}
+		err = helpers.CopyFile(filepath.Join(noshipDir, name), filepath.Join(chrootVersionDir, name))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// createVersionsFile creates a file that contains all the packages available for a specific
+// version. It uses one chroot to query information from the repositories using yum.
+func createVersionsFile(baseDir string, yumCmd []string) error {
+	// TODO: See if we query the list of packages some other way? Yum output is a bit
+	// unfriendly, see the workarounds below.
+	args := merge(yumCmd,
+		"--installroot="+filepath.Join(baseDir, "os-core"),
+		"list",
+	)
+
+	var outBuf bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		msg := fmt.Sprintf("couldn't list packages: %s\nCOMMAND LINE: %s", err, args)
+		if errBuf.Len() > 0 {
+			msg += "\nOUTPUT:\n%s" + errBuf.String()
+		}
+		return errors.New(msg)
+	}
+
+	type pkgEntry struct {
+		name, version string
+	}
+	var versions []*pkgEntry
+
+	scanner := bufio.NewScanner(&outBuf)
+	skippedPrefixes := []string{
+		// Default output from list command.
+		"Available",
+		"Installed",
+
+		// TODO: Review if those errors appear in stdout or stderr, if the former we can
+		// remove them. The rpm/yum cause the packages to be removed from the list.
+		"BDB2053", // Some Berkley DB error?
+		"rpm",
+		"yum",
+	}
+	for scanner.Scan() {
+		text := scanner.Text()
+
+		var skip bool
+		for _, p := range skippedPrefixes {
+			if strings.HasPrefix(text, p) {
+				skip = true
+				break
+			}
+		}
+		if skip {
+			continue
+		}
+
+		fields := strings.Fields(text)
+		if len(fields) != 3 {
+			// The output for yum list wraps at 80 when lacking information about the
+			// terminal, so we workaround by joining the next line and evaluating. See
+			// https://bugzilla.redhat.com/show_bug.cgi?id=584525 for the wrapping.
+			if scanner.Scan() {
+				text = text + scanner.Text()
+			} else {
+				return fmt.Errorf("couldn't parse line %q from yum list output", text)
+			}
+			fields = strings.Fields(text)
+			if len(fields) != 3 {
+				return fmt.Errorf("couldn't parse merged line %q from yum list output", text)
+			}
+		}
+
+		e := &pkgEntry{
+			name:    fields[0],
+			version: fields[1],
+		}
+		versions = append(versions, e)
+	}
+	err = scanner.Err()
+	if err != nil {
+		return err
+	}
+
+	sort.Slice(versions, func(i, j int) bool {
+		ii := versions[i]
+		jj := versions[j]
+		if ii.name == jj.name {
+			return ii.version < jj.version
+		}
+		return ii.name < jj.name
+	})
+
+	f, err := os.Create(filepath.Join(baseDir, "versions"))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	w := bufio.NewWriter(f)
+	for _, e := range versions {
+		// TODO: change users of "versions" file to not rely on this exact formatting (version
+		// starting at column 51). E.g. this doesn't handle very well packages with large names.
+		fmt.Fprintf(w, "%-50s%s\n", e.name, e.version)
+	}
+	return w.Flush()
+}
+
+func fixOSRelease(filename, version string) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	// TODO: If this is a mix, NAME and ID should probably change too. Create a section in
+	// configuration that will be used as reference to fill this.
+	// TODO: If this is a mix, add extra field for keeping track of the Clear Linux version
+	// used. Maybe also put the UPSTREAM URL, so we are ready to support mixes of mixes.
+	//
+	// See also: https://github.com/clearlinux/mixer-tools/issues/113
+
+	var newBuf bytes.Buffer
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		text := scanner.Text()
+		if strings.HasPrefix(text, "VERSION_ID=") {
+			text = "VERSION_ID=" + version
+		}
+		fmt.Fprintln(&newBuf, text)
+	}
+
+	err = scanner.Err()
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(filename, newBuf.Bytes(), 0644)
+}
+
+type osInfo struct {
+	ID        string
+	VersionID string
+}
+
+// readOSInfo reads the os-release(5) file to collect information about the system.
+func readOSInfo() (*osInfo, error) {
+	f, err := os.Open("/etc/os-release")
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		f, err = os.Open("/usr/lib/os-release")
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	release, err := ini.Load(f)
+	if err != nil {
+		return nil, err
+	}
+	section := release.Section("")
+
+	info := &osInfo{
+		ID:        section.Key("ID").Value(),
+		VersionID: section.Key("VERSION_ID").Value(),
+	}
+	return info, nil
+}
+
+func installPackagesToBundleChroot(yumCmd []string, chrootVersionDir string, bundle *bundle) error {
+	baseDir := filepath.Join(chrootVersionDir, bundle.Name)
+	args := merge(yumCmd,
+		"--installroot="+baseDir,
+		"install",
+	)
+	args = append(args, bundle.AllPackages...)
+	err := helpers.RunCommandSilent(args[0], args[1:]...)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(baseDir, "usr/share/clear/bundles", bundle.Name), nil, 0644)
+	if err != nil {
+		return err
+	}
+
+	// Generate packages-{BUNDLE} file, that contains the list of packages and package versions
+	// present in each bundle.
+	packages, err := helpers.RunCommandOutput(
+		"rpm",
+		"--root="+baseDir,
+		"-qa",
+		"--queryformat", "%{NAME}\t%{SOURCERPM}\n",
+	)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(filepath.Join(chrootVersionDir, "packages-"+bundle.Name), packages.Bytes(), 0644)
+}
+
+// cleanBundleChroot removes from the chroot files that were used during the chroot creation but
+// shouldn't be part of the bundle contents, e.g. temporary files, RPM database, yum cache.
+func cleanBundleChroot(chrootVersionDir string, bundle *bundle) error {
+	resetDir := func(path string, perm os.FileMode) error {
+		err := os.RemoveAll(path)
+		if err != nil {
+			return err
+		}
+		err = os.MkdirAll(path, perm)
+		if err != nil {
+			return err
+		}
+		// When creating, perm might get filtered with umask, so Chmod it.
+		return os.Chmod(path, perm)
+	}
+	var err error
+	baseDir := filepath.Join(chrootVersionDir, bundle.Name)
+	err = resetDir(filepath.Join(baseDir, "var/lib"), 0755)
+	if err != nil {
+		return err
+	}
+	err = resetDir(filepath.Join(baseDir, "var/cache"), 0755)
+	if err != nil {
+		return err
+	}
+	err = resetDir(filepath.Join(baseDir, "var/log"), 0755)
+	if err != nil {
+		return err
+	}
+	err = resetDir(filepath.Join(baseDir, "dev"), 0755)
+	if err != nil {
+		return err
+	}
+	err = resetDir(filepath.Join(baseDir, "run"), 0755)
+	if err != nil {
+		return err
+	}
+	err = resetDir(filepath.Join(baseDir, "tmp"), 01777)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func merge(a []string, b ...string) []string {
+	var result []string
+	result = append(result, a...)
+	result = append(result, b...)
+	return result
+}

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -1,0 +1,40 @@
+package helpers
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRunCommandOutputSuccess(t *testing.T) {
+	const msg = "Hello, world!"
+	const fail = "This is not working!"
+	// Prints both in stdout and stderr.
+	out, err := RunCommandOutput("bash", "-c", fmt.Sprintf("echo -n %q; echo -n %q >&2", msg, fail))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Output contains only stdout.
+	if out.String() != msg {
+		t.Fatalf("unexpected output %q instead of %q", out.String(), msg)
+	}
+}
+
+func TestRunCommandOutputFailure(t *testing.T) {
+	// Prints both in stdout and stderr. Calling false forces failure.
+	_, err := RunCommandOutput("bash", "-c", "export OK=OK; export FAIL=FAIL; echo -n $OK$OK; echo -n $FAIL$FAIL >&2; false")
+	if err == nil {
+		t.Fatal("unexpected success when running command")
+	}
+	// Error should contain both stdout and stderr. Note that the strings we are
+	// looking at are not part of the command, to avoid matching those.
+	if !strings.Contains(err.Error(), "OKOK") {
+		t.Errorf("error doesn't contain the stdout of the program")
+	}
+	if !strings.Contains(err.Error(), "FAILFAIL") {
+		t.Errorf("error doesn't contain the stderr of the program")
+	}
+	if t.Failed() {
+		fmt.Println(err)
+	}
+}

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -245,6 +245,7 @@ func init() {
 	RootCmd.AddCommand(buildCmd)
 
 	buildChrootsCmd.Flags().BoolVar(&buildFlags.noSigning, "no-signing", false, "Do not generate a certificate to sign the Manifest.MoM")
+	buildChrootsCmd.Flags().BoolVar(&builder.UseNewChrootBuilder, "new-chroots", false, "EXPERIMENTAL: Use new implementation of build chroots")
 
 	buildImageCmd.Flags().StringVar(&buildFlags.format, "format", "", "Supply the format used for the Mix")
 	buildImageCmd.Flags().StringVar(&buildFlags.template, "template", "", "Path to template file to use")


### PR DESCRIPTION
This rewrites bundle-chroot-builder.py in Go to be part of Mixer
code. Mixer is the only user of that software, and both Mixer and
b-c-b.py the same configuration file, with overlapping fields.

Main differences from bundle-chroot-builder.py:

- New bundleset type was added, that cares about collecting as much
  information as possible from the bundles themselves. This type and
  related functions also sets us up for success when upcoming changes
  to how bundles are specified happen. There is no assumption all
  bundles are in the same directory.

- We are not using m4, instead a bundleset takes care of parsing. If
  format of individual bundle files change. The upside is that we can
  give nicer error messages, specially for the circular case.

- Read the configuration file directly (with go-ini) to peek at values
  that Mixer didn't read before. Done that to avoid conflicting with
  existing patch in-flight that parses configuration.

- Some individual steps were reordered for code clarity. E.g.: since
  we have bundleset, we can upfront generate all the *-include files.

- Fixed the output for versions file. Due to the way yum list output
  works, parsing it is not very friendly. Comments around the code
  tells the story.

- Removed the network testing step. It wasn't covering every case in
  the Python version, so I'm leaning to let the failure come from
  yum/dnf itself. I'm usually in favor of such early tests, but in
  this case the price of parsing yet another config file didn't felt
  worth.

- Removed the "yum clean all" step from the bootstrap. There isn't any
  cache at that point, and the next yum call will bootstrap the
  necessary files for yum to operate.

- Removed generation of files-* files (and the pkgmap-* files used to
  generate them). I couldn't find any tool or team making use of this
  information. Those (or their content) might be relevant in future
  changes to use a single chroot, but we should add when we need them.

- Added more detailed commentary to individual steps, collecting
  information from the developers of bcb and related software.

- The port still don't parallelize the work into multiple
  goroutines. I plan to do this in a similar way than what was done in
  CreateFullfiles, but in a separated patch.

Fixes #42.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>