### PR TITLE
Import no-deltas test from swupd-server

### DIFF
--- a/swupd/delta_test.go
+++ b/swupd/delta_test.go
@@ -1,7 +1,10 @@
 package swupd
 
 import (
+	"fmt"
+	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -23,4 +26,80 @@ func TestCreateDeltas(t *testing.T) {
 
 	mustCreateAllDeltas(t, "Manifest.full", testDir, 10, 20)
 	mustExistDelta(t, testDir, "/bar", 10, 20)
+}
+
+// Imported from swupd-server/test/functional/no-delta.
+func TestNoDeltasForTypeChangesOrDereferencedSymlinks(t *testing.T) {
+	ts := newTestSwupd(t, "no-deltas-")
+	defer ts.cleanup()
+
+	// NOTE: Currently the delta is compared to the real file, but a better
+	// approximation comparison would be with a compressed version of the real file
+	// (fullfile), since the delta itself will already be compressed, so packing won't
+	// make it smaller like it might with the real file.
+
+	// Create a content that will get delta.
+	before := strings.Repeat("CONTENT", 1000)
+	after := strings.ToLower(before[:10]) + before[10:]
+
+	// file1 will remain a regular file.
+	ts.write("image/10/os-core/file1", before+"1")
+	ts.write("image/20/os-core/file1", after+"1")
+
+	// sym1 is a link that will become a regular file (L->F).
+	ts.symlink("image/10/os-core/sym1", "file1")
+	ts.cp("image/10/os-core/file1", "image/20/os-core/sym1")
+
+	// file2 will remain a regular file.
+	ts.write("image/10/os-core/file2", before+"2")
+	ts.write("image/20/os-core/file2", after+"2")
+
+	// sym2 is a regular file that will become a link (F->L).
+	ts.cp("image/10/os-core/file2", "image/10/os-core/sym2")
+	ts.symlink("image/20/os-core/sym2", "file2")
+
+	// file3 will remain a regular file.
+	ts.write("image/10/os-core/file3", before+"3")
+	ts.write("image/20/os-core/file3", after+"3")
+
+	// symlink change + symlink target change, no delta for dereferenced sym3.
+	ts.cp("image/20/os-core/file3", "image/20/os-core/file4")
+	ts.symlink("image/10/os-core/sym3", "file3")
+	ts.symlink("image/20/os-core/sym3", "file4")
+
+	ts.createManifests(10)
+	ts.createManifests(20)
+
+	info := ts.createPack("os-core", 10, 20, ts.path("image"))
+
+	mustHaveNoWarnings(t, info)
+	mustHaveDeltaCount(t, info, 3)
+	mustHaveFullfileCount(t, info, 5)
+
+	// Check that only the regular file to regular file deltas exist.
+	{
+		hashA := ts.mustHashFile("image/10/os-core/file1")
+		hashB := ts.mustHashFile("image/20/os-core/file1")
+		ts.checkExists(fmt.Sprintf("www/20/delta/10-20-%s-%s", hashA, hashB))
+	}
+	{
+		hashA := ts.mustHashFile("image/10/os-core/file2")
+		hashB := ts.mustHashFile("image/20/os-core/file2")
+		ts.checkExists(fmt.Sprintf("www/20/delta/10-20-%s-%s", hashA, hashB))
+	}
+	{
+		hashA := ts.mustHashFile("image/10/os-core/file3")
+		hashB := ts.mustHashFile("image/20/os-core/file3")
+		ts.checkExists(fmt.Sprintf("www/20/delta/10-20-%s-%s", hashA, hashB))
+	}
+
+	// Since pack has 3 deltas, no other delta is there. Double check other deltas
+	// were not created in the file system.
+	fis, err := ioutil.ReadDir(ts.path("www/20/delta"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uint64(len(fis)) != info.DeltaCount {
+		t.Fatalf("found %d files in %s but expected %d", len(fis), ts.path("www/20/delta"), info.DeltaCount)
+	}
 }

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -422,6 +422,19 @@ func (fs *testFileSystem) write(subpath, content string) {
 	}
 }
 
+func (fs *testFileSystem) symlink(subpath, linkname string) {
+	fs.t.Helper()
+	path := filepath.Join(fs.Dir, subpath)
+	err := os.MkdirAll(filepath.Dir(path), 0755)
+	if err != nil {
+		fs.t.Fatalf("couldn't create directory to write file: %s", err)
+	}
+	err = os.Symlink(linkname, path)
+	if err != nil {
+		fs.t.Fatal(err)
+	}
+}
+
 func (fs *testFileSystem) path(subpath string) string {
 	return filepath.Join(fs.Dir, subpath)
 }
@@ -634,4 +647,13 @@ func (ts *testSwupd) parseManifest(version uint32, name string) *Manifest {
 		ts.t.Fatalf("couldn't parse manifest %s for version %d: %s", name, version, err)
 	}
 	return m
+}
+
+func (ts *testSwupd) mustHashFile(subpath string) string {
+	ts.t.Helper()
+	hash, err := GetHashForFile(ts.path(subpath))
+	if err != nil {
+		ts.t.Fatalf("couldn't calculate hash for file %s: %s", subpath, err)
+	}
+	return hash
 }


### PR DESCRIPTION
Import a test and add a simple one.

Fix a difference in behavior with swupd-server: a target might have both a fullfile and a delta to it. Added a TODO note that we may want to drop packing the delta in this case.

Improve information about packs -- now we report what delta was pack for a specific file.