### PR TITLE
swupd: export manifest flag constants

### DIFF
--- a/swupd/files_test.go
+++ b/swupd/files_test.go
@@ -5,13 +5,13 @@ import "testing"
 func TestTypeFromFlagFile(t *testing.T) {
 	testCases := []struct {
 		flag     byte
-		expected ftype
+		expected TypeFlag
 	}{
-		{'F', typeFile},
-		{'D', typeDirectory},
-		{'L', typeLink},
-		{'M', typeManifest},
-		{'.', typeUnset},
+		{'F', TypeFile},
+		{'D', TypeDirectory},
+		{'L', TypeLink},
+		{'M', TypeManifest},
+		{'.', TypeUnset},
 	}
 
 	for _, tc := range testCases {
@@ -36,7 +36,7 @@ func TestTypeFromFlagFile(t *testing.T) {
 			t.Error("typeFromFlag did not fail with invalid input")
 		}
 
-		if f.Type != typeUnset {
+		if f.Type != TypeUnset {
 			t.Errorf("file type was set to %v from invalid flag", f.Type)
 		}
 	})
@@ -45,11 +45,11 @@ func TestTypeFromFlagFile(t *testing.T) {
 func TestStatusFromFlag(t *testing.T) {
 	testCases := []struct {
 		flag     byte
-		expected fstatus
+		expected StatusFlag
 	}{
-		{'d', statusDeleted},
-		{'g', statusGhosted},
-		{'.', statusUnset},
+		{'d', StatusDeleted},
+		{'g', StatusGhosted},
+		{'.', StatusUnset},
 	}
 
 	for _, tc := range testCases {
@@ -74,7 +74,7 @@ func TestStatusFromFlag(t *testing.T) {
 			t.Error("statusFromFlag did not fail with invalid input")
 		}
 
-		if f.Status != statusUnset {
+		if f.Status != StatusUnset {
 			t.Errorf("file modifier was set to %v from invalid flag", f.Status)
 		}
 	})
@@ -83,12 +83,12 @@ func TestStatusFromFlag(t *testing.T) {
 func TestModifierFromFlag(t *testing.T) {
 	testCases := []struct {
 		flag     byte
-		expected fmodifier
+		expected ModifierFlag
 	}{
-		{'C', modifierConfig},
-		{'s', modifierState},
-		{'b', modifierBoot},
-		{'.', modifierUnset},
+		{'C', ModifierConfig},
+		{'s', ModifierState},
+		{'b', ModifierBoot},
+		{'.', ModifierUnset},
 	}
 
 	for _, tc := range testCases {
@@ -113,7 +113,7 @@ func TestModifierFromFlag(t *testing.T) {
 			t.Error("setModifierFromFlag did not fail with invalid input")
 		}
 
-		if f.Modifier != modifierUnset {
+		if f.Modifier != ModifierUnset {
 			t.Errorf("file modifier was set to %v from invalid flag", f.Modifier)
 		}
 	})
@@ -261,33 +261,33 @@ func TestSameFile(t *testing.T) {
 		expected bool
 	}{
 		{
-			File{Name: "1", Hash: 1, Type: typeFile, Status: statusUnset, Modifier: modifierUnset},
-			File{Name: "1", Hash: 1, Type: typeFile, Status: statusUnset, Modifier: modifierUnset},
+			File{Name: "1", Hash: 1, Type: TypeFile, Status: StatusUnset, Modifier: ModifierUnset},
+			File{Name: "1", Hash: 1, Type: TypeFile, Status: StatusUnset, Modifier: ModifierUnset},
 			true,
 		},
 		{
-			File{Name: "1", Hash: 1, Type: typeFile, Status: statusUnset, Modifier: modifierUnset},
-			File{Name: "2", Hash: 1, Type: typeFile, Status: statusUnset, Modifier: modifierUnset},
+			File{Name: "1", Hash: 1, Type: TypeFile, Status: StatusUnset, Modifier: ModifierUnset},
+			File{Name: "2", Hash: 1, Type: TypeFile, Status: StatusUnset, Modifier: ModifierUnset},
 			false,
 		},
 		{
-			File{Name: "1", Hash: 1, Type: typeFile, Status: statusUnset, Modifier: modifierUnset},
-			File{Name: "1", Hash: 2, Type: typeFile, Status: statusUnset, Modifier: modifierUnset},
+			File{Name: "1", Hash: 1, Type: TypeFile, Status: StatusUnset, Modifier: ModifierUnset},
+			File{Name: "1", Hash: 2, Type: TypeFile, Status: StatusUnset, Modifier: ModifierUnset},
 			false,
 		},
 		{
-			File{Name: "1", Hash: 1, Type: typeFile, Status: statusUnset, Modifier: modifierUnset},
-			File{Name: "1", Hash: 1, Type: typeLink, Status: statusUnset, Modifier: modifierUnset},
+			File{Name: "1", Hash: 1, Type: TypeFile, Status: StatusUnset, Modifier: ModifierUnset},
+			File{Name: "1", Hash: 1, Type: TypeLink, Status: StatusUnset, Modifier: ModifierUnset},
 			false,
 		},
 		{
-			File{Name: "1", Hash: 1, Type: typeFile, Status: statusUnset, Modifier: modifierUnset},
-			File{Name: "1", Hash: 1, Type: typeFile, Status: statusDeleted, Modifier: modifierUnset},
+			File{Name: "1", Hash: 1, Type: TypeFile, Status: StatusUnset, Modifier: ModifierUnset},
+			File{Name: "1", Hash: 1, Type: TypeFile, Status: StatusDeleted, Modifier: ModifierUnset},
 			false,
 		},
 		{
-			File{Name: "1", Hash: 1, Type: typeFile, Status: statusUnset, Modifier: modifierUnset},
-			File{Name: "1", Hash: 1, Type: typeFile, Status: statusUnset, Modifier: modifierBoot},
+			File{Name: "1", Hash: 1, Type: TypeFile, Status: StatusUnset, Modifier: ModifierUnset},
+			File{Name: "1", Hash: 1, Type: TypeFile, Status: StatusUnset, Modifier: ModifierBoot},
 			false,
 		},
 	}
@@ -310,99 +310,99 @@ func TestTypeHasChanged(t *testing.T) {
 	}{
 		{
 			File{
-				Status: statusDeleted,
-				Type:   typeFile,
+				Status: StatusDeleted,
+				Type:   TypeFile,
 				DeltaPeer: &File{
-					Status: statusDeleted,
-					Type:   typeDirectory,
+					Status: StatusDeleted,
+					Type:   TypeDirectory,
 				},
 			},
 			false,
 		},
 		{
 			File{
-				Status: statusUnset,
-				Type:   typeFile,
+				Status: StatusUnset,
+				Type:   TypeFile,
 				DeltaPeer: &File{
-					Status: statusDeleted,
-					Type:   typeDirectory,
+					Status: StatusDeleted,
+					Type:   TypeDirectory,
 				},
 			},
 			false,
 		},
 		{
 			File{
-				Status: statusUnset,
-				Type:   typeDirectory,
+				Status: StatusUnset,
+				Type:   TypeDirectory,
 				DeltaPeer: &File{
-					Status: statusUnset,
-					Type:   typeDirectory,
+					Status: StatusUnset,
+					Type:   TypeDirectory,
 				},
 			},
 			false,
 		},
 		{
 			File{
-				Status: statusUnset,
-				Type:   typeLink,
+				Status: StatusUnset,
+				Type:   TypeLink,
 				DeltaPeer: &File{
-					Status: statusUnset,
-					Type:   typeFile,
+					Status: StatusUnset,
+					Type:   TypeFile,
 				},
 			},
 			false,
 		},
 		{
 			File{
-				Status: statusUnset,
-				Type:   typeDirectory,
+				Status: StatusUnset,
+				Type:   TypeDirectory,
 				DeltaPeer: &File{
-					Status: statusUnset,
-					Type:   typeFile,
+					Status: StatusUnset,
+					Type:   TypeFile,
 				},
 			},
 			false,
 		},
 		{
 			File{
-				Status: statusUnset,
-				Type:   typeFile,
+				Status: StatusUnset,
+				Type:   TypeFile,
 				DeltaPeer: &File{
-					Status: statusUnset,
-					Type:   typeLink,
+					Status: StatusUnset,
+					Type:   TypeLink,
 				},
 			},
 			false,
 		},
 		{
 			File{
-				Status: statusUnset,
-				Type:   typeDirectory,
+				Status: StatusUnset,
+				Type:   TypeDirectory,
 				DeltaPeer: &File{
-					Status: statusUnset,
-					Type:   typeLink,
+					Status: StatusUnset,
+					Type:   TypeLink,
 				},
 			},
 			false,
 		},
 		{
 			File{
-				Status: statusUnset,
-				Type:   typeFile,
+				Status: StatusUnset,
+				Type:   TypeFile,
 				DeltaPeer: &File{
-					Status: statusUnset,
-					Type:   typeDirectory,
+					Status: StatusUnset,
+					Type:   TypeDirectory,
 				},
 			},
 			true,
 		},
 		{
 			File{
-				Status: statusUnset,
-				Type:   typeLink,
+				Status: StatusUnset,
+				Type:   TypeLink,
 				DeltaPeer: &File{
-					Status: statusUnset,
-					Type:   typeDirectory,
+					Status: StatusUnset,
+					Type:   TypeDirectory,
 				},
 			},
 			true,

--- a/swupd/filesystem.go
+++ b/swupd/filesystem.go
@@ -65,11 +65,11 @@ func recordFromFile(rootPath, path string, fi os.FileInfo) (*File, error) {
 
 	switch mode := fi.Mode(); {
 	case mode.IsRegular():
-		file.Type = typeFile
+		file.Type = TypeFile
 	case mode.IsDir():
-		file.Type = typeDirectory
+		file.Type = TypeDirectory
 	case mode&os.ModeSymlink != 0:
-		file.Type = typeLink
+		file.Type = TypeLink
 	default:
 		return nil, fmt.Errorf("%v is an unsupported file type", file.Name)
 	}
@@ -101,7 +101,7 @@ func (m *Manifest) createManifestRecord(rootPath string, path string, fi os.File
 
 	// Only the bundle name should be part of the name in the manifest
 	file.Name = strings.Replace(file.Name, "/Manifest.", "", -1)
-	file.Type = typeManifest
+	file.Type = TypeManifest
 	file.Version = version
 	m.Files = append(m.Files, file)
 	return nil

--- a/swupd/filesystem_test.go
+++ b/swupd/filesystem_test.go
@@ -10,7 +10,7 @@ func TestCreateFileFromPath(t *testing.T) {
 	path := "testdata/manifest.good"
 	expected := File{
 		Name: path,
-		Type: typeFile,
+		Type: TypeFile,
 	}
 
 	var fh Hashval

--- a/swupd/fullfiles.go
+++ b/swupd/fullfiles.go
@@ -64,11 +64,11 @@ func CreateFullfiles(m *Manifest, chrootDir, outputDir string) error {
 			}
 
 			switch f.Type {
-			case typeDirectory:
+			case TypeDirectory:
 				err = createDirectoryFullfile(input, name, output)
-			case typeLink:
+			case TypeLink:
 				err = createLinkFullfile(input, name, output)
-			case typeFile:
+			case TypeFile:
 				err = createRegularFullfile(input, name, output)
 			default:
 				err = fmt.Errorf("file %s is of unsupported type %q", f.Name, f.Type)
@@ -88,7 +88,7 @@ func CreateFullfiles(m *Manifest, chrootDir, outputDir string) error {
 
 	done := make(map[Hashval]bool)
 	for _, f := range m.Files {
-		if done[f.Hash] || f.Version != m.Header.Version || f.Status == statusDeleted || f.Status == statusGhosted {
+		if done[f.Hash] || f.Version != m.Header.Version || f.Status == StatusDeleted || f.Status == StatusGhosted {
 			continue
 		}
 		done[f.Hash] = true

--- a/swupd/fullfiles_test.go
+++ b/swupd/fullfiles_test.go
@@ -51,7 +51,7 @@ func TestCreateFullfiles(t *testing.T) {
 		f := &File{
 			Name:    name,
 			Hash:    internHash(desc.hash),
-			Type:    typeFile,
+			Type:    TypeFile,
 			Version: desc.version,
 		}
 		if m.Header.Version == f.Version {

--- a/swupd/heuristics.go
+++ b/swupd/heuristics.go
@@ -24,7 +24,7 @@ func (f *File) setConfigFromPathname() {
 
 	for _, path := range configPaths {
 		if strings.HasPrefix(f.Name, path) {
-			f.Modifier = modifierConfig
+			f.Modifier = ModifierConfig
 			return
 		}
 	}
@@ -51,7 +51,7 @@ func (f *File) setStateFromPathname() {
 		if f.Name == path {
 			return
 		} else if strings.HasPrefix(f.Name, path+"/") {
-			f.Modifier = modifierState
+			f.Modifier = ModifierState
 			return
 		}
 	}
@@ -87,7 +87,7 @@ func (f *File) setStateFromPathname() {
 
 	for _, path := range finalStatePaths {
 		if strings.HasPrefix(f.Name, path) {
-			f.Modifier = modifierState
+			f.Modifier = ModifierState
 			return
 		}
 	}
@@ -105,9 +105,9 @@ func (f *File) setBootFromPathname() {
 
 	for _, path := range bootPaths {
 		if strings.HasPrefix(f.Name, path) {
-			f.Modifier = modifierBoot
-			if f.Status == statusDeleted {
-				f.Status = statusGhosted
+			f.Modifier = ModifierBoot
+			if f.Status == StatusDeleted {
+				f.Status = StatusGhosted
 			}
 			return
 		}

--- a/swupd/heuristics_test.go
+++ b/swupd/heuristics_test.go
@@ -7,13 +7,13 @@ import (
 func TestSetConfigFromPathname(t *testing.T) {
 	testCases := []struct {
 		file     File
-		expected fmodifier
+		expected ModifierFlag
 	}{
-		{File{Name: "/etc/something"}, modifierConfig},
-		{File{Name: "/etc/a"}, modifierConfig},
-		{File{Name: "/not/etc"}, modifierUnset},
-		{File{Name: "/etc"}, modifierUnset},
-		{File{Name: "/something/else/entirely"}, modifierUnset},
+		{File{Name: "/etc/something"}, ModifierConfig},
+		{File{Name: "/etc/a"}, ModifierConfig},
+		{File{Name: "/not/etc"}, ModifierUnset},
+		{File{Name: "/etc"}, ModifierUnset},
+		{File{Name: "/something/else/entirely"}, ModifierUnset},
 	}
 
 	for _, tc := range testCases {
@@ -44,34 +44,34 @@ func TestSetStateFromPathname(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			// actual directories do not get their modifier set
 			tc.setStateFromPathname()
-			if tc.Modifier != modifierUnset {
+			if tc.Modifier != ModifierUnset {
 				t.Errorf("file %v modifier %v did not match expected %v",
-					tc.Name, tc.Modifier, modifierUnset)
+					tc.Name, tc.Modifier, ModifierUnset)
 			}
 
 			// now check children of the directory
 			tc.Name = tc.Name + "/a"
 			tc.setStateFromPathname()
-			if tc.Modifier != modifierState {
+			if tc.Modifier != ModifierState {
 				t.Errorf("file %v modifier %v did not match expected %v",
-					tc.Name, tc.Modifier, modifierState)
+					tc.Name, tc.Modifier, ModifierState)
 			}
 		})
 	}
 
 	allTestCases := []struct {
 		file     File
-		expected fmodifier
+		expected ModifierFlag
 	}{
-		{File{Name: "/acct/a"}, modifierState},
-		{File{Name: "/cache/a"}, modifierState},
-		{File{Name: "/data/a"}, modifierState},
-		{File{Name: "/lost+found/a"}, modifierState},
-		{File{Name: "/mnt/asec/a"}, modifierState},
-		{File{Name: "/a"}, modifierUnset},
-		{File{Name: "/acct"}, modifierState},
-		{File{Name: "/other"}, modifierUnset},
-		{File{Name: "/usr/src/foo"}, modifierState},
+		{File{Name: "/acct/a"}, ModifierState},
+		{File{Name: "/cache/a"}, ModifierState},
+		{File{Name: "/data/a"}, ModifierState},
+		{File{Name: "/lost+found/a"}, ModifierState},
+		{File{Name: "/mnt/asec/a"}, ModifierState},
+		{File{Name: "/a"}, ModifierUnset},
+		{File{Name: "/acct"}, ModifierState},
+		{File{Name: "/other"}, ModifierUnset},
+		{File{Name: "/usr/src/foo"}, ModifierState},
 	}
 
 	for _, tc := range allTestCases {
@@ -88,15 +88,15 @@ func TestSetStateFromPathname(t *testing.T) {
 func TestSetBootFromPathname(t *testing.T) {
 	testCases := []struct {
 		file     File
-		expected fmodifier
+		expected ModifierFlag
 	}{
-		{File{Name: "/boot/EFI"}, modifierBoot},
-		{File{Name: "/usr/lib/modules/module"}, modifierBoot},
-		{File{Name: "/usr/lib/kernel/file"}, modifierBoot},
-		{File{Name: "/usr/lib/gummiboot/foo"}, modifierBoot},
-		{File{Name: "/usr/bin/gummiboot/bar"}, modifierBoot},
-		{File{Name: "/usr/gummiboot/bar"}, modifierUnset},
-		{File{Name: "/usr/kernel/bar"}, modifierUnset},
+		{File{Name: "/boot/EFI"}, ModifierBoot},
+		{File{Name: "/usr/lib/modules/module"}, ModifierBoot},
+		{File{Name: "/usr/lib/kernel/file"}, ModifierBoot},
+		{File{Name: "/usr/lib/gummiboot/foo"}, ModifierBoot},
+		{File{Name: "/usr/bin/gummiboot/bar"}, ModifierBoot},
+		{File{Name: "/usr/gummiboot/bar"}, ModifierUnset},
+		{File{Name: "/usr/kernel/bar"}, ModifierUnset},
 	}
 
 	for _, tc := range testCases {
@@ -113,15 +113,15 @@ func TestSetBootFromPathname(t *testing.T) {
 func TestSetModifierFromPathname(t *testing.T) {
 	testCases := []struct {
 		file     File
-		expected fmodifier
+		expected ModifierFlag
 	}{
-		{File{Name: "/etc/file"}, modifierConfig},
-		{File{Name: "/usr/src/debug"}, modifierUnset},
-		{File{Name: "/dev/foo"}, modifierState},
-		{File{Name: "/usr/src/file"}, modifierState},
-		{File{Name: "/acct/file"}, modifierState},
-		{File{Name: "/boot/EFI"}, modifierBoot},
-		{File{Name: "/randomfile"}, modifierUnset},
+		{File{Name: "/etc/file"}, ModifierConfig},
+		{File{Name: "/usr/src/debug"}, ModifierUnset},
+		{File{Name: "/dev/foo"}, ModifierState},
+		{File{Name: "/usr/src/file"}, ModifierState},
+		{File{Name: "/acct/file"}, ModifierState},
+		{File{Name: "/boot/EFI"}, ModifierBoot},
+		{File{Name: "/randomfile"}, ModifierUnset},
 	}
 
 	for _, tc := range testCases {
@@ -136,14 +136,14 @@ func TestSetModifierFromPathname(t *testing.T) {
 }
 
 func TestApplyHeuristics(t *testing.T) {
-	testCases := map[string]fmodifier{
-		"/etc/file":      modifierConfig,
-		"/usr/src/debug": modifierUnset,
-		"/dev/foo":       modifierState,
-		"/usr/src/file":  modifierState,
-		"/acct/file":     modifierState,
-		"/boot/EFI":      modifierBoot,
-		"/randomfile":    modifierUnset,
+	testCases := map[string]ModifierFlag{
+		"/etc/file":      ModifierConfig,
+		"/usr/src/debug": ModifierUnset,
+		"/dev/foo":       ModifierState,
+		"/usr/src/file":  ModifierState,
+		"/acct/file":     ModifierState,
+		"/boot/EFI":      ModifierBoot,
+		"/randomfile":    ModifierUnset,
 	}
 
 	m := Manifest{}

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -151,7 +151,7 @@ func readManifestFileEntry(fields []string, m *Manifest) error {
 	m.Files = append(m.Files, file)
 
 	// track deleted file
-	if file.Status == statusDeleted {
+	if file.Status == StatusDeleted {
 		m.DeletedFiles = append(m.DeletedFiles, file)
 	}
 
@@ -370,7 +370,7 @@ func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, minVersion uint32) 
 			// if it is the same name check if anything about the file has changed.
 			// if something has changed update the version to current version and
 			// record that the file has changed
-			if of.Status == statusDeleted || of.Status == statusGhosted {
+			if of.Status == StatusDeleted || of.Status == StatusGhosted {
 				nf.Version = m.Header.Version
 				added = append(added, nf)
 				ox++
@@ -406,7 +406,7 @@ func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, minVersion uint32) 
 		} else {
 			// if the file exists in the old manifest and does not *yet* exist
 			// in the new manifest, it was deleted.
-			if of.Status == statusDeleted || of.Status == statusGhosted {
+			if of.Status == StatusDeleted || of.Status == StatusGhosted {
 				ox++
 				continue
 			}
@@ -425,7 +425,7 @@ func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, minVersion uint32) 
 
 	// anything remaining in oldManifest is newly deleted in the new manifest
 	for _, of := range oldManifest.Files[ox:omFilesLen] {
-		if of.Status == statusDeleted || of.Status == statusGhosted {
+		if of.Status == StatusDeleted || of.Status == StatusGhosted {
 			continue
 		}
 		m.newDeleted(of)
@@ -437,9 +437,9 @@ func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, minVersion uint32) 
 	// if a file still has deleted status here and is not a rename
 	// the has needs to be set to all zeros
 	for _, f := range removed {
-		if f.Status == statusDeleted && !f.Rename {
+		if f.Status == StatusDeleted && !f.Rename {
 			f.Hash = 0
-			f.Type = typeUnset
+			f.Type = TypeUnset
 		}
 	}
 
@@ -452,8 +452,8 @@ func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, minVersion uint32) 
 
 func (m *Manifest) newDeleted(df *File) {
 	df.Version = m.Header.Version
-	df.Status = statusDeleted
-	df.Modifier = modifierUnset
+	df.Status = StatusDeleted
+	df.Modifier = ModifierUnset
 	// Add file to manifest
 	m.Files = append(m.Files, df)
 }
@@ -514,7 +514,7 @@ func (m *Manifest) subtractManifestFromManifest(m2 *Manifest) {
 			// required for "swupd update" to know when to delete the
 			// file, because the m2 bundle may be installed with or
 			// without the m1 bundle.
-			if f1.Status == statusDeleted && f2.Status == statusDeleted {
+			if f1.Status == StatusDeleted && f2.Status == StatusDeleted {
 				i++
 				j++
 				continue
@@ -590,7 +590,7 @@ func maxFullFromManifest(mf *Manifest, bundle *Manifest) {
 		bf := bundle.Files[j]
 		if ff.Name == bf.Name {
 			// files match, maximize versions if appropriate
-			if bf.Status != statusDeleted && bf.Version > ff.Version {
+			if bf.Status != StatusDeleted && bf.Version > ff.Version {
 				ff.Version = bf.Version
 			}
 			// advance both indices

--- a/swupd/manifest_test.go
+++ b/swupd/manifest_test.go
@@ -369,21 +369,21 @@ func TestSortFilesVersionName(t *testing.T) {
 func TestLinkPeersAndChange(t *testing.T) {
 	mOld := Manifest{
 		Files: []*File{
-			{Name: "1", Status: statusUnset},
-			{Name: "2", Status: statusDeleted},
-			{Name: "3", Status: statusGhosted},
-			{Name: "4", Status: statusUnset},
-			{Name: "5", Status: statusUnset, Hash: 1},
+			{Name: "1", Status: StatusUnset},
+			{Name: "2", Status: StatusDeleted},
+			{Name: "3", Status: StatusGhosted},
+			{Name: "4", Status: StatusUnset},
+			{Name: "5", Status: StatusUnset, Hash: 1},
 		},
 	}
 
 	mNew := Manifest{
 		Files: []*File{
-			{Name: "1", Status: statusUnset},
-			{Name: "2", Status: statusUnset},
-			{Name: "3", Status: statusUnset},
-			{Name: "5", Status: statusUnset, Hash: 2},
-			{Name: "6", Status: statusUnset},
+			{Name: "1", Status: StatusUnset},
+			{Name: "2", Status: StatusUnset},
+			{Name: "3", Status: StatusUnset},
+			{Name: "5", Status: StatusUnset, Hash: 2},
+			{Name: "6", Status: StatusUnset},
 		},
 	}
 
@@ -434,78 +434,78 @@ func TestHasTypeChanges(t *testing.T) {
 		Files: []*File{
 			{ // no delta peer, no type change
 				Name:      "1",
-				Type:      typeFile,
-				Status:    statusUnset,
+				Type:      TypeFile,
+				Status:    StatusUnset,
 				DeltaPeer: nil,
 			},
 			{ // same type, no type change
 				Name:   "2",
-				Type:   typeFile,
-				Status: statusUnset,
+				Type:   TypeFile,
+				Status: StatusUnset,
 				DeltaPeer: &File{
 					Name:   "2",
-					Type:   typeFile,
-					Status: statusUnset,
+					Type:   TypeFile,
+					Status: StatusUnset,
 				},
 			},
 			{ // File -> Link OK, no change reported
 				Name:   "3",
-				Type:   typeLink,
-				Status: statusUnset,
+				Type:   TypeLink,
+				Status: StatusUnset,
 				DeltaPeer: &File{
 					Name:   "3",
-					Type:   typeFile,
-					Status: statusUnset,
+					Type:   TypeFile,
+					Status: StatusUnset,
 				},
 			},
 			{ // File -> Directory OK, no change reported
 				Name:   "4",
-				Type:   typeDirectory,
-				Status: statusUnset,
+				Type:   TypeDirectory,
+				Status: StatusUnset,
 				DeltaPeer: &File{
 					Name:   "4",
-					Type:   typeFile,
-					Status: statusUnset,
+					Type:   TypeFile,
+					Status: StatusUnset,
 				},
 			},
 			{ // Link -> File OK, no change reported
 				Name:   "5",
-				Type:   typeFile,
-				Status: statusUnset,
+				Type:   TypeFile,
+				Status: StatusUnset,
 				DeltaPeer: &File{
 					Name:   "5",
-					Type:   typeLink,
-					Status: statusUnset,
+					Type:   TypeLink,
+					Status: StatusUnset,
 				},
 			},
 			{ // Link -> Directory OK, no change reported
 				Name:   "6",
-				Type:   typeDirectory,
-				Status: statusUnset,
+				Type:   TypeDirectory,
+				Status: StatusUnset,
 				DeltaPeer: &File{
 					Name:   "6",
-					Type:   typeLink,
-					Status: statusUnset,
+					Type:   TypeLink,
+					Status: StatusUnset,
 				},
 			},
 			{ // file deleted, no type change reported
 				Name:   "7",
-				Type:   typeFile,
-				Status: statusDeleted,
+				Type:   TypeFile,
+				Status: StatusDeleted,
 				DeltaPeer: &File{
 					Name:   "7",
-					Type:   typeLink,
-					Status: statusUnset,
+					Type:   TypeLink,
+					Status: StatusUnset,
 				},
 			},
 			{ // delta peer deleted, no type change reported
 				Name:   "8",
-				Type:   typeFile,
-				Status: statusUnset,
+				Type:   TypeFile,
+				Status: StatusUnset,
 				DeltaPeer: &File{
 					Name:   "8",
-					Type:   typeLink,
-					Status: statusDeleted,
+					Type:   TypeLink,
+					Status: StatusDeleted,
 				},
 			},
 		},
@@ -515,12 +515,12 @@ func TestHasTypeChanges(t *testing.T) {
 			Files: []*File{ // Directory -> File TYPE CHANGE
 				{
 					Name:   "1",
-					Type:   typeFile,
-					Status: statusUnset,
+					Type:   TypeFile,
+					Status: StatusUnset,
 					DeltaPeer: &File{
 						Name:   "1",
-						Type:   typeDirectory,
-						Status: statusUnset,
+						Type:   TypeDirectory,
+						Status: StatusUnset,
 					},
 				},
 			},
@@ -529,12 +529,12 @@ func TestHasTypeChanges(t *testing.T) {
 			Files: []*File{ // Directory -> Link TYPE CHANGE
 				{
 					Name:   "2",
-					Type:   typeLink,
-					Status: statusUnset,
+					Type:   TypeLink,
+					Status: StatusUnset,
 					DeltaPeer: &File{
 						Name:   "2",
-						Type:   typeDirectory,
-						Status: statusUnset,
+						Type:   TypeDirectory,
+						Status: StatusUnset,
 					},
 				},
 			},

--- a/swupd/packs.go
+++ b/swupd/packs.go
@@ -131,11 +131,11 @@ func WritePack(w io.Writer, m *Manifest, fromVersion uint32, outputDir, chrootDi
 			entry.Reason = "hash already packed"
 			continue
 		}
-		if f.Status == statusDeleted {
+		if f.Status == StatusDeleted {
 			entry.Reason = "file deleted"
 			continue
 		}
-		if f.Status == statusGhosted {
+		if f.Status == StatusGhosted {
 			entry.Reason = "file ghosted"
 			continue
 		}
@@ -185,13 +185,13 @@ func copyFromFullChrootFile(tw *tar.Writer, fullChrootDir string, f *File) (fall
 	// TODO: Also perform this verification for copyFromFullfile?
 
 	switch f.Type {
-	case typeDirectory:
+	case TypeDirectory:
 		if !fi.IsDir() {
 			return true, fmt.Errorf("couldn't use %s for packing: manifest expected a directory but it is not", realname)
 		}
 		hdr.Name = hdr.Name + "/"
 		hdr.Typeflag = tar.TypeDir
-	case typeLink:
+	case TypeLink:
 		if fi.Mode()&os.ModeSymlink == 0 {
 			return true, fmt.Errorf("couldn't use %s for packing: manifest expected a link but it is not", realname)
 		}
@@ -202,7 +202,7 @@ func copyFromFullChrootFile(tw *tar.Writer, fullChrootDir string, f *File) (fall
 		}
 		hdr.Typeflag = tar.TypeSymlink
 		hdr.Linkname = link
-	case typeFile:
+	case TypeFile:
 		if !fi.Mode().IsRegular() {
 			return true, fmt.Errorf("couldn't use %s for packing: manifest expected a regular file but it is not", realname)
 		}


### PR DESCRIPTION
The flag attributes are already exported, but the constants were not,
so export them. Re-order them in the file to be consistent with the
flag order. Flags are now represented by a single byte.

One option in the future is to map the constants directly to their
real values in the file (e.g. 'F', 'D'), instead of having a new
enumeration starting from zero.

Opted not to do the same with rename (fourth byte) since it is
currently mapped in a different way (boolean), but might make sense to
treat it as a modifier instead (as other extensions might reuse that
byte).

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>