### PR TITLE
Bundle refactor new

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -31,7 +31,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -126,35 +125,12 @@ func GenerateCertificate(cert string, template, parent *x509.Certificate, pubkey
 func ReadFileAndSplit(filename string) ([]string, error) {
 	builder, err := ioutil.ReadFile(filename)
 	if err != nil {
-		PrintError(err)
 		return nil, err
 	}
 	data := string(builder)
 	lines := strings.Split(data, "\n")
 
 	return lines, nil
-}
-
-// GetIncludedBundles parses a bundle definition file and returns a list of all
-// bundles it includes.
-func GetIncludedBundles(filename string) ([]string, error) {
-	lines, err := ReadFileAndSplit(filename)
-	if err != nil {
-		PrintError(err)
-		return nil, err
-	}
-
-	// Note: Matches lines like "include(os-core-update)", pulling out
-	// the string between the parens. The "\" needs to be escaped due to
-	// Go's string literal parsing, so "\\(" matches "("
-	r := regexp.MustCompile("^include\\(([A-Za-z0-9-]+)\\)$")
-	var includes []string
-	for _, line := range lines {
-		if matches := r.FindStringSubmatch(line); len(matches) > 1 {
-			includes = append(includes, matches[1])
-		}
-	}
-	return includes, nil
 }
 
 // UnpackFile unpacks a .tar or .tar.gz/.tgz file to a given directory.


### PR DESCRIPTION
This PR replaces #107.  I don't want anything to slip past people, so please carefully read the individual commit comments for the impact and side effects of each.

> **NOTE**: Per @cmarcelo's request, I pulled the first two commits out and submitted them as #148 and #149. This PR will be rebased on top of that once it's merged.

This is a fairly major overhaul (I rewrote almost everything in #107 to significantly improve efficiency, take advantage of #102 being merged, and to  account for everyone's feedback), so that's why it's a new PR instead of a force push.

The major differences are:
- Refactored to remove the `stringset` package and type abstraction. The `bundleSet` type is used throughout.
- The `mix-bundles` directory is no longer created **iff** the UseNewChrootBuilder flag (`--new-chroots`) flag is passed. If so, the new BCB now directly reads the definition files in-place without needing them copied to a directory. If using old BCB, the `mix-bundles` dir is built on-the-fly.
- Significant overhaul of `mixer bundle list` that
  - Lists the *full* set of mix bundles (following includes), as per @tmarcu's feedback
  - Eliminates the ambiguous, mutually exclusive `bool`'s, as per @icarus-sparry's feedback
  - Adds formatted information when viewing the mix bundle list that indicates whether a mix bundle is from and include and whether it comes from local/upstream, and when viewing the local or upstream bundle lists that indicates whether a bundle is already included in the list (see sample output below for example)
  - Adds a tree-print view for mix, local, and upstream lists that helps visualize how and why bundles are in your mix.