### PR TITLE
swupd: improve test infrastructure and import tests from swupd-server

### DIFF
--- a/swupd/files.go
+++ b/swupd/files.go
@@ -158,6 +158,18 @@ func statusFromFlag(flag byte) (StatusFlag, error) {
 	}
 }
 
+func (s StatusFlag) String() string {
+	switch s {
+	case StatusDeleted:
+		return "d"
+	case StatusGhosted:
+		return "g"
+	case StatusUnset:
+		return "."
+	}
+	return "?"
+}
+
 // modifierFromFlag return modifier from flag byte
 func modifierFromFlag(flag byte) (ModifierFlag, error) {
 	switch flag {

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -301,6 +301,27 @@ func checkFileInManifest(t *testing.T, m *Manifest, version uint32, name string)
 	t.Errorf("couldn't find file %s in manifest %s version %d", name, m.Name, m.Header.Version)
 }
 
+func fileInManifest(t *testing.T, m *Manifest, version uint32, name string) *File {
+	for _, f := range m.Files {
+		if f.Name == name {
+			if f.Version == version {
+				return f
+			}
+			t.Fatalf("in manifest %s version %d: file %s has version %d but expected %d", m.Name, m.Header.Version, f.Name, f.Version, version)
+		}
+	}
+	t.Fatalf("couldn't find file %s in manifest %s version %d", name, m.Name, m.Header.Version)
+	return nil
+}
+
+func fileNotInManifest(t *testing.T, m *Manifest, name string) {
+	for _, f := range m.Files {
+		if f.Name == name {
+			t.Fatalf("unexpectedly found file %s with version %d in manifest %s version %d", f.Name, f.Version, m.Name, m.Header.Version)
+		}
+	}
+}
+
 func checkIncludes(t *testing.T, m *Manifest, includes ...string) {
 	if len(m.Header.Includes) != len(includes) {
 		t.Errorf("manifest %s in version %d has %d includes but expected %d", m.Name, m.Header.Version, len(m.Header.Includes), len(includes))

--- a/swupd/swupd_test.go
+++ b/swupd/swupd_test.go
@@ -1,0 +1,76 @@
+package swupd
+
+import "testing"
+
+// Imported from swupd-server/test/functional/include-version-bump.
+func TestIncludeVersionBump(t *testing.T) {
+	ts := newTestSwupd(t, "include-version-bump-")
+	defer ts.cleanup()
+
+	// Version 10.
+	ts.Bundles = []string{"test-bundle"}
+	ts.write("image/10/test-bundle/foo", "foo")
+	ts.createManifests(10)
+	ts.createFullfiles(10)
+	ts.createPack("os-core", 0, 10, ts.path("image"))
+	ts.createPack("test-bundle", 0, 10, ts.path("image"))
+
+	mustValidateZeroPack(t, ts.path("www/10/Manifest.os-core"), ts.path("www/10/pack-os-core-from-0.tar"))
+	mustValidateZeroPack(t, ts.path("www/10/Manifest.test-bundle"), ts.path("www/10/pack-test-bundle-from-0.tar"))
+
+	m10 := ts.parseManifest(10, "test-bundle")
+	checkIncludes(t, m10, "os-core")
+	checkFileInManifest(t, m10, 10, "/foo")
+
+	// Version 20. Add "included" and "included-two" to be included by "test-bundle".
+	ts.Bundles = append(ts.Bundles, "included", "included-two")
+	ts.copyChroots(10, 20)
+	ts.write("image/20/included/bar", "bar")
+	ts.write("image/20/included-two/baz", "baz")
+	ts.write("image/20/noship/test-bundle-includes", "included\nincluded-two")
+	ts.createManifests(20)
+	ts.createFullfiles(20)
+
+	ts.createPack("os-core", 0, 20, ts.path("image"))
+	ts.createPack("test-bundle", 0, 20, ts.path("image"))
+	ts.createPack("included", 0, 20, ts.path("image"))
+	ts.createPack("included-two", 0, 20, ts.path("image"))
+
+	mustValidateZeroPack(t, ts.path("www/20/Manifest.os-core"), ts.path("www/20/pack-os-core-from-0.tar"))
+	mustValidateZeroPack(t, ts.path("www/20/Manifest.test-bundle"), ts.path("www/20/pack-test-bundle-from-0.tar"))
+	mustValidateZeroPack(t, ts.path("www/20/Manifest.included"), ts.path("www/20/pack-included-from-0.tar"))
+	mustValidateZeroPack(t, ts.path("www/20/Manifest.included-two"), ts.path("www/20/pack-included-two-from-0.tar"))
+
+	m20 := ts.parseManifest(20, "test-bundle")
+	checkIncludes(t, m20, "os-core", "included", "included-two")
+
+	checkFileInManifest(t, ts.parseManifest(20, "included"), 20, "/bar")
+	checkFileInManifest(t, ts.parseManifest(20, "included-two"), 20, "/baz")
+
+	// Version 30. Add "included-nested" to be included by "included".
+	ts.Bundles = append(ts.Bundles, "included-nested")
+	ts.copyChroots(20, 30)
+	ts.write("image/30/included-nested/foobarbaz", "foobarbaz")
+	ts.write("image/30/noship/test-bundle-includes", "included\nincluded-two")
+	ts.write("image/30/noship/included-includes", "included-nested")
+	ts.createManifests(30)
+	ts.createFullfiles(30)
+
+	ts.checkExists("www/30/Manifest.os-core")
+	ts.checkNotExists("www/30/Manifest.test-bundle")
+	ts.checkNotExists("www/30/Manifest.included-two")
+
+	// Note: original test in swupd-server expected zero packs for all bundles
+	// including ones missing manifests, the new code fails in that case, since these
+	// packs are not used or generated in practice.
+	ts.createPack("os-core", 0, 30, ts.path("image"))
+	ts.createPack("included", 0, 30, ts.path("image"))
+	ts.createPack("included-nested", 0, 30, ts.path("image"))
+
+	mustValidateZeroPack(t, ts.path("www/30/Manifest.os-core"), ts.path("www/30/pack-os-core-from-0.tar"))
+	mustValidateZeroPack(t, ts.path("www/30/Manifest.included"), ts.path("www/30/pack-included-from-0.tar"))
+	mustValidateZeroPack(t, ts.path("www/30/Manifest.included-nested"), ts.path("www/30/pack-included-nested-from-0.tar"))
+
+	checkIncludes(t, ts.parseManifest(30, "included"), "os-core", "included-nested")
+	checkFileInManifest(t, ts.parseManifest(30, "included-nested"), 30, "/foobarbaz")
+}


### PR DESCRIPTION
Add testSwupd, in the same spirit of testFileSystem, to make tests less noisy.

Convert two tests to use it, to give some context for reviewing it.

Also import new tests from swupd-server.

Related to #138.