### PR TITLE
mixer: accept --packager flag when building chroots

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -511,7 +511,7 @@ func (b *Builder) UpdateMixVer() error {
 // BuildChroots will attempt to construct the chroots required by populating roots
 // using the m4 bundle configurations in conjunction with the YUM configuration file,
 // installing all required named packages into the roots.
-func (b *Builder) BuildChroots(template *x509.Certificate, privkey *rsa.PrivateKey, signflag bool) error {
+func (b *Builder) BuildChroots(template *x509.Certificate, privkey *rsa.PrivateKey, packager string, signflag bool) error {
 	// Generate the yum config file if it does not exist.
 	// This takes the template and adds the relevant local rpm repo path if needed
 	fmt.Println("Building chroots..")
@@ -581,7 +581,7 @@ func (b *Builder) BuildChroots(template *x509.Certificate, privkey *rsa.PrivateK
 			return err
 		}
 		// TODO: Merge the rest of this function into buildBundleChroots (or vice-versa).
-		err = b.buildBundleChroots(set)
+		err = b.buildBundleChroots(set, packager)
 		if err != nil {
 			return err
 		}
@@ -598,6 +598,9 @@ func (b *Builder) BuildChroots(template *x509.Certificate, privkey *rsa.PrivateK
 		}
 
 	} else {
+		if packager != "" {
+			fmt.Println("WARNING: Ignoring flag --packager, just works with --new-chroots.")
+		}
 		// If this is a mix, we need to build with the Clear version, but publish the mix version
 		chrootcmd := exec.Command(b.Buildscript, "-c", b.Buildconf, "-m", b.Mixver, b.Clearver)
 		chrootcmd.Stdout = os.Stdout


### PR DESCRIPTION
This lets override the default choice of packager for performing build
chroots. Makes easy to test dnf with --packager=dnf. The flag is
ignored when not using --new-chroots.
    
Also prints the actual command line being used.
