### PR TITLE
[WIP] Bundle refactor

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -561,6 +561,19 @@ func (b *Builder) getMixBundlesListFull() ([]string, error) {
 	return bundleSet.Sort(), nil
 }
 
+func (b *Builder) getDirBundleList(dir string) ([]string, error) {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to read bundles dir: %s", dir)
+	}
+
+	var bundles []string
+	for _, file := range files {
+		bundles = append(bundles, file.Name())
+	}
+	return bundles, nil
+}
+
 // AddBundles adds the specified bundles to the Mix Bundles List. Values are
 // verified as valid, and duplicate values are removed. The resulting Mix
 // Bundles List will be in sorted order.
@@ -640,6 +653,43 @@ func (b *Builder) AddBundles(bundles []string, alllocal bool, allupstream bool, 
 			return err
 		}
 	}
+	return nil
+}
+
+// ListBundles prints out the bundles in the mix, all bundles in the mix
+// including recursive includes, all bundles available in local bundles, or
+// all bundles available in upstream bundles
+func (b *Builder) ListBundles(full bool, local bool, upstream bool) error {
+	var bundles []string
+	var err error
+
+	switch {
+	case local:
+		bundles, err = b.getDirBundleList(b.Lbundledir)
+		if err != nil {
+			return errors.New("Error retreiving local bundle list")
+		}
+	case upstream:
+		bundles, err = b.getDirBundleList(b.getUpstreamBundlesPath(b.Clearver))
+		if err != nil {
+			return errors.New("Error retreiving local bundle list")
+		}
+	case full:
+		bundles, err = b.getMixBundlesListFull()
+		if err != nil {
+			return errors.New("Error retreiving mix bundle list")
+		}
+	default:
+		bundles, err = b.getMixBundlesList()
+		if err != nil {
+			return errors.New("Error retreiving mix bundle list")
+		}
+	}
+
+	for _, bundle := range bundles {
+		fmt.Println(bundle)
+	}
+
 	return nil
 }
 

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -30,7 +30,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -125,35 +124,12 @@ func GenerateCertificate(cert string, template, parent *x509.Certificate, pubkey
 func ReadFileAndSplit(filename string) ([]string, error) {
 	builder, err := ioutil.ReadFile(filename)
 	if err != nil {
-		PrintError(err)
 		return nil, err
 	}
 	data := string(builder)
 	lines := strings.Split(data, "\n")
 
 	return lines, nil
-}
-
-// GetIncludedBundles parses a bundle definition file and returns a list of all
-// bundles it includes.
-func GetIncludedBundles(filename string) ([]string, error) {
-	lines, err := ReadFileAndSplit(filename)
-	if err != nil {
-		PrintError(err)
-		return nil, err
-	}
-
-	// Note: Matches lines like "include(os-core-update)", pulling out
-	// the string between the parens. The "\" needs to be escaped due to
-	// Go's string literal parsing, so "\\(" matches "("
-	r := regexp.MustCompile("^include\\(([A-Za-z0-9-]+)\\)$")
-	var includes []string
-	for _, line := range lines {
-		if matches := r.FindStringSubmatch(line); len(matches) > 1 {
-			includes = append(includes, matches[1])
-		}
-	}
-	return includes, nil
 }
 
 // UnpackFile unpacks a .tar or .tar.gz/.tgz file to a given directory.

--- a/internal/stringset/stringset.go
+++ b/internal/stringset/stringset.go
@@ -1,0 +1,72 @@
+// Copyright © 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package stringset implements a very basic set collection of strings. Items
+// are unique, and basic set operations of addition, deletion, and existence
+// testing are supported. Additionally, supports exporting the elements as a
+// slice, optionally with the values sorted in ascending order.
+//
+// While the functionality of this package could easily be expanded, it would
+// likely soon be better to use a more full-featured, public set package.
+package stringset
+
+import (
+	"sort"
+)
+
+// Set represents a set collection of strings.
+type Set map[string]struct{}
+
+// New returns a new Set object.
+func New(values ...string) Set {
+	s := make(Set)
+	s.Add(values...)
+	return s
+}
+
+// Add adds one or more strings to the set
+func (s *Set) Add(values ...string) {
+	for _, v := range values {
+		(*s)[v] = struct{}{}
+	}
+}
+
+// Delete removes one or more strings from the set
+func (s *Set) Delete(values ...string) {
+	for _, v := range values {
+		delete(*s, v)
+	}
+}
+
+// Contains checks if the set contains a string
+func (s *Set) Contains(value string) bool {
+	_, c := (*s)[value]
+	return c
+}
+
+// Values returns the strings in the set as a slice of strings
+func (s *Set) Values() []string {
+	keys := make([]string, 0, len(*s))
+	for k := range *s {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// Sort returns the strings in the set as a sorted slice of strings
+func (s *Set) Sort() []string {
+	v := s.Values()
+	sort.Strings(v)
+	return v
+}

--- a/mixer/cmd/bundles.go
+++ b/mixer/cmd/bundles.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/clearlinux/mixer-tools/builder"
@@ -25,9 +24,9 @@ import (
 )
 
 type bundleCmdFlags struct {
-	all   bool
-	force bool
-	git   bool
+	alllocal    bool
+	allupstream bool
+	git         bool
 }
 
 var bundleFlags bundleCmdFlags
@@ -39,13 +38,13 @@ var bundleCmd = &cobra.Command{
 
 var addBundlesCmd = &cobra.Command{
 	Use:   "add [bundle(s)]",
-	Short: "Add clr-bundles to your mix",
-	Long:  `Add clr-bundles to your mix`,
+	Short: "Add local or upstream bundles to your mix",
+	Long:  `Add local or upstream bundles to your mix`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var bundles []string
-		if bundleFlags.all == false {
+		if bundleFlags.alllocal == false && bundleFlags.allupstream == false {
 			if len(args) == 0 {
-				return errors.New("bundle add requires at least 1 argument if --all is not passed")
+				return errors.New("bundle add requires at least 1 argument neither --all-local nor --all-upstream are passed")
 			}
 			bundles = strings.Split(args[0], ",")
 		}
@@ -53,8 +52,7 @@ var addBundlesCmd = &cobra.Command{
 		if err != nil {
 			fail(err)
 		}
-		numadded, err := b.AddBundles(bundles, bundleFlags.force, bundleFlags.all, bundleFlags.git)
-		fmt.Println(numadded, " bundles were added")
+		err = b.AddBundles(bundles, bundleFlags.alllocal, bundleFlags.allupstream, bundleFlags.git)
 		if err != nil {
 			fail(err)
 		}
@@ -75,7 +73,7 @@ func init() {
 
 	RootCmd.AddCommand(bundleCmd)
 
-	addBundlesCmd.Flags().BoolVar(&bundleFlags.force, "force", false, "Override bundles that already exist")
-	addBundlesCmd.Flags().BoolVar(&bundleFlags.all, "all", false, "Add all bundles from CLR; takes precedence over -bundles")
+	addBundlesCmd.Flags().BoolVar(&bundleFlags.alllocal, "all-local", false, "Add all local bundles; takes precedence over bundle list")
+	addBundlesCmd.Flags().BoolVar(&bundleFlags.allupstream, "all-upstream", false, "Add all upstream bundles; takes precedence over bundle list")
 	addBundlesCmd.Flags().BoolVar(&bundleFlags.git, "git", false, "Automatically apply new git commit")
 }

--- a/mixer/cmd/bundles.go
+++ b/mixer/cmd/bundles.go
@@ -23,26 +23,28 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type bundleCmdFlags struct {
-	alllocal    bool
-	allupstream bool
-	git         bool
-}
-
-var bundleFlags bundleCmdFlags
-
+// Top level bundle command ('mixer bundle')
 var bundleCmd = &cobra.Command{
 	Use:   "bundle",
 	Short: "Perform various actions on bundles",
 }
 
-var addBundlesCmd = &cobra.Command{
+// Bundle add command ('mixer bundle add')
+type bundleAddCmdFlags struct {
+	alllocal    bool
+	allupstream bool
+	git         bool
+}
+
+var bundleAddFlags bundleAddCmdFlags
+
+var bundleAddCmd = &cobra.Command{
 	Use:   "add [bundle(s)]",
 	Short: "Add local or upstream bundles to your mix",
 	Long:  `Add local or upstream bundles to your mix`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var bundles []string
-		if bundleFlags.alllocal == false && bundleFlags.allupstream == false {
+		if bundleAddFlags.alllocal == false && bundleAddFlags.allupstream == false {
 			if len(args) == 0 {
 				return errors.New("bundle add requires at least 1 argument neither --all-local nor --all-upstream are passed")
 			}
@@ -52,7 +54,7 @@ var addBundlesCmd = &cobra.Command{
 		if err != nil {
 			fail(err)
 		}
-		err = b.AddBundles(bundles, bundleFlags.alllocal, bundleFlags.allupstream, bundleFlags.git)
+		err = b.AddBundles(bundles, bundleAddFlags.alllocal, bundleAddFlags.allupstream, bundleAddFlags.git)
 		if err != nil {
 			fail(err)
 		}
@@ -60,9 +62,36 @@ var addBundlesCmd = &cobra.Command{
 	},
 }
 
+// Bundle list command ('mixer bundle list')
+type bundleListCmdFlags struct {
+	full     bool
+	local    bool
+	upstream bool
+}
+
+var bundleListFlags bundleListCmdFlags
+
+var bundleListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the bundles in the mix",
+	Long:  `List the bundles in the mix, local bundles, or upstream bundles`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		b, err := builder.NewFromConfig(config)
+		if err != nil {
+			fail(err)
+		}
+		err = b.ListBundles(bundleListFlags.full, bundleListFlags.local, bundleListFlags.upstream)
+		if err != nil {
+			fail(err)
+		}
+		return nil
+	},
+}
+
+// List of all bundle commands
 var bundlesCmds = []*cobra.Command{
-	addBundlesCmd,
-	// Leaving this in place because more are coming soon
+	bundleAddCmd,
+	bundleListCmd,
 }
 
 func init() {
@@ -72,8 +101,11 @@ func init() {
 	}
 
 	RootCmd.AddCommand(bundleCmd)
+	bundleAddCmd.Flags().BoolVar(&bundleAddFlags.alllocal, "all-local", false, "Add all local bundles; takes precedence over bundle list")
+	bundleAddCmd.Flags().BoolVar(&bundleAddFlags.allupstream, "all-upstream", false, "Add all upstream bundles; takes precedence over bundle list")
+	bundleAddCmd.Flags().BoolVar(&bundleAddFlags.git, "git", false, "Automatically apply new git commit")
 
-	addBundlesCmd.Flags().BoolVar(&bundleFlags.alllocal, "all-local", false, "Add all local bundles; takes precedence over bundle list")
-	addBundlesCmd.Flags().BoolVar(&bundleFlags.allupstream, "all-upstream", false, "Add all upstream bundles; takes precedence over bundle list")
-	addBundlesCmd.Flags().BoolVar(&bundleFlags.git, "git", false, "Automatically apply new git commit")
+	bundleListCmd.Flags().BoolVar(&bundleListFlags.full, "full", false, "List all bundles in the mix, recursively pulling in included bundles")
+	bundleListCmd.Flags().BoolVar(&bundleListFlags.local, "local", false, "List all available local bundles")
+	bundleListCmd.Flags().BoolVar(&bundleListFlags.upstream, "upstream", false, "List all available upstream bundles")
 }

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -85,15 +85,16 @@ var rootCmdFlags = struct {
 }{}
 
 type initCmdFlags struct {
-	all         bool
+	alllocal    bool
+	allupstream bool
 	clearver    int
 	mixver      int
+	localrpms   bool
 	upstreamurl string
+	git         bool
 }
 
 var initFlags initCmdFlags
-
-var localrpms bool
 
 var initCmd = &cobra.Command{
 	Use:   "init",
@@ -103,7 +104,7 @@ var initCmd = &cobra.Command{
 		b := builder.New()
 		if config == "" {
 			// Create default config if necessary
-			if err := b.CreateDefaultConfig(localrpms); err != nil {
+			if err := b.CreateDefaultConfig(initFlags.localrpms); err != nil {
 				fail(err)
 			}
 		}
@@ -113,7 +114,7 @@ var initCmd = &cobra.Command{
 		if err := b.ReadBuilderConf(); err != nil {
 			fail(err)
 		}
-		err := b.InitMix(strconv.Itoa(initFlags.clearver), strconv.Itoa(initFlags.mixver), initFlags.all, initFlags.upstreamurl)
+		err := b.InitMix(strconv.Itoa(initFlags.clearver), strconv.Itoa(initFlags.mixver), initFlags.alllocal, initFlags.allupstream, initFlags.upstreamurl, initFlags.git)
 		if err != nil {
 			fail(err)
 		}
@@ -139,12 +140,14 @@ func init() {
 	RootCmd.Flags().BoolVar(&rootCmdFlags.version, "version", false, "Print version information and quit")
 	RootCmd.Flags().BoolVar(&rootCmdFlags.check, "check", false, "Check all dependencies needed by mixer and quit")
 
-	initCmd.Flags().BoolVar(&initFlags.all, "all", false, "Initialize mix with all upstream bundles automatically included")
-	initCmd.Flags().BoolVar(&localrpms, "local-rpms", false, "Create and configure local RPMs directories")
+	initCmd.Flags().BoolVar(&initFlags.alllocal, "all-local", false, "Initialize mix with all local bundles automatically included")
+	initCmd.Flags().BoolVar(&initFlags.allupstream, "all-upstream", false, "Initialize mix with all upstream bundles automatically included")
 	initCmd.Flags().IntVar(&initFlags.clearver, "clear-version", 1, "Supply the Clear version to compose the mix from")
 	initCmd.Flags().IntVar(&initFlags.mixver, "mix-version", 0, "Supply the Mix version to build")
+	initCmd.Flags().BoolVar(&initFlags.localrpms, "local-rpms", false, "Create and configure local RPMs directories")
 	initCmd.Flags().StringVar(&config, "config", "", "Supply a specific builder.conf to use for mixing")
 	initCmd.Flags().StringVar(&initFlags.upstreamurl, "upstream-url", "https://download.clearlinux.org", "Supply an upstream URL to use for mixing")
+	initCmd.Flags().BoolVar(&initFlags.git, "git", false, "Track mixer's internal work dir with git")
 
 	// mark required flags
 	_ = cobra.MarkFlagRequired(initCmd.Flags(), "clear-version")


### PR DESCRIPTION
# Overview
This commit implements #55 and #57.

# Changes
## Major changes in this patch:
- Introduces the **Mix Bundles List**, a newline-separated file in the mixer working directory that lists the bundles that must be in the mix. Other bundles (included by those in the list) will be added automatically.
- Introduces the `local-bundles` directory that stores any bundles that the user created or that have been edited from upstream. Bundles in the `local-bundles` directory take precedence over upstream bundles of the same name.
- Generates the `mix-bundles` directory (used as input to the Bundle Chroot Builder) automatically on-the-fly when chroots are built. The Mix Bundles List is recursed to find all bundles needed for the mix, and the bundle definition files are copied from either the local or upstream bundles.
  - Note: Changes introduced in #102 will allow this `mix-bundles` generation to be completely eliminated. Instead, the functions used to populate this directory can be used to directly inform the new BCP code where to look for the bundles.
- Modifies the `mixer bundle add` command to now edit the Mix Bundles List. Bundles are verified to exist in either the local or upstream bundles. The user is informed whether the added bundles came from local or upstream.
- Adds a new `mixer bundle list` command that prints out the bundles in the Mix Bundle List, *all* bundles  in the mix (including those recursively included), all bundles available in local bundles, or all bundles available in upstream bundles.

## Minor changes in this patch:
- Files that generally have to do with configuration, such as the `builder.conf` and `.clearversion` file, now live inside the mixer working directory (`.mixer`) by default.
- As the `mix-bundles` directory is now created on-the-fly, it is no longer tracked as a git repository. Instead, the entire mixer working directory (`.mixer`) is tracked, with temporary, tool-generated files ignored. This allows one to track and correlate the Mix Bundle List, mix version, and upstream version as they are changed.
- The above-mentioned git revision tracking is now optional, and is only set up if `--git` is passed to `mixer init`. `mixer bundle add` still supports `--git`, which mirrors this behavior.
- The `--all` flags for `mixer init` and `mixer bundle add` have been split up into `--all-local` and `--all-upstream`. This allows a user to add or start with all local or upstream bundles, or both.
- A `mixer-tools/internal/stringset` package is added that introduces a new `stringset.Set` type. This is used throughout the Mix Bundle List code to efficiently handle bundle duplication (especially while recursing included bundles)  and list sorting.