### PR TITLE
Only support File->File renames

### DIFF
--- a/swupd/rename.go
+++ b/swupd/rename.go
@@ -106,7 +106,15 @@ func trimRenamed(a []*File) []*File {
 		// and it is helpful to be able to ship just the differences for them.
 		// Worst case is that the files do not exist on the target system, in which
 		// case the swupd-client will fall back to doing a full download.
-		if f.DeltaPeer == nil {
+		//
+		// Renames are only supported for TypeFile right now so skip if the file is
+		// not the right type.
+		//
+		// Unfortunately deleted files have lost their association with a file type
+		// so we have to leave all deleted files in the list
+		// TODO: refactor to leave file type in the deleted file records. There is no
+		// reason to clear them.
+		if f.DeltaPeer == nil && (!f.Present() || f.Type == TypeFile) {
 			r = append(r, f)
 		}
 	}

--- a/swupd/rename_test.go
+++ b/swupd/rename_test.go
@@ -38,16 +38,16 @@ func generateTestArray(t *testing.T) map[string]File {
 		k string // stuff to make content unique
 	}{
 		// Two files, same contents
-		{n: "I1", f: File{Name: "/lib/python3.6/libpython.3.6.0.so"}, s: 400, m: _rwx, k: "file1"},
-		{n: "I2", f: File{Name: "/lib/python3.7/libpython.3.7.0.so"}, s: 400, m: _rwx, k: "file1"},
+		{n: "I1", f: File{Name: "/lib/python3.6/libpython.3.6.0.so", Type: TypeFile}, s: 400, m: _rwx, k: "file1"},
+		{n: "I2", f: File{Name: "/lib/python3.7/libpython.3.7.0.so", Type: TypeFile}, s: 400, m: _rwx, k: "file1"},
 		// Two short files, different contents
-		{n: "S1", f: File{Name: "/lib/python3.6/tiny"}, s: 180, m: _rwx, k: "123"},
-		{n: "S2", f: File{Name: "/lib/python3.7/tiny"}, s: 180, m: _rwx, k: "456"},
+		{n: "S1", f: File{Name: "/lib/python3.6/tiny", Type: TypeFile}, s: 180, m: _rwx, k: "123"},
+		{n: "S2", f: File{Name: "/lib/python3.7/tiny", Type: TypeFile}, s: 180, m: _rwx, k: "456"},
 		// long files, different contents, same length
-		{n: "L1", f: File{Name: "/lib/python3.6/big"}, s: 580, m: _rwx, k: "123"},
-		{n: "L2", f: File{Name: "/lib/python3.7/big"}, s: 580, m: _rwx, k: "456"},
-		{n: "L3", f: File{Name: "/lib/python2.6/big"}, s: 580, m: _rwx, k: "123"},
-		{n: "L4", f: File{Name: "/lib/python2.7/big"}, s: 580, m: _rwx, k: "456"},
+		{n: "L1", f: File{Name: "/lib/python3.6/big", Type: TypeFile}, s: 580, m: _rwx, k: "123"},
+		{n: "L2", f: File{Name: "/lib/python3.7/big", Type: TypeFile}, s: 580, m: _rwx, k: "456"},
+		{n: "L3", f: File{Name: "/lib/python2.6/big", Type: TypeFile}, s: 580, m: _rwx, k: "123"},
+		{n: "L4", f: File{Name: "/lib/python2.7/big", Type: TypeFile}, s: 580, m: _rwx, k: "456"},
 	}
 
 	m := &Manifest{}


### PR DESCRIPTION
Only support renaming a file to a file since renames are not supported
for the other cases. This is done in trimRenamed by only appending to
the rename list if the file is deleted/ghosted or is a TypeFile. It is
necessary to allow all deleted/ghosted files through because we have
lost the file type association at this point. At least the added list
will only contain files and therefore directories and links will not be
renamed.

Add a TODO to stop removing file type information from deleted files.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>