### PR TITLE
Fix add all bundle during init bug

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -380,13 +380,10 @@ func (b *Builder) AddBundles(bundles []string, force bool, allbundles bool, git 
 			return bundleAddCount, err
 		}
 
-		// Clear out bundles list if not empty
-		if len(bundles) > 0 {
-			bundles = make([]string, len(files))
-		}
+		bundles = make([]string, len(files))
 
-		for _, file := range files {
-			bundles = append(bundles, file.Name())
+		for i, file := range files {
+			bundles[i] = file.Name()
 		}
 	}
 


### PR DESCRIPTION
Fixes #126 

Fixes a bug in AddBundles where it didn't clear out the bundles
slice correctly if 'all' was passed AND a bundle list was passed
in. This case never happened with 'mixer bundle add --all', but
did happen with 'mixer init --all'.