### PR TITLE
swupd: fix typo in linking logic for packs

### DIFF
--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -518,7 +518,7 @@ func linkDeltaPeersForPack(c *config, oldManifest, newManifest *Manifest) error 
 				continue
 			}
 
-			if !nf.Present() || !nf.Present() {
+			if !nf.Present() || !of.Present() {
 				continue
 			}
 


### PR DESCRIPTION
We need to check that both old and new file are present to link them
when linking files with the same name.

We were not hitting issues because of the earlier check for hashes
matching. If the old file was deleted, the old hash would either be
all zeros (not match) or will be the same hash as another file we
renamed to in the old manifest (unlikely to match this new file, but
possible).

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>