### PR TITLE
Improve error messages for manifest write failures

### DIFF
--- a/swupd/files.go
+++ b/swupd/files.go
@@ -15,7 +15,6 @@
 package swupd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 )
@@ -231,7 +230,7 @@ func (f *File) GetFlagString() (string, error) {
 		f.Status == StatusUnset &&
 		f.Modifier == ModifierUnset &&
 		f.Rename == renameUnset {
-		return "", errors.New("no flags are set on file")
+		return "", fmt.Errorf("no flags are set on file %s", f.Name)
 	}
 
 	flagBytes := []byte{

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -315,7 +315,7 @@ func (m *Manifest) WriteManifest(w io.Writer) error {
 	}
 	err = manifestTemplate.Execute(w, m)
 	if err != nil {
-		return fmt.Errorf("couldn't write manifest: %s", err)
+		return fmt.Errorf("couldn't write Manifest.%s: %s", m.Name, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Ran into an issue during testing where a build failed and I had no
context to debug with. Add some meaningful information (file and
manifest name) to GetFlagString and WriteManifest failures.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>