### PR TITLE
Rename, cleanup, and remove .mixer directory

### DIFF
--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -118,7 +118,7 @@ var buildAllCmd = &cobra.Command{
 		if err != nil {
 			fail(err)
 		}
-		rpms, err := ioutil.ReadDir(b.RPMdir)
+		rpms, err := ioutil.ReadDir(b.RPMDir)
 		if err == nil {
 			err = b.AddRPMList(rpms)
 			if err != nil {

--- a/mixer/cmd/rpms.go
+++ b/mixer/cmd/rpms.go
@@ -50,10 +50,10 @@ func runAddRPM(cmd *cobra.Command, args []string) {
 	if err != nil {
 		fail(err)
 	}
-	if b.RPMdir == "" {
+	if b.RPMDir == "" {
 		failf("RPMDIR not set in configuration")
 	}
-	rpms, err := ioutil.ReadDir(b.RPMdir)
+	rpms, err := ioutil.ReadDir(b.RPMDir)
 	if err != nil {
 		failf("cannot read RPMDIR: %s", err)
 	}


### PR DESCRIPTION
>**NOTE**: Per @cmarcelo's request, I pulled this out of #137 so that it can be merged sooner, and so the discussion around deprecation can be had here. 
It is almost exactly the same as the commit in #137, but because it's now on its own (instead of on top of the commit now in #148), there was a small conflict in the section in BuildChroots that #148 also touches. This will likely need to be rebased on top of #148 once it merges.

This commit has three main side effects:
1) The .clearversion, .mixversion, and .clearurl files are no longer
hidden files.

They were likely originally hidden to declutter the workspace, but
they are (for now) files the user needs to edit directly, and thus
should not be hidden.

2) The clearversion and clearurl files has been renamed
upstreamversion and upstreamurl, as part of a larger goal to
accomodate derivatives-of-derivatives, for whom upstream is not
mainline CLR. (The internal fields on the Builder object have been
renamed as well.)

3) Per feedback, the .mixer directory has been removed.

Two of the goals the directory was introduced to solve will instead
be met in different ways:

i) Hiding temporary, sausage-making files. The mix-bundles/
directory will soon cease to exist entirely, once the BCB rewrite
moves out from behind UseNewChrootBuilder. upstream-bundles/ also
contains temporary, tool-generated files, but people have expressed
interest (or at least tolerance) of these not being hidden away.

ii) Organizing/decluttering the workspace. As there are numerous
different configuration files (including the mixversion,
clearversion, clearurl, and forthcoming mix bundle list), having
them in the .mixer directory provided a better form of decluttering
than having the files as hidden dot-files. However, ideally these
files will soon be merged into the builder.conf, when the that
file gets rewritten as a TOML file.

This commit also has minor side effects:
1) General code clean-up (e.g., use of filepath.Join())
2) Change Builder struct field names to match capitalization
conventions
3) Moves the location of InitMix within the file for organizational
purposes.