### PR TITLE
Improve CreateFullfiles test

### DIFF
--- a/swupd/fullfiles_test.go
+++ b/swupd/fullfiles_test.go
@@ -24,19 +24,34 @@ func TestCreateFullfiles(t *testing.T) {
 	mustMkdir(t, outputDir)
 
 	files := map[string]*struct {
-		data    []byte
-		version uint32
-		hash    string
+		Contents string
+		Version  uint32
+		Mode     os.FileMode
+		IsDir    bool
+		Linkname string
+
+		ExpectedHash string
 	}{
-		"A": {data: []byte(`file1`), version: 20},
-		"B": {data: []byte(`file2`), version: 20},
-		"C": {data: []byte(`file3`), version: 20},
+		"A": {Contents: `file1`, Version: 20, Mode: 0755},
+		"B": {Contents: `file2`, Version: 20, Mode: 0644},
+		"C": {Contents: `file3`, Version: 20, Mode: 0644},
 
 		// File from previous version will not have a fullfile.
-		"D": {data: []byte(`DDD`), version: 10},
+		"D": {Contents: `DDD`, Version: 10, Mode: 0755},
 
-		// File with same content (and hash).
-		"E": {data: []byte(`file1`), version: 20},
+		// File with same content and mode (and hash).
+		"E": {Contents: `file1`, Version: 20, Mode: 0755},
+
+		// File with same content but different mode.
+		"F": {Contents: `file1`, Version: 20, Mode: 0644},
+
+		// Directories.
+		"G": {IsDir: true, Version: 20},
+		"H": {IsDir: true, Version: 10},
+
+		// Links.
+		"I": {Linkname: "A", Version: 20},
+		"J": {Linkname: "A", Version: 10},
 	}
 
 	m := &Manifest{}
@@ -44,22 +59,47 @@ func TestCreateFullfiles(t *testing.T) {
 
 	unique := make(map[Hashval]bool)
 	for name, desc := range files {
+		var typeFlag TypeFlag
 		path := filepath.Join(chrootDir, name)
-		err = ioutil.WriteFile(path, desc.data, 0644)
+		switch {
+		case desc.IsDir:
+			typeFlag = TypeDirectory
+			if desc.Mode == 0 {
+				desc.Mode = 0755
+			}
+			err = os.Mkdir(path, desc.Mode)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = os.Chmod(path, desc.Mode)
+		case desc.Linkname != "":
+			typeFlag = TypeLink
+			err = os.Symlink(desc.Linkname, path)
+		default:
+			typeFlag = TypeFile
+			if desc.Mode == 0 {
+				desc.Mode = 0644
+			}
+			err = ioutil.WriteFile(path, []byte(desc.Contents), desc.Mode)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = os.Chmod(path, desc.Mode)
+		}
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		desc.hash, err = GetHashForFile(path)
+		desc.ExpectedHash, err = GetHashForFile(path)
 		if err != nil {
 			t.Fatalf("couldn't get hashes for the test file %s: %s", path, err)
 		}
 
 		f := &File{
 			Name:    name,
-			Hash:    internHash(desc.hash),
-			Type:    TypeFile,
-			Version: desc.version,
+			Hash:    internHash(desc.ExpectedHash),
+			Type:    typeFlag,
+			Version: desc.Version,
 		}
 		if m.Header.Version == f.Version {
 			unique[f.Hash] = true
@@ -74,12 +114,10 @@ func TestCreateFullfiles(t *testing.T) {
 
 	// All correct files were created.
 	for _, desc := range files {
-		tarName := filepath.Join(outputDir, desc.hash+".tar")
-		if desc.version != m.Header.Version {
-			mustNotExist(t, tarName)
+		if desc.Version != m.Header.Version {
 			continue
 		}
-
+		tarName := filepath.Join(outputDir, desc.ExpectedHash+".tar")
 		mustExist(t, tarName)
 		mustHaveMatchingHash(t, tarName)
 	}

--- a/swupd/fullfiles_test.go
+++ b/swupd/fullfiles_test.go
@@ -1,8 +1,12 @@
 package swupd
 
 import (
+	"archive/tar"
+	"io"
 	"io/ioutil"
+	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 )
 
@@ -40,13 +44,16 @@ func TestCreateFullfiles(t *testing.T) {
 
 	unique := make(map[Hashval]bool)
 	for name, desc := range files {
-		err = ioutil.WriteFile(filepath.Join(chrootDir, name), desc.data, 0644)
+		path := filepath.Join(chrootDir, name)
+		err = ioutil.WriteFile(path, desc.data, 0644)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		// TODO: Use the proper hash function to derive this, then check the output later.
-		desc.hash = "hash" + string(desc.data)
+		desc.hash, err = GetHashForFile(path)
+		if err != nil {
+			t.Fatalf("couldn't get hashes for the test file %s: %s", path, err)
+		}
 
 		f := &File{
 			Name:    name,
@@ -65,23 +72,85 @@ func TestCreateFullfiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// All correct files were created.
 	for _, desc := range files {
 		tarName := filepath.Join(outputDir, desc.hash+".tar")
 		if desc.version != m.Header.Version {
 			mustNotExist(t, tarName)
-		} else {
-			mustExist(t, tarName)
+			continue
 		}
+
+		mustExist(t, tarName)
+		mustHaveMatchingHash(t, tarName)
 	}
 
+	// No extra files were created.
 	fis, err := ioutil.ReadDir(outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	if len(fis) != len(unique) {
 		t.Fatalf("generated %d fullfiles, but want %d", len(fis), len(unique))
 	}
+}
 
-	// TODO: Extract the tar files and retake the hash to see if it matches.
+func mustHaveMatchingHash(t *testing.T, path string) {
+	expectedHash := filepath.Base(path)
+	// Take the ".tar" extension off.
+	expectedHash = expectedHash[:len(expectedHash)-4]
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("couldn't open %s to check contents hash: %s", path, err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	tr, err := newCompressedTarReader(f)
+	if err != nil {
+		t.Fatalf("couldn't uncompress %s to check contents hash: %s", path, err)
+	}
+	defer func() {
+		_ = tr.Close()
+	}()
+
+	hdr, err := tr.Next()
+	if err != nil {
+		t.Fatalf("couldn't read archive in %s: %s", path, err)
+	}
+
+	h, err := newHashFromTarHeader(hdr)
+	if err != nil {
+		t.Fatalf("couldn't create hash struct from %s: %s", path, err)
+	}
+
+	_, err = io.Copy(h, tr)
+	if err != nil {
+		t.Fatalf("couldn't read archive %s contents: %s", path, err)
+	}
+
+	hash := h.Sum()
+	if hash != expectedHash {
+		t.Fatalf("unexpected hash %s for contents of %s", hash, path)
+	}
+}
+
+func newHashFromTarHeader(hdr *tar.Header) (*Hash, error) {
+	info := &HashFileInfo{
+		Mode:     uint32(hdr.Mode),
+		UID:      uint32(hdr.Uid),
+		GID:      uint32(hdr.Gid),
+		Size:     hdr.Size,
+		Linkname: hdr.Linkname,
+	}
+	switch hdr.Typeflag {
+	case tar.TypeReg, tar.TypeRegA:
+		info.Mode |= syscall.S_IFREG
+	case tar.TypeDir:
+		info.Mode |= syscall.S_IFDIR
+	case tar.TypeSymlink:
+		info.Mode |= syscall.S_IFLNK
+	}
+	return NewHash(info)
 }


### PR DESCRIPTION
This fixes some TODOs we had in TestCreateFullfiles test.

Add hash verification (to ensure the hash is preserved in the fullfile), add cases for directories and symlinks.