### PR TITLE
Fix os-core-update-index generation

### DIFF
--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -294,6 +294,10 @@ func CreateManifests(version uint32, minVersion uint32, format uint, statedir st
 	// copy over unchanged manifests
 	for _, m := range oldMoM.Files {
 		if m.findFileNameInSlice(newMoM.Files) == nil {
+			if m.Name == indexBundle {
+				// this is generated new each time
+				continue
+			}
 			newMoM.Files = append(newMoM.Files, m)
 		}
 	}

--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -607,6 +607,16 @@ func TestCreateManifestsIndex(t *testing.T) {
 	checkManifestMatches(t, testDir, "20", "full", re)
 	// no update to this dir
 	checkManifestContains(t, testDir, "20", "os-core-update-index", "10\t/usr/share\n")
+
+	mustInitStandardTest(t, testDir, "20", "30", []string{"test-bundle1", "test-bundle2"})
+	mustCreateManifestsStandard(t, 30, testDir)
+	// expect only the current version to show up in the MoM
+	// this is an issue we ran into where the old index manifest was copied over
+	// as well as generated.
+	re = regexp.MustCompile("F\\.\\.\\.\t.*\t30\t/usr/share/clear/os-core-update-index\n")
+	checkManifestMatches(t, testDir, "30", "full", re)
+	checkManifestContains(t, testDir, "30", "MoM", "30\tos-core-update-index")
+	checkManifestNotContains(t, testDir, "30", "MoM", "10\tos-core-update-index")
 }
 
 func TestCreateManifestsIndexInclude(t *testing.T) {

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -984,26 +984,19 @@ func writeIndexManifest(c *config, ui *UpdateInfo, bundles []*Manifest) (*Manife
 	// linkPeersAndChange will update file versions correctly
 	_, _, _ = idxMan.linkPeersAndChange(oldM, *c, ui.minVersion)
 	// now add any new files to the full manifest
-	lenIdxM := len(idxMan.Files)
-	lenFullM := len(newFull.Files)
-	for ix, fx := 0, 0; ix < lenIdxM && fx < lenFullM; {
-		idxF := idxMan.Files[ix]
-		fulF := newFull.Files[fx]
-		switch {
-		case idxF.Name < fulF.Name:
-			// only present in full
-			ix++
-		case idxF.Name > fulF.Name:
-			// only present in idx manifest, add to full
-			newFull.Files = append(newFull.Files, idxF)
-			newFull.Header.FileCount++
-			fx++
-		default:
-			// present in both but updated in idx man, replace
-			fulF = idxF
-			ix++
-			fx++
+	for _, idxF := range idxMan.Files {
+		i := sort.Search(len(newFull.Files), func(i int) bool {
+			return newFull.Files[i].Name >= idxF.Name
+		})
+
+		if i < len(newFull.Files) && newFull.Files[i].Name == idxF.Name {
+			// overwrite existing
+			newFull.Files[i] = idxF
+			continue
 		}
+
+		// add to full manifest
+		newFull.Files = append(newFull.Files, idxF)
 	}
 
 	manOutput := filepath.Join(c.outputDir, fmt.Sprint(ui.version), "Manifest."+indexBundle)


### PR DESCRIPTION
Generation for os-core-update-index was causing many duplicated files to
be added to Manifest.full for each build because the manifest walk was
done incorrectly. It was adding a file every time there was a file miss
when doing the walk because it was appending every time. This was
converted to a simple binary search from the sort package.

os-core-update-index was also both being copied from the old MoM and
generated and added later. This caused a duplicate entry for
os-core-update-index in the Manifest.MoM for every build after the first
one. Now skip the indexBundle when copying over old manifests.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>