### PR TITLE
WIP: Using deltas in the packs

### DIFF
--- a/swupd/delta.go
+++ b/swupd/delta.go
@@ -10,10 +10,31 @@ import (
 	"github.com/pkg/errors"
 )
 
-// CreateDeltas creates all delta files between the previous and current
-// version of the supplied manifest, returning a list of files that
-// delta creation failed for.
-func CreateDeltas(manifest, statedir string, from, to uint32) ([]*File, error) {
+const (
+	// From swupd-server's include/swupd.h:
+	//
+	//     Approximately the smallest size of a pair of input files which differ by a
+	//     single bit that bsdiff can produce a more compact deltafile. Files smaller
+	//     than this are always marked as different. See the magic 200 value in the
+	//     bsdiff/src/diff.c code.
+	//
+	minimumSizeToMakeDeltaInBytes = 200
+)
+
+// Delta represents a delta file between two other files. If Error is present, it
+// indicates that the delta couldn't be created.
+type Delta struct {
+	Path  string
+	Error error
+	from  *File
+	to    *File
+}
+
+// CreateDeltas creates all delta files between the previous and current version of the
+// supplied manifest. Returns a list of deltas (which contains information about
+// individual delta errors). Returns error (and no deltas) if it can't assemble the delta
+// list.
+func CreateDeltas(manifest, statedir string, from, to uint32) ([]Delta, error) {
 	var c config
 
 	c, err := getConfig(statedir)
@@ -31,149 +52,101 @@ func CreateDeltas(manifest, statedir string, from, to uint32) ([]*File, error) {
 		return nil, err
 	}
 
-	// Must be sorted before passing into linkPeersAndChange()
-	oldManifest.sortFilesName()
-	newManifest.sortFilesName()
+	return createDeltasFromManifests(&c, oldManifest, newManifest)
+}
 
-	_, _, _ = newManifest.linkPeersAndChange(oldManifest, from)
-
-	deltas, err := consolidateDeltaFiles(newManifest, from, c)
+func createDeltasFromManifests(c *config, oldManifest, newManifest *Manifest) ([]Delta, error) {
+	deltas, err := findDeltas(c, oldManifest, newManifest)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to create deltas list %s", manifest)
+		return nil, errors.Wrapf(err, "Failed to create deltas list %s", newManifest.Name)
 	}
 
 	const maxRoutines = 3
-	var deltaQueue = make(chan *File)
-	var failedChan = make(chan *File)
-	var failedList = make(chan []*File)
+	var deltaQueue = make(chan *Delta)
 	var wg sync.WaitGroup
 	wg.Add(maxRoutines)
 
-	// Start a collector for the failure cases
-	go func() {
-		var failed []*File
-		// Drains the failedChan appropriately
-		for f := range failedChan {
-			failed = append(failed, f)
-		}
-		failedList <- failed // This list is what we return in the end
-	}()
-
 	// Don't flood the system with goroutines, delta creation takes up an
-	// incredibly amount of memory, so we cannot max out on goroutines
+	// incredibly amount of memory, so we cannot max out on goroutines.
 	for i := 0; i < maxRoutines; i++ {
-		go func(statedir string) {
+		go func() {
 			defer wg.Done()
-
-			// Take in jobs from the queue and try to make a delta
-			for f := range deltaQueue {
-				err := createDelta(c, f, statedir, f.DeltaPeer.Version, f.DeltaPeer.Hash)
-				if err != nil {
-					failedChan <- f
-				}
+			for delta := range deltaQueue {
+				delta.Error = createDelta(c, delta)
 			}
-		}(statedir)
+		}()
 	}
 
-	// Send jobs to the queue for delta goroutines to pick up
-	for _, file := range deltas {
-		deltaQueue <- file
+	// Send jobs to the queue for delta goroutines to pick up.
+	for i := range deltas {
+		deltaQueue <- &deltas[i]
 	}
 
 	// Send message that no more jobs are being sent
 	close(deltaQueue)
 	wg.Wait()
 
-	// Once wait finishes we can signal the collector that no more jobs exist
-	close(failedChan)
-
-	return <-failedList, nil
+	return deltas, nil
 }
 
-func consolidateDeltaFiles(manifest *Manifest, from uint32, c config) ([]*File, error) {
-	var files []*File
+func createDelta(c *config, delta *Delta) error {
+	oldPath := filepath.Join(c.imageBase, fmt.Sprint(delta.from.Version), "full", delta.from.Name)
+	newPath := filepath.Join(c.imageBase, fmt.Sprint(delta.to.Version), "full", delta.to.Name)
+	deltaDir := filepath.Join(c.outputDir, fmt.Sprint(delta.to.Version), "delta")
+	deltaName := fmt.Sprintf("%d-%d-%s-%s", delta.from.Version, delta.to.Version, delta.from.Hash, delta.to.Hash)
+	delta.Path = filepath.Join(deltaDir, deltaName)
 
-	if manifest == nil {
-		return nil, nil
+	if err := helpers.RunCommandSilent("bsdiff", oldPath, newPath, delta.Path); err != nil {
+		_ = os.Remove(delta.Path) // Might have returned FULLDL
+		return errors.Wrapf(err, "Failed to create delta for %s -> %s", oldPath, newPath)
 	}
 
-	for _, file := range manifest.Files {
-		if file.Version <= from {
-			continue
-		}
-		if file.DeltaPeer == nil {
-			continue
-		}
-		if file.Type != TypeFile ||
-			file.DeltaPeer.Type != TypeFile {
-			continue
-		}
-
-		deltadir := filepath.Join(c.outputDir, fmt.Sprintf("%d", file.Version), "delta")
-		fromToString := fmt.Sprintf("%d-%d-%s-%s", file.DeltaPeer.Version, file.Version, file.DeltaPeer.Hash, file.Hash)
-
-		deltaFile := filepath.Join(deltadir, fromToString)
-
-		// Only add to list if the delta file does not already exist on the system
-		if _, err := os.Stat(deltaFile); os.IsNotExist(err) {
-			// Only create deltas for files bigger than 200 bytes
-			fullname := filepath.Join(c.imageBase, fmt.Sprintf("%d", file.Version), "full", file.Name)
-			file.Info, _ = os.Stat(fullname)
-			if file.Info.Size() > 200 {
-				files = append(files, file)
-			}
-		}
-
+	// Check that the delta actually applies correctly.
+	testPath := filepath.Join(deltaDir, "."+deltaName+".testnewfile")
+	if err := helpers.RunCommandSilent("bspatch", oldPath, testPath, delta.Path); err != nil {
+		return errors.Wrapf(err, "Failed to apply delta %s", delta.Path)
 	}
+	defer func() {
+		_ = os.Remove(testPath)
+	}()
 
-	return files, nil
-}
-
-func createDelta(c config, file *File, statedir string, fromVersion uint32, fromHash Hashval) error {
-	// File without peers cannot have deltas
-	if file.DeltaPeer == nil {
-		return nil
-	}
-
-	// We only support deltas between two regular files for now
-	// TODO: Support directory -> file in the future, this is a complex case
-	if file.Type != TypeFile || file.DeltaPeer.Type != TypeFile {
-		return nil
-	}
-
-	newfile := filepath.Join(c.imageBase, fmt.Sprintf("%d", file.Version), "full", file.Name)
-	original := filepath.Join(c.imageBase, fmt.Sprintf("%d", fromVersion), "full", file.Name)
-
-	deltadir := filepath.Join(c.outputDir, fmt.Sprintf("%d", file.Version), "delta")
-	fromToString := fmt.Sprintf("%d-%d-%s-%s", fromVersion, file.Version, fromHash, file.Hash)
-
-	// Files to create and validate deltas with
-	deltafile := filepath.Join(deltadir, fromToString)
-	testnewfile := filepath.Join(deltadir, "."+fromToString+".testnewfile")
-
-	// Shell out to bsdiff for now...false = don't print to screen
-	if err := helpers.RunCommandSilent("bsdiff", original, newfile, deltafile); err != nil {
-		_ = os.Remove(deltafile) // Might have returned FULLDL
-		return errors.Wrapf(err, "Failed to create delta for %s -> %s", original, newfile)
-	}
-
-	// Check that the delta actually applies correctly
-	if err := helpers.RunCommandSilent("bspatch", original, testnewfile, deltafile); err != nil {
-		return errors.Wrapf(err, "Failed to apply delta %s", deltafile)
-	}
-
-	deltahash, err := Hashcalc(testnewfile)
+	testHash, err := Hashcalc(testPath)
 	if err != nil {
-		return errors.Wrap(err, "Failed to calculate hash for new file")
+		return errors.Wrap(err, "Failed to calculate hash for test file created applying delta")
 	}
-
-	if !HashEquals(deltahash, file.Hash) {
-		return errors.Wrapf(err, "Delta mismatch: %s -> %s via delta: %s", original, newfile, deltafile)
+	if testHash != delta.to.Hash {
+		return errors.Wrapf(err, "Delta mismatch: %s -> %s via delta: %s", oldPath, newPath, delta.Path)
 	}
-
-	_ = os.Remove(testnewfile)
-
-	// add rename code here
 
 	return nil
+}
+
+func findDeltas(c *config, oldManifest, newManifest *Manifest) ([]Delta, error) {
+	oldManifest.sortFilesName()
+	newManifest.sortFilesName()
+
+	err := linkDeltaPeers(c, oldManifest, newManifest)
+	if err != nil {
+		return nil, err
+	}
+
+	deltaCount := 0
+	for _, nf := range newManifest.Files {
+		if nf.DeltaPeer != nil {
+			deltaCount++
+		}
+	}
+
+	deltas := make([]Delta, 0, deltaCount)
+	for _, nf := range newManifest.Files {
+		if nf.DeltaPeer == nil {
+			continue
+		}
+		deltas = append(deltas, Delta{
+			from: nf.DeltaPeer,
+			to:   nf,
+		})
+	}
+
+	return deltas, nil
 }

--- a/swupd/delta_test.go
+++ b/swupd/delta_test.go
@@ -21,6 +21,6 @@ func TestCreateDeltas(t *testing.T) {
 	mustCreateManifestsStandard(t, 20, testDir)
 	mustMkdir(t, filepath.Join(testDir, "www/20/delta"))
 
-	mustCreateDeltas(t, "Manifest.full", testDir, 10, 20)
+	mustCreateAllDeltas(t, "Manifest.full", testDir, 10, 20)
 	mustExistDelta(t, testDir, "/bar", 10, 20)
 }


### PR DESCRIPTION
DO NOT MERGE.

This is on top of PR #116, so just look at the last commit. Pushed PR to show the direction I'm taking with the delta integration:

- Create a function to find the deltas, it contains logic that was in linkPeersAndChange and consolidateDeltaFiles. I think that this led to a clearer logic, but has problems (see below).

- I'm experimenting with returning a list, basically because I wanted to see how it would work. This still can be done with putting things on DeltaPeers, but I've felt this was a bit cleaner, because with a Delta struct I have a place to put the error that delta had as well as cache the full path to the delta. Tradeoffs.

- In theory packing already works and there's even a test. But we need to put more test cases.

The problem I have: I don't know where Rename logic will hook up, and whether it will be compatible with the direction I'm taking.

@icarus-sparry what's the approach you are taking to return the result of the rename logic, is it by mutating the existing Files in the Manifests being evaluated, or by building up a separate list?