### PR TITLE
Add BAT tests for UI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,11 @@ go:
 
 go_import_path: github.com/clearlinux/mixer-tools
 
+services:
+    - docker
+
 before_install:
-    - sudo apt-get update -qq
-    - go get -u gopkg.in/alecthomas/gometalinter.v2
-    - gometalinter.v2 --install
-    - wget https://github.com/clearlinux/bsdiff/releases/download/v1.0.2/bsdiff-1.0.2.tar.xz
-    - tar -xvf bsdiff-1.0.2.tar.xz
-    - pushd bsdiff-1.0.2 && ./configure --prefix=/usr --disable-tests && make -j48 && sudo make install && popd
+    - docker build -t testdock .
 
 script:
-    - make lint
-    - make check
+    - docker run testdock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM clearlinux:latest
+
+ENV GOPATH /home/gopath
+ENV PATH="/home/gopath/bin:${PATH}"
+COPY . / /home/gopath/src/github.com/clearlinux/mixer-tools/
+RUN swupd bundle-add mixer go-basic c-basic os-core-update-dev && \
+    git config --global user.email "travis@example.com" && \
+    git config --global user.name "Travis CI" && \
+    clrtrust generate && \
+    go get -u gopkg.in/alecthomas/gometalinter.v2 && \
+    gometalinter.v2 --install
+
+ENTRYPOINT ["/bin/sh", "-c", "cd /home/gopath/src/github.com/clearlinux/mixer-tools && make && make install && make lint; make check"]
+

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 #
 # For historical purposes, it also works in a development environment
 # when the repository is already inside a GOPATH.
+include Makefile.bats
 
 .NOTPARALLEL:
 

--- a/Makefile.bats
+++ b/Makefile.bats
@@ -1,0 +1,18 @@
+SUBMAKEFILES := $(shell find bat/tests/ -name Makefile)
+DIRS2RUNMAKECHECK := $(addprefix checkdir-,${SUBMAKEFILES})
+DIRS2RUNMAKECLEAN := $(addprefix clean-,${SUBMAKEFILES})
+
+batcheck: ${DIRS2RUNMAKECHECK}
+
+${DIRS2RUNMAKECHECK}: checkdir-%:
+	$(MAKE) -C $(dir $(subst checkdir-,,$@)) check
+
+batclean: $(DIRS2RUNMAKECLEAN)
+
+${DIRS2RUNMAKECLEAN}: clean-%:
+	$(MAKE) -C $(dir $(subst clean-,,$@)) clean
+
+.PHONY: batcheck
+.PHONY: batclean
+.PHONY: ${DIRS2RUNMAKECHECK}
+.PHONY: ${DIRS2RUNMAKECLEAN}

--- a/bat/lib/mixerlib.bash
+++ b/bat/lib/mixerlib.bash
@@ -1,0 +1,75 @@
+# NOTE: source this file from a BATS test case file
+
+# This library defines functions to use in the BATS test files during a local
+# test run with 'make check'.
+
+export cachedir="$HOME/.cache/mixer-tests"
+logdir="$BATS_TEST_DIRNAME/logs"
+BUNDLE_DIR="$BATS_TEST_DIRNAME/local-bundles"
+CLRVER=$(curl https://download.clearlinux.org/latest)
+CLR_BUNDLES="$BATS_TEST_DIRNAME/upstream-bundles/clr-bundles-$CLRVER/bundles"
+BUNDLE_LIST="$BATS_TEST_DIRNAME/mixbundles"
+mkdir -p $cachedir
+mkdir -p $logdir
+
+setup_builder_conf() {
+:
+}
+
+localize_builder_conf() {
+  echo "LOCAL_RPM_DIR = $BATS_TEST_DIRNAME/local-rpms
+LOCAL_REPO_DIR = $BATS_TEST_DIRNAME/local-yum" >> $BATS_TEST_DIRNAME/builder.conf
+}
+
+mixer-init-versions() {
+  sudo -E mixer init --clear-version $1 --mix-version $2 --new-swupd
+}
+
+clean-bundle-dir() {
+  sudo rm -rf $BUNDLE_DIR/*
+  echo -e "filesystem\n" | sudo tee $BUNDLE_DIR/os-core > /dev/null
+}
+
+mixer-build-chroots() {
+  sudo -E mixer build chroots --config $BATS_TEST_DIRNAME/builder.conf --new-swupd --new-chroots
+}
+
+mixer-create-update() {
+  sudo -E mixer build update --config $BATS_TEST_DIRNAME/builder.conf --new-swupd
+}
+
+mixer-add-rpms() {
+  mkdir -p ./local ./rpms
+  sudo -E mixer add-rpms --config $BATS_TEST_DIRNAME/builder.conf --new-swupd
+}
+
+add-bundle() {
+  sudo touch $BUNDLE_DIR/$1
+}
+
+add-package() {
+  echo $1 | sudo tee -a $BUNDLE_DIR/$2 > /dev/null
+  sudo mixer bundle add $2
+}
+
+add-clear-bundle() {
+  sudo cp $CLR_BUNDLES/$1 $BUNDLE_DIR
+  sudo mixer bundle add $1
+}
+
+remove-bundle() {
+  sudo sed -i "/$1/d" $BUNDLE_LIST
+}
+
+remove-package() {
+  sudo sed -i "/$1/d" $BUNDLE_DIR/$2
+}
+
+download-rpm() {
+  mkdir -p ./rpms
+  pushd rpms
+  sudo curl -O $1
+  popd
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/bat/tests/01-create-simple-mix/Makefile
+++ b/bat/tests/01-create-simple-mix/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local ./results ./repodata ./rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/01-create-simple-mix/description.txt
+++ b/bat/tests/01-create-simple-mix/description.txt
@@ -1,0 +1,4 @@
+01-create-simple-mix
+====================
+This test case creates a mix with no custom changes, simply creating an
+initial version 10, bumping the version to 20, and creating another update.

--- a/bat/tests/01-create-simple-mix/run.bats
+++ b/bat/tests/01-create-simple-mix/run.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  setup_builder_conf
+}
+
+@test "Create initial mix 10" {
+  mixer-init-versions $CLRVER 10
+  clean-bundle-dir
+  mixer-build-chroots
+  mixer-create-update
+}
+
+@test "Create version 20 with no changes" {
+  mixer-init-versions $CLRVER 20
+  mixer-build-chroots
+  mixer-create-update > $BATS_TEST_DIRNAME/create_update20.log
+}
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/bat/tests/02-mix-clear-bundles/Makefile
+++ b/bat/tests/02-mix-clear-bundles/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local ./results ./repodata ./rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/02-mix-clear-bundles/description.txt
+++ b/bat/tests/02-mix-clear-bundles/description.txt
@@ -1,0 +1,4 @@
+02-mix-clear-bundles
+====================
+This test creates an initial version 10, a version 20 with Clear bundles
+added, and a version 30 with one of those bundles removed.

--- a/bat/tests/02-mix-clear-bundles/run.bats
+++ b/bat/tests/02-mix-clear-bundles/run.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  setup_builder_conf
+}
+
+@test "Create initial mix 10" {
+  mixer-init-versions $CLRVER 10
+  clean-bundle-dir
+  mixer-build-chroots
+  mixer-create-update > $BATS_TEST_DIRNAME/create_update-10.log
+}
+
+@test "Create version 20 with more Clear bundles" {
+  mixer-init-versions $CLRVER 20
+  add-bundle "editors"
+  add-package "joe" "editors"
+  add-bundle "os-core-update"
+  add-package "bsdiff" "os-core-update"
+  mixer-build-chroots
+  mixer-create-update > $BATS_TEST_DIRNAME/create_update-20.log
+}
+@test "Create version 30 with Clear bundle deleted" {
+  mixer-init-versions $CLRVER 30
+  remove-bundle "editors"
+  mixer-build-chroots
+  mixer-create-update > $BATS_TEST_DIRNAME/create_update-30.log
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/bat/tests/03-create-mix-with-unique-bundle/Makefile
+++ b/bat/tests/03-create-mix-with-unique-bundle/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local ./results ./repodata ./rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/03-create-mix-with-unique-bundle/description.txt
+++ b/bat/tests/03-create-mix-with-unique-bundle/description.txt
@@ -1,0 +1,4 @@
+03-create-mix-with-unique-bundle
+================================
+This test creates an initial version 10, a version 20 with a unique bundle
+that does not exist in Clear, and contains a package that is not in Clear.

--- a/bat/tests/03-create-mix-with-unique-bundle/run.bats
+++ b/bat/tests/03-create-mix-with-unique-bundle/run.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  setup_builder_conf
+}
+
+@test "Create initial mix 10" {
+  mixer-init-versions $CLRVER 10
+  clean-bundle-dir
+  mixer-build-chroots
+  mixer-create-update
+}
+
+@test "Create version 20 with unique custom bundle" {
+  localize_builder_conf
+  mixer-init-versions $CLRVER 20
+  download-rpm "ftp://rpmfind.net/linux/fedora-secondary/development/rawhide/source/SRPMS/j/json-c-0.12-7.fc24.src.rpm"
+  mixer-add-rpms
+  add-bundle "testbundle"
+  add-package "json-c" "testbundle"
+  mixer-build-chroots
+  mixer-create-update > $BATS_TEST_DIRNAME/create_update-20.log
+}
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/bat/tests/04-add-unique-package-to-clear-bundle/Makefile
+++ b/bat/tests/04-add-unique-package-to-clear-bundle/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local ./results ./repodata ./rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/04-add-unique-package-to-clear-bundle/description.txt
+++ b/bat/tests/04-add-unique-package-to-clear-bundle/description.txt
@@ -1,0 +1,4 @@
+04-add-unique-package-to-clear-bundle
+=====================================
+This test creates an initial version 10, a version 20 with a unique package
+that does not exist in Clear, and is added to an existing Clear bundle.

--- a/bat/tests/04-add-unique-package-to-clear-bundle/run.bats
+++ b/bat/tests/04-add-unique-package-to-clear-bundle/run.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  setup_builder_conf
+}
+
+@test "Create initial mix 10" {
+  mixer-init-versions $CLRVER 10
+  clean-bundle-dir
+  mixer-build-chroots
+  mixer-create-update
+}
+
+@test "Create version 20 with unique custom bundle added to os-core-update" {
+  localize_builder_conf
+  mixer-init-versions $CLRVER 20
+  download-rpm "ftp://rpmfind.net/linux/fedora-secondary/development/rawhide/source/SRPMS/j/json-c-0.12-7.fc24.src.rpm"
+  mixer-add-rpms
+  add-bundle "os-core-update"
+  add-package "bsdiff" "os-core-update"
+  add-package "json-c" "os-core-update"
+  mixer-build-chroots
+  mixer-create-update > $BATS_TEST_DIRNAME/create_update-20.log
+}
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/bat/tests/05-remove-package-from-clear-bundle/Makefile
+++ b/bat/tests/05-remove-package-from-clear-bundle/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local ./results ./repodata ./rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/05-remove-package-from-clear-bundle/description.txt
+++ b/bat/tests/05-remove-package-from-clear-bundle/description.txt
@@ -1,0 +1,4 @@
+05-remove-package-from-clear-bundle
+===================================
+This test creates a version 10, then version 20 with the Clear editors bundle
+added, and a version 30 with emacs removed from the editors bundle definition.

--- a/bat/tests/05-remove-package-from-clear-bundle/run.bats
+++ b/bat/tests/05-remove-package-from-clear-bundle/run.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  setup_builder_conf
+}
+
+@test "Create initial mix 10" {
+  mixer-init-versions $CLRVER 10
+  clean-bundle-dir
+  mixer-build-chroots
+  mixer-create-update
+}
+
+@test "Create version 20 with Clear editors bundle added" {
+  mixer-init-versions $CLRVER 20
+  add-bundle "editors"
+  add-package "joe" "editors"
+  add-package "nano" "editors"
+  mixer-build-chroots
+  mixer-create-update > $BATS_TEST_DIRNAME/create_update-20.log
+}
+
+@test "Create version 30 with nano removed from editors bundle" {
+  mixer-init-versions $CLRVER 30
+  remove-package "nano" "editors"
+  mixer-build-chroots
+  mixer-create-update > $BATS_TEST_DIRNAME/create_update-30.log
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/bat/tests/06-create-mix-with-swapped-clear-packages/Makefile
+++ b/bat/tests/06-create-mix-with-swapped-clear-packages/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local ./results ./repodata ./rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/06-create-mix-with-swapped-clear-packages/description.txt
+++ b/bat/tests/06-create-mix-with-swapped-clear-packages/description.txt
@@ -1,0 +1,4 @@
+06-create-mix-with-swapped-clear-packages
+===================================
+This test creates a version 10, then version 20 with a package swapped between
+os-core and os-core-update.

--- a/bat/tests/06-create-mix-with-swapped-clear-packages/run.bats
+++ b/bat/tests/06-create-mix-with-swapped-clear-packages/run.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  setup_builder_conf
+}
+
+@test "Create initial mix 10" {
+  mixer-init-versions $CLRVER 10
+  clean-bundle-dir
+  add-bundle "os-core-update"
+  add-package "swupd-client" "os-core-update"
+  add-package "bsdiff" "os-core-update"
+  mixer-build-chroots
+  mixer-create-update
+}
+
+@test "Create version 20 with swupd moved from os-core-update into os-core" {
+  mixer-init-versions $CLRVER 20
+  remove-package "swupd-client" "os-core-update"
+  add-package "swupd-client" "os-core"
+  mixer-build-chroots
+  mixer-create-update > $BATS_TEST_DIRNAME/create_update-20.log
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/bat/tests/07-add-clear-package-to-custom-bundle/Makefile
+++ b/bat/tests/07-add-clear-package-to-custom-bundle/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local ./results ./repodata ./rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/07-add-clear-package-to-custom-bundle/description.txt
+++ b/bat/tests/07-add-clear-package-to-custom-bundle/description.txt
@@ -1,0 +1,4 @@
+07-add-clear-package-to-custom-bundle
+====================================
+This test creates a version 10, then version 20 with a Clear package added to
+a custom bundle not included in upstream Clear.

--- a/bat/tests/07-add-clear-package-to-custom-bundle/run.bats
+++ b/bat/tests/07-add-clear-package-to-custom-bundle/run.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  setup_builder_conf
+}
+
+@test "Create initial mix 10" {
+  mixer-init-versions $CLRVER 10
+  clean-bundle-dir
+  add-bundle "os-core-update"
+  add-package "bsdiff" "os-core-update"
+  add-package "swupd" "os-core-update"
+  mixer-build-chroots
+  mixer-create-update
+}
+
+@test "Create version 20 with swupd moved from os-core-update into custom testbundle" {
+  mixer-init-versions $CLRVER 20
+  remove-package "swupd-client" "os-core-update"
+  add-bundle "testbundle"
+  add-package "swupd-client" "testbundle"
+  mixer-build-chroots
+  mixer-create-update > $BATS_TEST_DIRNAME/create_update-20.log
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/bat/tests/08-test-format-bump/Makefile
+++ b/bat/tests/08-test-format-bump/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local ./results ./repodata ./rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/08-test-format-bump/description.txt
+++ b/bat/tests/08-test-format-bump/description.txt
@@ -1,0 +1,6 @@
+11-test-format-bump
+===================
+This test simulates a format bump change by creating an initial version 10,
+a version 20 with a new bundle and package inside of-it, version 30 with
+that package deleted from the bundle, version 40 with the format bumped +1,
+then 50 and 60 updates built with new (locally cloned) swupd server code.

--- a/bat/tests/08-test-format-bump/run.bats
+++ b/bat/tests/08-test-format-bump/run.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+@test "Create initial mix 10" {
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
Add BAT tests for command-line interface testing. Use --new-swupd option to run with new integrated swupd implementation.

TODO: make them run faster pls
TODO: add `make batcheck` to .travis.yml

Collaboration between @matthewrsj @icarus-sparry and @tmarcu (mostly this guy, he originally wrote the tests)