### PR TITLE
** DO NOT MERGE ** : Use Viper to parse config file

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -26,13 +26,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/clearlinux/mixer-tools/helpers"
 	"github.com/clearlinux/mixer-tools/swupd"
 	"github.com/pkg/errors"
+	"github.com/spf13/viper"
 )
 
 // Version of Mixer. Also used by the Makefile for releases.
@@ -87,16 +87,47 @@ func NewFromConfig(conf string) (*Builder, error) {
 	if err := b.LoadBuilderConf(conf); err != nil {
 		return nil, err
 	}
-	if err := b.ReadBuilderConf(); err != nil {
-		return nil, err
-	}
 	if err := b.ReadVersions(); err != nil {
 		return nil, err
 	}
 	return b, nil
 }
 
-// CreateDefaultConfig creates a default builder.conf using the active
+// LoadDefaults set default values for the properties in builder.toml
+func (b *Builder) LoadDefaults() error {
+	pwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	viper.SetDefault("Builder.SERVER_STATE_DIR", filepath.Join(pwd, "update"))
+	viper.SetDefault("Builder.BUNDLE_DIR", filepath.Join(pwd, "mix-bundles"))
+	viper.SetDefault("Builder.YUM_CONF", filepath.Join(pwd, ".yum-mix.conf"))
+	viper.SetDefault("Builder.CERT", filepath.Join(pwd, "Swupd_Root.pem"))
+	viper.SetDefault("Builder.VERSIONS_PATH", pwd)
+
+	viper.SetDefault("swupd.BUNDLE", "os-core-update")
+	viper.SetDefault("swupd.CONTENTURL", "<URL where the content will be hosted>")
+	viper.SetDefault("swupd.VERSIONURL", "<URL where the version of the mix will be hosted>")
+	viper.SetDefault("swupd.FORMAT", "1")
+
+	viper.SetDefault("Server.debuginfo_banned", "true")
+	viper.SetDefault("Server.debuginfo_lib", "/usr/lib/debug")
+	viper.SetDefault("Server.debuginfo_src", "/usr/src/debug")
+
+	viper.SetDefault("Mixer.RPMDIR", "")
+	viper.SetDefault("Mixer.REPODIR", "")
+
+	viper.SetConfigName("builder")
+	viper.AddConfigPath(pwd)
+
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
+
+	return nil
+}
+
+// CreateDefaultConfig creates a default builder.toml using the active
 // directory as base path for the variables values.
 func (b *Builder) CreateDefaultConfig(localrpms bool) error {
 	pwd, err := os.Getwd()
@@ -104,34 +135,14 @@ func (b *Builder) CreateDefaultConfig(localrpms bool) error {
 		return err
 	}
 
-	builderconf := filepath.Join(pwd, "builder.conf")
-
-	err = helpers.CopyFileNoOverwrite(builderconf, "/usr/share/defaults/bundle-chroot-builder/builder.conf")
-	if os.IsExist(err) {
-		// builder.conf already exists. Skip creation.
-		return nil
-	} else if err != nil {
-		return err
-	}
-
-	fmt.Println("Creating new builder.conf configuration file...")
-
-	raw, err := ioutil.ReadFile(builderconf)
-	if err != nil {
-		return err
-	}
-
-	data := strings.Replace(string(raw), "/home/clr/mix", pwd, -1)
 	if localrpms {
-		data += "\n[Mixer]\n"
-		data += "RPMDIR=" + pwd + "/rpms\n"
-		data += "REPODIR=" + pwd + "/local\n"
+		viper.Set("Mixer.RPMDIR", filepath.Join(pwd, "rpms"))
+		viper.Set("Mixer.REPODIR", filepath.Join(pwd, "local"))
 	}
 
-	if err = ioutil.WriteFile(builderconf, []byte(data), 0666); err != nil {
-		return err
-	}
-	return nil
+	fmt.Println("Creating new builder.toml configuration file...")
+
+	return viper.WriteConfigAs(filepath.Join(pwd, "builder.toml"))
 }
 
 // createRpmDirs creates the RPM directories
@@ -154,85 +165,27 @@ func (b *Builder) createRpmDirs() error {
 
 // LoadBuilderConf will read the builder configuration from the command line if
 // it was provided, otherwise it will fall back to reading the configuration from
-// the local builder.conf file.
+// the local builder.toml file.
 func (b *Builder) LoadBuilderConf(builderconf string) error {
-	local, err := os.Getwd()
-	if err != nil {
+	if len(builderconf) > 0 {
+		viper.AddConfigPath(filepath.Dir(builderconf))
+		viper.SetConfigName(filepath.Base(builderconf))
+	}
+
+	if err := viper.ReadInConfig(); err != nil {
 		return err
 	}
 
-	// If builderconf is set via cmd line, use that one
-	if len(builderconf) > 0 {
-		b.Buildconf = builderconf
-		return nil
-	}
+	b.Statedir = viper.GetString("Builder.SERVER_STATE_DIR")
+	b.Bundledir = viper.GetString("Builder.BUNDLE_DIR")
+	b.Yumconf = viper.GetString("Builder.YUM_CONF")
+	b.Cert = viper.GetString("Builder.CERT")
+	b.Versiondir = viper.GetString("Builder.VERSIONS_PATH")
 
-	// Check if there's a local builder.conf if one wasn't supplied
-	localpath := local + "/builder.conf"
-	if _, err := os.Stat(localpath); err == nil {
-		b.Buildconf = localpath
-	} else {
-		return errors.Wrap(err, "Cannot find any builder.conf to use")
-	}
+	b.Format = viper.GetString("swupd.FORMAT")
 
-	return nil
-}
-
-// ReadBuilderConf will populate the configuration data from the builder
-// configuration file, which is mandatory information for performing a mix.
-func (b *Builder) ReadBuilderConf() error {
-	lines, err := helpers.ReadFileAndSplit(b.Buildconf)
-	if err != nil {
-		return errors.Wrap(err, "Failed to read buildconf")
-	}
-
-	// Map the builder values to the regex here to make it easier to assign
-	fields := []struct {
-		re       string
-		dest     *string
-		required bool
-	}{
-		{`^BUNDLE_DIR\s*=\s*`, &b.Bundledir, true},
-		{`^CERT\s*=\s*`, &b.Cert, true},
-		{`^CLEARVER\s*=\s*`, &b.Clearver, false},
-		{`^FORMAT\s*=\s*`, &b.Format, true},
-		{`^MIXVER\s*=\s*`, &b.Mixver, false},
-		{`^REPODIR\s*=\s*`, &b.Repodir, false},
-		{`^RPMDIR\s*=\s*`, &b.RPMdir, false},
-		{`^SERVER_STATE_DIR\s*=\s*`, &b.Statedir, true},
-		{`^VERSIONS_PATH\s*=\s*`, &b.Versiondir, true},
-		{`^YUM_CONF\s*=\s*`, &b.Yumconf, true},
-	}
-
-	for _, h := range fields {
-		r := regexp.MustCompile(h.re)
-		// Look for Environment variables in the config file
-		re := regexp.MustCompile(`\$\{?([[:word:]]+)\}?`)
-		for _, i := range lines {
-			if m := r.FindIndex([]byte(i)); m != nil {
-				// We want the variable without the $ or {} for lookup checking
-				matches := re.FindAllStringSubmatch(i[m[1]:], -1)
-				for _, s := range matches {
-					if _, ok := os.LookupEnv(s[1]); !ok {
-						return errors.Errorf("buildconf contains an undefined environment variable: %s", s[1])
-					}
-				}
-
-				// Replace valid Environment Variables
-				*h.dest = os.ExpandEnv(i[m[1]:])
-			}
-		}
-
-		if h.required && *h.dest == "" {
-			missing := h.re
-			re := regexp.MustCompile(`([[:word:]]+)\\s\*=`)
-			if matches := re.FindStringSubmatch(h.re); matches != nil {
-				missing = matches[1]
-			}
-
-			return errors.Errorf("buildconf missing entry for variable: %s", missing)
-		}
-	}
+	b.Repodir = viper.GetString("Mixer.RPMDIR")
+	b.RPMdir = viper.GetString("Mixer.REPODIR")
 
 	return nil
 }
@@ -267,7 +220,7 @@ func (b *Builder) ReadVersions() error {
 }
 
 // SignManifestMoM will sign the Manifest.MoM file in in place based on the Mix
-// version read from builder.conf.
+// version read from builder.toml.
 func (b *Builder) SignManifestMoM() error {
 	mom := filepath.Join(b.Statedir, "www", b.Mixver, "Manifest.MoM")
 	sig := mom + ".sig"
@@ -902,7 +855,7 @@ func (b *Builder) buildUpdateWithOldSwupd(timer *stopWatch, prefixflag string, m
 // BuildImage will now proceed to build the full image with the previously
 // validated configuration.
 func (b *Builder) BuildImage(format string, template string) error {
-	// If the user did not pass in a format, default to builder.conf
+	// If the user did not pass in a format, default to builder.toml
 	if format == "" {
 		format = b.Format
 	}

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -101,6 +101,7 @@ var initCmd = &cobra.Command{
 	Long:  `Initialize the mixer and workspace`,
 	Run: func(cmd *cobra.Command, args []string) {
 		b := builder.New()
+		b.LoadDefaults()
 		if config == "" {
 			// Create default config if necessary
 			if err := b.CreateDefaultConfig(localrpms); err != nil {
@@ -108,9 +109,6 @@ var initCmd = &cobra.Command{
 			}
 		}
 		if err := b.LoadBuilderConf(config); err != nil {
-			fail(err)
-		}
-		if err := b.ReadBuilderConf(); err != nil {
 			fail(err)
 		}
 		err := b.InitMix(strconv.Itoa(initFlags.clearver), strconv.Itoa(initFlags.mixver), initFlags.all, initFlags.upstreamurl)
@@ -143,7 +141,7 @@ func init() {
 	initCmd.Flags().BoolVar(&localrpms, "local-rpms", false, "Create and configure local RPMs directories")
 	initCmd.Flags().IntVar(&initFlags.clearver, "clear-version", 1, "Supply the Clear version to compose the mix from")
 	initCmd.Flags().IntVar(&initFlags.mixver, "mix-version", 0, "Supply the Mix version to build")
-	initCmd.Flags().StringVar(&config, "config", "", "Supply a specific builder.conf to use for mixing")
+	initCmd.Flags().StringVar(&config, "config", "", "Supply a specific builder.toml to use for mixing")
 	initCmd.Flags().StringVar(&initFlags.upstreamurl, "upstream-url", "https://download.clearlinux.org", "Supply an upstream URL to use for mixing")
 
 	// mark required flags


### PR DESCRIPTION
This is just a preview of how it will look like to have Viper as our config parser for mixer. This does not replace go-ini in swupd code due to some reasons described below. This PR also doesn't include the files from `dep ensure`

One of the main things I want to point out with this preview is how the defaults are initialized. If you look at the builder only, it works just fine. When you start looking at values that are only used by swupd, things start to get a bit ugly. Right now in the main program, every time swupd reads a config value it so happens to be after a builder object has been initialized, but there is no guarantee that this will always be the case. For instance, the tests for swupd never use a builder object. This is one of the main reasons why I believe it would be healthy to separate config parsing from the builder object.

Some notable changes with the move:
- The use of Environment Variables also changes a bit since now nested values are properly parsed. E.g. `CONTENTURL="..."` becomes `SWUPD_CONTENTURL="..."`
- Since viper determines the type of config based on its extension, `builder.conf` needs to be renamed `builder.toml`
- There is no check to see if all required values are present in the config file since there is always a default value that will be used as fallback

On a side note, I found an issue in the Viper API to save a config file without overwriting an existing one. I sent a PR to Viper, I'm waiting for review.