### PR TITLE
swupd: teach ParseManifestFile to fill in the Name field

### DIFF
--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -204,11 +204,21 @@ func ParseManifestFile(path string) (*Manifest, error) {
 		_ = f.Close()
 		return nil, err
 	}
+	m.Name = getNameForManifestFile(path)
 	err = f.Close()
 	if err != nil {
 		return nil, err
 	}
 	return m, nil
+}
+
+func getNameForManifestFile(path string) string {
+	prefix := "Manifest."
+	idx := strings.LastIndex(path, prefix)
+	if idx != -1 {
+		return path[idx+len(prefix):]
+	}
+	return ""
 }
 
 // ParseManifest creates a Manifest from an io.Reader.

--- a/swupd/manifest_test.go
+++ b/swupd/manifest_test.go
@@ -551,3 +551,25 @@ func TestHasTypeChanges(t *testing.T) {
 		}
 	}
 }
+
+func TestGetNameForManifestFile(t *testing.T) {
+	tests := []struct {
+		Filename     string
+		ExpectedName string
+	}{
+		{"Manifest.MoM", "MoM"},
+		{"Manifest.c-basic", "c-basic"},
+		{"12/Manifest.MoM", "MoM"},
+
+		{"manifest.good", ""},
+		{"Othername", ""},
+		{"Othername.MoM", ""},
+	}
+
+	for _, tt := range tests {
+		name := getNameForManifestFile(tt.Filename)
+		if name != tt.ExpectedName {
+			t.Errorf("Manifest with filename %s got name %q, but want %q", tt.Filename, name, tt.ExpectedName)
+		}
+	}
+}

--- a/swupd/packs.go
+++ b/swupd/packs.go
@@ -410,9 +410,6 @@ func CreatePack(name string, fromVersion, toVersion uint32, outputDir, chrootDir
 	if err != nil {
 		return nil, err
 	}
-	// TODO: Should ParseManifestFile fill this with whatever comes after "Manifest."?
-	m.Name = name
-
 	packPath := filepath.Join(toDir, GetPackFilename(name, fromVersion))
 	output, err := os.Create(packPath)
 	if err != nil {


### PR DESCRIPTION
When parsing a file, fill in the Name field based on the
filename, essentially taking whatever comes after "Manifest.". If
doesn't match, just leave Name empty like before.

Small test added so we can keep track of edge cases in the future.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>