### PR TITLE
Only set delta peers if files are not identical

### DIFF
--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -387,9 +387,6 @@ func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, minVersion uint32) 
 				nx++
 				continue
 			}
-			// set up peers since old file exists
-			nf.DeltaPeer = of
-			of.DeltaPeer = nf
 			if sameFile(nf, of) && of.Version >= minVersion {
 				// file did not change, set version to the old version
 				nf.Version = of.Version
@@ -401,6 +398,9 @@ func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, minVersion uint32) 
 				// minversion
 				nf.Version = m.Header.Version
 				changed = append(changed, nf)
+				// set up peers since old file exists
+				nf.DeltaPeer = of
+				of.DeltaPeer = nf
 			}
 			// advance indices for both file lists since we had a match
 			nx++

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -368,7 +368,7 @@ func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, minVersion uint32) 
 	// set previous version to oldManifest version
 	m.Header.Previous = oldManifest.Header.Version
 
-	var unchanged, changed, removed, added []*File
+	var changed, removed, added []*File
 	nx := 0 // new manifest file index
 	ox := 0 // old manifest file index
 	mFilesLen := len(m.Files)
@@ -390,7 +390,6 @@ func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, minVersion uint32) 
 			if sameFile(nf, of) && of.Version >= minVersion {
 				// file did not change, set version to the old version
 				nf.Version = of.Version
-				unchanged = append(unchanged, nf)
 			} else {
 				// if the file isn't exactly the same, record the change
 				// and update the version

--- a/swupd/manifest_test.go
+++ b/swupd/manifest_test.go
@@ -379,7 +379,7 @@ func TestLinkPeersAndChange(t *testing.T) {
 
 	mNew := Manifest{
 		Files: []*File{
-			{Name: "1", Status: StatusUnset},
+			{Name: "1", Status: StatusUnset, Hash: 1},
 			{Name: "2", Status: StatusUnset},
 			{Name: "3", Status: StatusUnset},
 			{Name: "5", Status: StatusUnset, Hash: 2},
@@ -403,8 +403,8 @@ func TestLinkPeersAndChange(t *testing.T) {
 	mNew.sortFilesName()
 	mOld.sortFilesName()
 	changed, added, deleted := mNew.linkPeersAndChange(&mOld, 0)
-	if changed != 1 {
-		t.Errorf("%v files detected as changed when 1 was expected", changed)
+	if changed != 2 {
+		t.Errorf("%v files detected as changed when 2 was expected", changed)
 	}
 	if added != 3 {
 		t.Errorf("%v files detected as added when 3 were expected", added)


### PR DESCRIPTION
Delta peers are only necessary when the file name is the same, but the
contents have change. Avoid setting every identical delta peer and only
set when the files are not the same.

Also remove unused `unchanged` list in `linkPeersAndChange`