### PR TITLE
Rename from/to files should have matching hashes

### DIFF
--- a/swupd/rename.go
+++ b/swupd/rename.go
@@ -93,6 +93,7 @@ func linkRenamePair(renameTo, renameFrom *File) {
 	renameTo.Rename = true
 	renameFrom.Rename = true
 	renameFrom.Type = TypeUnset
+	renameFrom.Hash = renameTo.Hash
 }
 
 // trimRenamed returns an slice which has had files with DeltaPeers purged


### PR DESCRIPTION
The hashes for these two files should be the hash of the rename-to file.
Add test to verify as well.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>