### PR TITLE
swupd: Add file index for swupd search

### DIFF
--- a/swupd/filesystem.go
+++ b/swupd/filesystem.go
@@ -85,7 +85,12 @@ func recordFromFile(rootPath, path string, fi os.FileInfo) (*File, error) {
 }
 
 // createManifestRecord wraps createFileRecord to create a Manifest record for a MoM
-func (m *Manifest) createManifestRecord(rootPath string, path string, fi os.FileInfo, version uint32) error {
+func (m *Manifest) createManifestRecord(rootPath string, path string, version uint32) error {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+
 	file, err := recordFromFile(rootPath, path, fi)
 	if err != nil {
 		if strings.Contains(err.Error(), "hash calculation error") {

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -260,6 +260,34 @@ func checkManifestNotContains(t *testing.T, testDir, ver, name string, subs ...s
 	}
 }
 
+func checkFileContains(t *testing.T, path string, subs ...string) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	for _, sub := range subs {
+		if !bytes.Contains(b, []byte(sub)) {
+			t.Errorf("%s did not contain expected '%s'", path, sub)
+		}
+	}
+}
+
+func checkFileNotContains(t *testing.T, path string, subs ...string) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	for _, sub := range subs {
+		if bytes.Contains(b, []byte(sub)) {
+			t.Errorf("%s contains unexpected substring '%s'", path, sub)
+		}
+	}
+}
+
 func checkManifestMatches(t *testing.T, testDir, ver, name string, res ...*regexp.Regexp) {
 	manFpath := filepath.Join(testDir, "www", ver, "Manifest."+name)
 	b, err := ioutil.ReadFile(manFpath)


### PR DESCRIPTION
Add a file->bundle index file to go in a manufactured
os-core-update-index bundle for faster swupd search operations on
client. Instead of downloading all manifests in the current version the
client can just bundle-add this bundle and use the file as its search
helper.

Because this file is part of a bundle and regular update it will be a
candidate for renames and delta updating. Only present files and
symlinks, not directories or deleted files, are added to this file. The
file contains a tab-separated list of filename to bundlename mappings,
sorted first by filename and secondarily by bundle name.

This manifest has to be processed after all other manifests have been
processed because the "subtracted" file lists have to be complete. This
means we have to post-munge the MoM and full manifests with the new
index file and new index bundle.

An exception in bundle includes reading is also necessary because the
first time includes are read this bundle will not exist. This means that
bundles that include this index bundle will not perform manifest
subtraction with that bundle. In this specific case it is okay because
the only file in the manifest lives at a path that is present in every
bundle (/usr/share/clear/...). If this changes in the future the impact
will be small because this bundle will only ever provide one file.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>