### PR TITLE
swupd-extract: initial import

### DIFF
--- a/swupd-extract/archive.go
+++ b/swupd-extract/archive.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/bzip2"
+	"compress/gzip"
+	"fmt"
+	"io"
+
+	"github.com/clearlinux/mixer-tools/swupd"
+)
+
+// TODO: Evaluate where to put this, partially duplicate with code in packs.
+
+type compressedTarReader struct {
+	*tar.Reader
+	compressionCloser io.Closer
+}
+
+func (ctr *compressedTarReader) Close() error {
+	if ctr.compressionCloser != nil {
+		return ctr.compressionCloser.Close()
+	}
+	return nil
+}
+
+// Compression algorithms have "magic" bytes in the beginning of the file to identify them.
+var (
+	gzipMagic  = []byte{0x1F, 0x8B}
+	xzMagic    = []byte{0xFD, '7', 'z', 'X', 'Z', 0x00}
+	bzip2Magic = []byte{'B', 'Z', 'h'}
+)
+
+// newCompressedTarReader creates a struct compatible with tar.Reader reading from uncompressed or
+// compressed input.
+func newCompressedTarReader(rs io.ReadSeeker) (*compressedTarReader, error) {
+	var h [6]byte
+	_, err := rs.Read(h[:])
+	if err != nil {
+		return nil, err
+	}
+	_, err = rs.Seek(0, io.SeekStart)
+	if err != nil {
+		return nil, err
+	}
+	result := &compressedTarReader{}
+
+	switch {
+	case bytes.HasPrefix(h[:], gzipMagic):
+		gr, err := gzip.NewReader(rs)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't decompress using gzip: %s", err)
+		}
+		result.compressionCloser = gr
+		result.Reader = tar.NewReader(gr)
+	case bytes.HasPrefix(h[:], xzMagic):
+		return newTarXzReader(rs)
+	case bytes.HasPrefix(h[:], bzip2Magic):
+		br := bzip2.NewReader(rs)
+		result.Reader = tar.NewReader(br)
+	default:
+		// Assume uncompressed tar and let it complain if not valid.
+		result.Reader = tar.NewReader(rs)
+	}
+	return result, nil
+}
+
+func newTarXzReader(r io.Reader) (*compressedTarReader, error) {
+	result := &compressedTarReader{}
+	xr, err := swupd.NewExternalReader(r, "unxz")
+	if err != nil {
+		return nil, fmt.Errorf("couldn't decompress using xz: %s", err)
+	}
+	result.compressionCloser = xr
+	result.Reader = tar.NewReader(xr)
+	return result, nil
+}

--- a/swupd-extract/main.go
+++ b/swupd-extract/main.go
@@ -1,0 +1,516 @@
+package main
+
+// TODO: Flag to ignore included bundles (only extract the requested). Still need to parse
+// the included to figure out the directories metadata. Skip the packs for includes, just
+// download fullfile.
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/clearlinux/mixer-tools/swupd"
+)
+
+func usage() {
+	fmt.Printf(`swupd-extract reads a swupd update repository and write it to disk
+
+Usage:
+
+    swupd-extract https://.../version        [bundles...]
+    swupd-extract /local/path/to/.../version [bundles...]
+
+The program downloads the content of a specific version in a swupd
+repository and extract the content of the specified bundles (groups of
+content). If no bundle is specified the program will list the bundles
+available. Bundles specified will automatically trigger the extraction
+of bundles that they include.
+
+The program extracts the content to a directory called "output" or a
+directory set with the -output flag. Intermediate data is saved in a
+directory sibling to the output directory called "swupd-state" or a
+directory set with the -state flag.
+
+The state directory can hold intermediate data for multiple versions
+from the same repository.
+
+There is a shorthand for extracting content from Clear Linux. For this
+case the version can be omitted so that the latest version is used:
+
+    swupd-extract clear/20520 [bundles...]
+    swupd-extract clear       [bundles...]
+
+If not available locally, the certificate for Clear Linux is
+automatically downloaded and verified.
+
+Flags:
+`)
+	flag.PrintDefaults()
+	os.Exit(1)
+}
+
+const (
+	clearLinuxLatestURL         = "https://download.clearlinux.org/latest"
+	clearLinuxBaseContent       = "https://cdn.download.clearlinux.org/update"
+	clearLinuxCertificateURL    = "https://download.clearlinux.org/current/Swupd_Root.pem"
+	clearLinuxCertificateSHA256 = "ff06fc76ec5148040acb4fcb2bc8105cc72f1963b55de0daf3a4ed664c6fe72c"
+)
+
+func main() {
+	log.SetFlags(0)
+
+	var (
+		outputDir   string
+		stateDir    string
+		cert        string
+		noCache     bool
+		noOverwrite bool
+	)
+
+	flag.StringVar(&outputDir, "output", "output", "where to extract the files")
+	flag.StringVar(&stateDir, "state", "", "directory to store intermediate files")
+	flag.StringVar(&cert, "cert", "", "certificate used to verify content")
+	flag.BoolVar(&noCache, "no-cache", false, "don't use cached files, force downloads")
+	flag.BoolVar(&noOverwrite, "no-overwrite", false, "don't overwrite output files")
+	flag.Parse()
+
+	if os.Getuid() != 0 {
+		log.Fatal("This program needs to run as root to write files with proper permissions.")
+	}
+
+	if len(flag.Args()) == 0 {
+		usage()
+		return
+	}
+
+	// Normalize content argument to not have ending slashes.
+	content := flag.Arg(0)
+	for content[len(content)-1] == '/' {
+		content = content[:len(content)-1]
+	}
+
+	if strings.HasPrefix(content, "clear/") || strings.HasPrefix(content, "clearlinux/") {
+		parts := strings.SplitN(content, "/", 2)
+		content = clearLinuxBaseContent + "/" + parts[1]
+	} else if content == "clear" || content == "clearlinux" {
+		// Query latest version from Clear Linux.
+		res, err := http.Get(clearLinuxLatestURL)
+		if err != nil {
+			log.Fatalf("ERROR: no version passed and couldn't query latest version of Clear Linux: %s", err)
+		}
+		if res.StatusCode != http.StatusOK {
+			log.Fatalf("ERROR: no version passed and couldn't query latest version of Clear Linux: %s resulted in %d %s", clearLinuxLatestURL, res.StatusCode, http.StatusText(res.StatusCode))
+		}
+		latestBytes, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			log.Fatalf("ERROR: no version passed and couldn't query latest version of Clear Linux: %s", err)
+		}
+		content = clearLinuxBaseContent + "/" + string(bytes.TrimSpace(latestBytes))
+	}
+
+	// Extract baseContent and version information.
+	sep := strings.LastIndex(content, "/")
+	if sep == -1 {
+		log.Fatalf("Invalid URL or directory for content: %s", content)
+	}
+	baseContent, version := content[:sep], content[sep+1:]
+
+	if stateDir == "" {
+		stateDir = filepath.Join(filepath.Dir(outputDir), "swupd-state")
+	}
+
+	parsed, err := strconv.ParseUint(version, 10, 32)
+	if err != nil {
+		log.Fatalf("ERROR: invalid content URL or directory %s: last part must be the version number, but found %q instead", content, version)
+	}
+	if parsed == 0 {
+		log.Fatalf("ERROR: version must be greater than zero")
+	}
+
+	var mayDownloadClearLinuxCert bool
+	if cert == "" {
+		cert = findDefaultCert()
+		if cert == "" {
+			if baseContent != clearLinuxBaseContent {
+				log.Fatalf("ERROR: couldn't find Swupd_Root.pem in current directory and no -cert flag was passed")
+			}
+			cert = filepath.Join(stateDir, "Swupd_Root.pem")
+			mayDownloadClearLinuxCert = true
+		}
+	}
+
+	fmt.Printf(`» Parameters
+
+  Base content:     %s
+  Version:          %s
+  Use Cache:        %t
+  Certificate:      %s
+  State directory:  %s
+  Output directory: %s
+
+`, baseContent, version, !noCache, cert, stateDir, outputDir)
+
+	fmt.Printf("» Verifying state directory\n")
+	state, err := newClientState(stateDir, baseContent)
+	if err != nil {
+		log.Fatalf("ERROR: %s", err)
+	}
+	state.noCache = noCache
+
+	if mayDownloadClearLinuxCert {
+		if _, err = os.Stat(cert); err != nil {
+			if !os.IsNotExist(err) {
+				log.Fatalf("ERROR: couldn't open certificate file: %s", err)
+			}
+			tempCert := cert + ".temp"
+			err = download(clearLinuxCertificateURL, tempCert)
+			if err != nil {
+				log.Fatalf("ERROR: couldn't download Clear Linux certificate: %s", err)
+			}
+			var certBytes []byte
+			certBytes, err = ioutil.ReadFile(tempCert)
+			if err != nil {
+				_ = os.Remove(tempCert)
+				log.Fatalf("ERROR: couldn't downloaded Clear Linux certificate: %s", err)
+			}
+			tempSHA256Bytes := sha256.Sum256(certBytes)
+			tempSHA256 := hex.EncodeToString(tempSHA256Bytes[:])
+			if string(tempSHA256[:]) != clearLinuxCertificateSHA256 {
+				_ = os.Remove(tempCert)
+				log.Fatalf(`ERROR: verification of downloaded Clear Linux certificate failed:
+  got SHA256 hash %q
+     but expected %q`, tempSHA256, clearLinuxCertificateSHA256)
+			}
+			err = os.Rename(tempCert, cert)
+			if err != nil {
+				log.Fatalf("ERROR: couldn't rename downloaded certificate to its final name: %s", err)
+			}
+		}
+	}
+
+	fmt.Printf("» Reading metadata\n")
+	momFile, err := state.GetFile(version, "Manifest.MoM")
+	if err != nil {
+		log.Fatalf("ERROR: %s", err)
+	}
+	momSig, err := state.GetFile(version, "Manifest.MoM.sig")
+	if err != nil {
+		log.Fatalf("ERROR: %s", err)
+	}
+
+	err = verifySignature(momFile, momSig, cert)
+	if err != nil {
+		log.Fatalf("ERROR: couldn't verify Manifest.MoM: %s", err)
+	}
+
+	mom, err := swupd.ParseManifestFile(momFile)
+	if err != nil {
+		log.Fatalf("ERROR: %s", err)
+	}
+
+	// If not bundles passed, just show the list of available bundles.
+	if len(flag.Args()) == 1 {
+		sort.Slice(mom.Files, func(i, j int) bool {
+			return mom.Files[i].Name < mom.Files[j].Name
+		})
+		fmt.Printf("Available bundles in %s\n", content)
+		for _, f := range mom.Files {
+			fmt.Printf("  %s\n", f.Name)
+		}
+		return
+	}
+
+	requestedBundles := flag.Args()[1:]
+	bundleMap, err := resolveBundles(state, mom, requestedBundles)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("» Extracting packs\n")
+	for _, b := range bundleMap {
+		err = state.GetZeroPack(fmt.Sprint(b.Header.Version), b.Name)
+		if err != nil {
+			log.Fatalf("ERROR: couldn't get pack for %s: %s", b.Name, err)
+		}
+	}
+
+	fmt.Printf("» Copying files\n")
+	allFileMap := make(map[string]*swupd.File)
+	var allFiles []*swupd.File
+	for _, b := range bundleMap {
+		for _, f := range b.Files {
+			if f.Status == swupd.StatusDeleted || f.Status == swupd.StatusGhosted {
+				continue
+			}
+			// TODO: Should ignore files with certain f.Modifiers?
+			if _, ok := allFileMap[f.Name]; ok {
+				continue
+			}
+			allFileMap[f.Name] = f
+			allFiles = append(allFiles, f)
+		}
+	}
+
+	sort.Slice(allFiles, func(i, j int) bool {
+		return allFiles[i].Name < allFiles[j].Name
+	})
+
+	err = copyAllFiles(state, outputDir, allFiles, noOverwrite)
+	if err != nil {
+		log.Fatalf("ERROR: couldn't copy files: %s", err)
+	}
+}
+
+func resolveBundles(state *clientState, mom *swupd.Manifest, requested []string) (map[string]*swupd.Manifest, error) {
+	var includes []string
+
+	// Ignore requested duplicates.
+	sort.Strings(requested)
+	for i, name := range requested {
+		if i > 0 && requested[i-1] == name {
+			continue
+		}
+		includes = append(includes, name)
+	}
+
+	// Visit bundles and their included files. For the purposes of extracting, we
+	// don't care if there are cycles in the bundles, so don't validate that.
+	max := 0
+	bundles := make(map[string]*swupd.Manifest)
+	for len(includes) > 0 {
+		var name string
+		name, includes = includes[0], includes[1:]
+
+		// Already included.
+		if _, ok := bundles[name]; ok {
+			continue
+		}
+
+		if max < len(name) {
+			max = len(name)
+		}
+
+		var bundleFile *swupd.File
+		for _, f := range mom.Files {
+			if f.Name == name {
+				bundleFile = f
+				break
+			}
+		}
+		if bundleFile == nil {
+			return nil, fmt.Errorf("bundle %s not found in Manifest.MoM", name)
+		}
+
+		m, err := state.GetBundleManifest(fmt.Sprint(bundleFile.Version), name, bundleFile.Hash.String())
+		if err != nil {
+			return nil, err
+		}
+
+		for _, inc := range m.Header.Includes {
+			includes = append(includes, inc.Name)
+		}
+		bundles[name] = m
+	}
+
+	fmt.Println()
+	for name, b := range bundles {
+		fmt.Printf("  %-*s %d\n", max, name, b.Header.Version)
+	}
+	fmt.Println()
+
+	return bundles, nil
+}
+
+func copyAllFiles(state *clientState, outputDir string, allFiles []*swupd.File, noOverwrite bool) error {
+	err := os.MkdirAll(outputDir, 0755)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range allFiles {
+		src := state.Path("staged/", f.Hash.String())
+		dst := filepath.Join(outputDir, f.Name)
+
+		// Check if we have the source file, if not download it.
+		srcFI, err := os.Lstat(src)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("couldn't access existing staged file %s for %s: %s", src, dst, err)
+			}
+			err = state.GetFullfile(fmt.Sprint(f.Version), f.Hash.String())
+			if err != nil {
+				return fmt.Errorf("couldn't download fullfile for %s with hash %s: %s", dst, f.Hash.String(), err)
+			}
+			srcFI, err = os.Lstat(src)
+			if err != nil {
+				return fmt.Errorf("couldn't access staged file for %s: %s", dst, err)
+			}
+		}
+
+		// Check if destination file is already what we want.
+		dstFI, err := os.Lstat(dst)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("couldn't access existing file %s: %s", dst, err)
+		}
+		if err == nil {
+			var hash string
+			hash, err = swupd.GetHashForFile(dst)
+			if err != nil {
+				return err
+			}
+			if hash == f.Hash.String() {
+				continue
+			}
+
+			// Try to fix the permissions of directory, to avoid destroying
+			// its contents if not necessary.
+			if srcFI.IsDir() && dstFI.IsDir() {
+				if srcFI.Mode() != dstFI.Mode() {
+					fmt.Printf("! fixing mode for %s from %s to %s\n", dst, dstFI.Mode(), srcFI.Mode())
+					err = os.Chmod(dst, srcFI.Mode())
+					if err != nil {
+						return fmt.Errorf("couldn't fix mode for existing file %s: %s", dst, err)
+					}
+				}
+				srcStat := srcFI.Sys().(*syscall.Stat_t)
+				dstStat := dstFI.Sys().(*syscall.Stat_t)
+				if srcStat.Uid != dstStat.Uid || srcStat.Gid != dstStat.Gid {
+					fmt.Printf("! fixing ownership for %s from %d:%d to %d:%d\n", dst, dstStat.Uid, dstStat.Gid, srcStat.Uid, srcStat.Gid)
+					err = os.Chown(dst, int(srcStat.Uid), int(srcStat.Gid))
+					if err != nil {
+						return fmt.Errorf("couldn't fix ownership of existing file %s: %s", dst, err)
+					}
+				}
+				continue
+			}
+
+			if noOverwrite {
+				fmt.Printf("! skipping %s\n", dst)
+				continue
+			}
+
+			fmt.Printf("! overwriting %s\n", dst)
+			err = os.RemoveAll(dst)
+			if err != nil {
+				return fmt.Errorf("couldn't remove %s for overwriting: %s", dst, err)
+			}
+		}
+
+		switch f.Type {
+		case swupd.TypeFile:
+			err = copyFile(dst, src, srcFI)
+		case swupd.TypeDirectory:
+			err = os.Mkdir(dst, srcFI.Mode())
+			if err != nil {
+				return err
+			}
+			err = os.Chmod(dst, srcFI.Mode())
+		case swupd.TypeLink:
+			var linkname string
+			linkname, err = os.Readlink(src)
+			if err != nil {
+				return err
+			}
+			err = os.Symlink(linkname, dst)
+		default:
+			err = fmt.Errorf("unknown type for %s", f.Name)
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func copyFile(dst string, src string, srcFI os.FileInfo) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+
+	dstFile, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, srcFI.Mode())
+	if err != nil {
+		_ = srcFile.Close()
+		return err
+	}
+
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		_ = srcFile.Close()
+		_ = dstFile.Close()
+		return fmt.Errorf("failure to copy data from %s to %s: %s", src, dst, err)
+	}
+	err = srcFile.Close()
+	if err != nil {
+		_ = dstFile.Close()
+		return err
+	}
+
+	srcStat := srcFI.Sys().(*syscall.Stat_t)
+	err = dstFile.Chown(int(srcStat.Uid), int(srcStat.Gid))
+	if err != nil {
+		_ = dstFile.Close()
+		return err
+	}
+	if srcFI.Mode()&(os.ModeSticky|os.ModeSetgid|os.ModeSetuid) != 0 {
+		err = dstFile.Chmod(srcFI.Mode())
+		if err != nil {
+			_ = dstFile.Close()
+			return err
+		}
+	}
+	return dstFile.Close()
+}
+
+func verifySignature(content, sig, cert string) error {
+	cmd := exec.Command(
+		"openssl", "smime", "-verify",
+		"-in", sig,
+		"-inform", "der",
+		"-content", content,
+		"-CAfile", cert,
+		"-purpose", "crlsign",
+	)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("%s\nsignature verification failed: %s\nCOMMAND LINE: %s", buf.Bytes(), err, strings.Join(cmd.Args, " "))
+	}
+	return nil
+}
+
+func findDefaultCert() string {
+	certInCurrentDir, err := filepath.Abs("Swupd_Root.pem")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defaultCerts := []string{
+		certInCurrentDir,
+		"/usr/share/clear/update-ca/Swupd_Root.pem",
+	}
+
+	for _, cert := range defaultCerts {
+		if _, err := os.Stat(cert); err == nil {
+			return cert
+		}
+	}
+
+	return ""
+}

--- a/swupd-extract/state.go
+++ b/swupd-extract/state.go
@@ -1,0 +1,364 @@
+package main
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/clearlinux/mixer-tools/swupd"
+)
+
+type clientState struct {
+	dir string
+
+	noCache     bool
+	baseContent string
+	isRemote    bool
+}
+
+func newClientState(stateDir, baseContent string) (*clientState, error) {
+	contentFilename := filepath.Join(stateDir, "content")
+	stateContent, err := ioutil.ReadFile(contentFilename)
+	if err == nil {
+		if string(stateContent) != baseContent {
+			fmt.Printf("- Resetting state in %s previously used for %q\n", stateDir, stateContent)
+			// Delete files individually in case stateDir is managed by the user.
+			var fis []os.FileInfo
+			fis, err = ioutil.ReadDir(stateDir)
+			if err != nil {
+				return nil, fmt.Errorf("couldn't reset state directory: %s", err)
+			}
+			for _, fi := range fis {
+				err = os.RemoveAll(filepath.Join(stateDir, fi.Name()))
+				if err != nil {
+					return nil, fmt.Errorf("couldn't reset state directory: %s", err)
+				}
+			}
+		}
+	}
+	err = os.MkdirAll(filepath.Join(stateDir, "staged/temp"), 0755)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create state directory: %s", err)
+	}
+	err = ioutil.WriteFile(contentFilename, []byte(baseContent), 0644)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't write %s: %s", contentFilename, err)
+	}
+
+	var isRemote bool
+	if strings.HasPrefix(baseContent, "https://") || strings.HasPrefix(baseContent, "http://") {
+		isRemote = true
+	}
+
+	cs := &clientState{
+		dir:         stateDir,
+		baseContent: baseContent,
+		isRemote:    isRemote,
+	}
+
+	return cs, nil
+}
+
+func (cs *clientState) OpenFile(elem ...string) (io.ReadCloser, error) {
+	joined := filepath.Join(elem...)
+	if !cs.isRemote {
+		return os.Open(filepath.Join(cs.baseContent, joined))
+	}
+
+	u := cs.baseContent + "/" + joined
+	fmt.Printf("- downloading %s\n", u)
+	res, err := http.Get(u)
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != http.StatusOK {
+		_ = res.Body.Close()
+		return nil, fmt.Errorf("couldn't download %q: got response with code: %d %s", u, res.StatusCode, http.StatusText(res.StatusCode))
+	}
+	return res.Body, nil
+}
+
+func (cs *clientState) GetFile(elem ...string) (string, error) {
+	joined := filepath.Join(elem...)
+	if !cs.isRemote {
+		return filepath.Join(cs.baseContent, joined), nil
+	}
+	localFile := filepath.Join(cs.dir, joined)
+	if _, err := os.Stat(localFile); err == nil {
+		if !cs.noCache {
+			return localFile, nil
+		}
+		err = os.RemoveAll(localFile)
+		if err != nil {
+			return "", fmt.Errorf("couldn't remove %s to redownload: %s", localFile, err)
+		}
+	}
+	err := os.MkdirAll(filepath.Dir(localFile), 0755)
+	if err != nil {
+		return "", err
+	}
+	err = download(cs.baseContent+"/"+joined, localFile)
+	if err != nil {
+		return "", err
+	}
+	return localFile, nil
+}
+
+func (cs *clientState) Path(elem ...string) string {
+	return filepath.Join(cs.dir, filepath.Join(elem...))
+}
+
+func (cs *clientState) GetBundleManifest(version, name, expectedHash string) (*swupd.Manifest, error) {
+	if name == "MoM" {
+		return nil, fmt.Errorf("invalid arguments to GetBundleManifest: MoM is not a bundle")
+	}
+	filename, err := cs.GetFile(version, "Manifest."+name)
+	if err != nil {
+		return nil, err
+	}
+	hash, err := swupd.GetHashForFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't calculate hash for %s: %s", filename, err)
+	}
+	if hash != expectedHash {
+		return nil, fmt.Errorf("hash mismatch in %s got %s but expected %s", filename, hash, expectedHash)
+	}
+	m, err := swupd.ParseManifestFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't parse bundle manifest file %s: %s", filename, err)
+	}
+	return m, nil
+}
+
+func (cs *clientState) GetFullfile(version, hash string) error {
+	tarredFilename, err := cs.GetFile(version, "files", hash+".tar")
+	if err != nil {
+		return err
+	}
+	tarred, err := os.Open(tarredFilename)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tarred.Close()
+	}()
+
+	tr, err := newCompressedTarReader(tarred)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tr.Close()
+	}()
+
+	hdr, err := tr.Next()
+	if err != nil {
+		return err
+	}
+	err = cs.extractFullfile(hdr, tr)
+	if err != nil {
+		return err
+	}
+
+	hdr, err = tr.Next()
+	if err == nil {
+		fmt.Printf("! ignoring unexpected extra content in %s: %s\n", tarredFilename, hdr.Name)
+	}
+
+	return nil
+}
+
+func (cs *clientState) GetZeroPack(version, name string) error {
+	cachedName := cs.Path(fmt.Sprintf("pack-%s-from-0-to-%s.tar", name, version))
+	if !cs.noCache {
+		if _, err := os.Stat(cachedName); err == nil {
+			return nil
+		}
+	}
+
+	pack, err := cs.OpenFile(version, fmt.Sprintf("pack-%s-from-0.tar", name))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = pack.Close()
+	}()
+
+	tr, err := newTarXzReader(pack)
+	if err != nil {
+		return err
+	}
+	for {
+		var hdr *tar.Header
+		hdr, err = tr.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return fmt.Errorf("invalid pack for %s", name)
+		}
+		if !strings.HasPrefix(hdr.Name, "staged/") || hdr.Name == "staged/" {
+			continue
+		}
+		err = cs.extractFullfile(hdr, tr)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = tr.Close()
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(cachedName, nil, 0600)
+}
+
+func download(u, path string) (err error) {
+	tempPath := path + ".downloading"
+	f, err := os.OpenFile(tempPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("couldn't open temporary file to write downloaded contents: %s", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tempPath)
+		}
+	}()
+	fmt.Printf("- downloading %s\n", u)
+	res, err := http.Get(u)
+	if err != nil {
+		_ = f.Close()
+		return err
+	}
+	defer func() {
+		_ = res.Body.Close()
+	}()
+	if res.StatusCode != http.StatusOK {
+		_ = f.Close()
+		return fmt.Errorf("couldn't download %q: got response with code: %d %s", u, res.StatusCode, http.StatusText(res.StatusCode))
+	}
+	_, err = io.Copy(f, res.Body)
+	if err != nil {
+		_ = f.Close()
+		return fmt.Errorf("couldn't download %q: %s", u, err)
+	}
+
+	err = f.Close()
+	if err != nil {
+		return err
+	}
+	return os.Rename(tempPath, path)
+}
+
+func (cs *clientState) extractFullfile(hdr *tar.Header, r io.Reader) error {
+	basename := filepath.Base(hdr.Name)
+	filename := cs.Path("staged", basename)
+
+	// First check if file already exists.
+	_, err := os.Lstat(filename)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("couldn't access existing file %s: %s", filename, err)
+	}
+
+	// File exists, check the hash.
+	if err == nil {
+		hash, herr := swupd.GetHashForFile(filename)
+		if herr == nil && hash == basename {
+			if !cs.noCache {
+				// No work needed!
+				return nil
+			}
+		} else if herr != nil {
+			fmt.Printf("! couldn't calculate hash for existing file %s, removing to extract it again\n", filename)
+		} else {
+			fmt.Printf("! existing file %s has invalid hash %s, removing to extract it again\n", filename, hash)
+		}
+		err = os.Remove(filename)
+		if err != nil {
+			return fmt.Errorf("couldn't remove file for extracting new one: %s", err)
+		}
+	}
+
+	// Write to a temporary filename.
+	tempFilename := cs.Path("staged/temp", basename)
+
+	switch hdr.Typeflag {
+	case tar.TypeReg:
+		mode := hdr.FileInfo().Mode()
+		var f *os.File
+		f, err = os.OpenFile(tempFilename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode)
+		if err != nil {
+			return fmt.Errorf("couldn't create temporary file: %s", err)
+		}
+		_, err = io.Copy(f, r)
+		if err != nil {
+			_ = f.Close()
+			return fmt.Errorf("couldn't extract data to temporary file %s: %s", tempFilename, err)
+		}
+		err = f.Chown(hdr.Uid, hdr.Gid)
+		if err != nil {
+			_ = f.Close()
+			return fmt.Errorf("couldn't change ownership of temporary file: %s", err)
+		}
+		if mode&(os.ModeSticky|os.ModeSetgid|os.ModeSetuid) != 0 {
+			err = f.Chmod(mode)
+			if err != nil {
+				_ = f.Close()
+				return fmt.Errorf("couldn't change mode of temporary file: %s", err)
+			}
+		}
+		err = f.Close()
+		if err != nil {
+			return fmt.Errorf("couldn't close temporary file: %s", err)
+		}
+
+	case tar.TypeSymlink:
+		err = os.Remove(tempFilename)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("couldn't remove previous temporary file: %s", err)
+		}
+		err = os.Symlink(hdr.Linkname, tempFilename)
+		if err != nil {
+			return fmt.Errorf("couldn't create temporary file: %s", err)
+		}
+
+	case tar.TypeDir:
+		err = os.Remove(tempFilename)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("couldn't remove previous temporary file: %s", err)
+		}
+		err = os.Mkdir(tempFilename, hdr.FileInfo().Mode())
+		if err != nil {
+			return fmt.Errorf("couldn't create temporary file: %s", err)
+		}
+		err = os.Chown(tempFilename, hdr.Uid, hdr.Gid)
+		if err != nil {
+			return fmt.Errorf("couldn't change ownership of temporary file: %s", err)
+		}
+		err = os.Chmod(tempFilename, hdr.FileInfo().Mode())
+		if err != nil {
+			return fmt.Errorf("couldn't change mode of temporary file: %s", err)
+		}
+
+	default:
+		return fmt.Errorf("unsupported type %c in fullfile %s", hdr.Typeflag, basename)
+	}
+
+	// Now validate the file.
+	hash, err := swupd.GetHashForFile(tempFilename)
+	if err != nil {
+		return err
+	}
+
+	if hash != basename {
+		return fmt.Errorf("staged file %s has invalid hash %s", filename, hash)
+	}
+
+	return os.Rename(tempFilename, filename)
+}


### PR DESCRIPTION
swupd-extract is a program that reads a swupd update repository and
extracts the files for bundles of a specific version. It does a
similar job as "swupd verify --install --no-scripts --no-boot-update".

There is code for maintaining the client state, but at the moment it
only care about zero packs. Verification of the Manifest.MoM signature
is done using "openssl" external program.

It has some niceties when we are extracting Clear Linux content

    // List the latest clear linux bundles.
    $ sudo swupd-extract clear

    // Extracts os-core into "output/" directory.
    $ sudo swupd-extract clear os-core

    // Extracts editors and all its included bundles into mydir.
    $ sudo swupd-extract --output mydir clear/20540 editors

but instead of clear, a proper URL with version can be used instead,
i.e. it is easy to use it to extract mixes content. It also works fine
with local paths. The included help enumerates the rest of the features.

There is some duplicate code for compressedTarReader which I intend to
make into an internal package further on (as well as consolidating
other related archive code).

The main motivation was to allow users of distros other than Clear
Linux to use mkosi to generate Clear Linux images, but the program can
also be useful for validation.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>