### PR TITLE
File did not change if hash and name are the same

### DIFF
--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -797,3 +797,23 @@ func TestRenameFlagSticks(t *testing.T) {
 	checkRenameFlag(fileA30)
 	checkRenameFlag(fileB30)
 }
+
+func TestNoUpdateStateFiles(t *testing.T) {
+	ts := newTestSwupd(t, "no-update-boot-files")
+	defer ts.cleanup()
+
+	ts.Bundles = []string{"os-core", "test-bundle"}
+
+	// Version 10
+	ts.write("image/10/test-bundle/usr/lib/kernel/file", "content")
+	ts.createManifests(10)
+
+	// Version 20 has same content for /usr/lib/kernel/file and a new
+	// file to force manifest creation
+	ts.copyChroots(10, 20)
+	ts.write("image/20/test-bundle/new", "new")
+	ts.createManifests(20)
+
+	m20 := ts.parseManifest(20, "test-bundle")
+	_ = fileInManifest(t, m20, 10, "/usr/lib/kernel/file")
+}

--- a/swupd/files.go
+++ b/swupd/files.go
@@ -254,14 +254,6 @@ func (f *File) findFileNameInSlice(fs []*File) *File {
 	return nil
 }
 
-func sameFile(f1 *File, f2 *File) bool {
-	return f1.Name == f2.Name &&
-		f1.Hash == f2.Hash &&
-		f1.Type == f2.Type &&
-		f1.Status == f2.Status &&
-		f1.Modifier == f2.Modifier
-}
-
 func (f *File) isUnsupportedTypeChange() bool {
 	if f.DeltaPeer == nil {
 		// nothing to check, new or deleted file

--- a/swupd/files_test.go
+++ b/swupd/files_test.go
@@ -254,55 +254,6 @@ func TestFindFileNameInSlice(t *testing.T) {
 	}
 }
 
-func TestSameFile(t *testing.T) {
-	testCases := []struct {
-		file1    File
-		file2    File
-		expected bool
-	}{
-		{
-			File{Name: "1", Hash: 1, Type: TypeFile, Status: StatusUnset, Modifier: ModifierUnset},
-			File{Name: "1", Hash: 1, Type: TypeFile, Status: StatusUnset, Modifier: ModifierUnset},
-			true,
-		},
-		{
-			File{Name: "1", Hash: 1, Type: TypeFile, Status: StatusUnset, Modifier: ModifierUnset},
-			File{Name: "2", Hash: 1, Type: TypeFile, Status: StatusUnset, Modifier: ModifierUnset},
-			false,
-		},
-		{
-			File{Name: "1", Hash: 1, Type: TypeFile, Status: StatusUnset, Modifier: ModifierUnset},
-			File{Name: "1", Hash: 2, Type: TypeFile, Status: StatusUnset, Modifier: ModifierUnset},
-			false,
-		},
-		{
-			File{Name: "1", Hash: 1, Type: TypeFile, Status: StatusUnset, Modifier: ModifierUnset},
-			File{Name: "1", Hash: 1, Type: TypeLink, Status: StatusUnset, Modifier: ModifierUnset},
-			false,
-		},
-		{
-			File{Name: "1", Hash: 1, Type: TypeFile, Status: StatusUnset, Modifier: ModifierUnset},
-			File{Name: "1", Hash: 1, Type: TypeFile, Status: StatusDeleted, Modifier: ModifierUnset},
-			false,
-		},
-		{
-			File{Name: "1", Hash: 1, Type: TypeFile, Status: StatusUnset, Modifier: ModifierUnset},
-			File{Name: "1", Hash: 1, Type: TypeFile, Status: StatusUnset, Modifier: ModifierBoot},
-			false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run("sameFile", func(t *testing.T) {
-			if sameFile(&tc.file1, &tc.file2) != tc.expected {
-				t.Errorf("sameFile returned %v when %v was expected",
-					!tc.expected,
-					tc.expected)
-			}
-		})
-	}
-}
-
 func TestTypeHasChanged(t *testing.T) {
 	testCases := []struct {
 		file     File

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -398,7 +398,7 @@ func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, c config, minVersio
 				nx++
 				continue
 			}
-			if sameFile(nf, of) && of.Version >= minVersion {
+			if nf.Hash == of.Hash && of.Version >= minVersion {
 				// file did not change, set version to the old version
 				// persist the Rename flag
 				nf.Rename = of.Rename


### PR DESCRIPTION
sameFile checks many things which have yet to be detected on the new
manifest such as the Modifier flag. Because the old manifest will have
this information due to being read directly from a file the new file
would be detected as needing an updated version. Only check the hash and
minversion instead of all file data when deciding whether it is the same
file in relation to an update.

Add a test for a boot file to make sure it stays at the correct version.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>