### PR TITLE
New Command: mixer bundle remove

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -739,6 +739,78 @@ func (b *Builder) AddBundles(bundles []string, allLocal bool, allUpstream bool, 
 	return nil
 }
 
+// RemoveBundles removes a list of bundles from the Mix Bundles List. If a
+// bundle is not present, it is skipped. If 'local' is passed, the corresponding
+// bundle file is removed from local-bundles. Note that this is an irreversible
+// step. The Mix Bundles List is validated when read in, and the resulting Mix
+// Bundles List will be in sorted order.
+func (b *Builder) RemoveBundles(bundles []string, mix bool, local bool, git bool) error {
+	// Fetch upstream bundle files if needed
+	if err := b.getUpstreamBundles(b.UpstreamVer, true); err != nil {
+		return err
+	}
+
+	// Read in current mix bundles list
+	set, err := b.getMixBundlesListAsSet()
+	if err != nil {
+		return err
+	}
+
+	// Remove the ones passed in from the set
+	for _, bundle := range bundles {
+		_, inMix := set[bundle]
+
+		if local {
+			if _, err := os.Stat(filepath.Join(b.LocalBundleDir, bundle)); err == nil {
+				fmt.Printf("Removing bundle file for '%s' from local-bundles\n", bundle)
+				if err := os.Remove(filepath.Join(b.LocalBundleDir, bundle)); err != nil {
+					return errors.Wrapf(err, "Cannot remove bundle file for '%s' from local-bundles", bundle)
+				}
+
+				if !mix && inMix {
+					// Check if bundle is still available upstream
+					if _, err := b.getBundlePath(bundle); err != nil {
+						fmt.Printf("Warning: Invalid bundle left in mix: %s\n", bundle)
+					} else {
+						fmt.Printf("Mix bundle '%s' now points to upstream\n", bundle)
+					}
+				}
+			} else {
+				fmt.Printf("Bundle '%s' not found in local-bundles; skipping\n", bundle)
+			}
+		}
+
+		if mix {
+			if inMix {
+				fmt.Printf("Removing bundle '%s' from mix\n", bundle)
+				delete(set, bundle)
+			} else {
+				fmt.Printf("Bundle '%s' not found in mix; skipping\n", bundle)
+			}
+		}
+	}
+
+	// Write final mix bundle list back to file, only if the Mix Bundle List was edited
+	if mix {
+		if err := b.writeMixBundleList(set); err != nil {
+			return err
+		}
+	}
+
+	if git {
+		fmt.Println("Adding git commit")
+		if err := helpers.Git("add", "."); err != nil {
+			return err
+		}
+		commitMsg := fmt.Sprintf("Bundles removed: %v", bundles)
+		if err := helpers.Git("commit", "-q", "-m", commitMsg); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 const (
 	// Using the Unicode "Box Drawing" group
 	treeNil = "    "

--- a/mixer/cmd/bundles.go
+++ b/mixer/cmd/bundles.go
@@ -65,6 +65,46 @@ resultant list is written back out in sorted order.`,
 	},
 }
 
+// Bundle add command ('mixer bundle add')
+type bundleRemoveCmdFlags struct {
+	mix   bool
+	local bool
+	git   bool
+}
+
+var bundleRemoveFlags bundleRemoveCmdFlags
+
+var bundleRemoveCmd = &cobra.Command{
+	Use:   "remove [bundle(s)]",
+	Short: "Remove bundles from your mix",
+	Long: `Removes bundles from your mix by modifying the Mix Bundle List
+(stored in the 'mixbundles' file). The Mix Bundle List is parsed, the bundles
+are removed, and the resultant list is written back out in sorted order. If
+bundles do not exist in the mix, they are skipped.
+
+Passing '--local' will also remove the corresponding bundle definition file from
+local-bundles, if it exists. Please note that this is an irrevocable step.
+
+'--mix' defaults to true. Passing '--mix=false' will prevent the bundle from
+being removed from your Mix Bundle List. This is useful when used in conjunction
+with '--local' to *only* remove a bundle from local-bundles. If the bundle being
+removed is an edited version from upstream, the bundle will remain in your mix
+and now reference the original upstream version. If the bundle was custom, and
+no upstream alternative exists, a warning will be returned.`,
+	Args: cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		b, err := builder.NewFromConfig(config)
+		if err != nil {
+			fail(err)
+		}
+
+		err = b.RemoveBundles(args, bundleRemoveFlags.mix, bundleRemoveFlags.local, bundleRemoveFlags.git)
+		if err != nil {
+			fail(err)
+		}
+	},
+}
+
 // Bundle list command ('mixer bundle list')
 type bundleListCmdFlags struct {
 	tree bool
@@ -117,6 +157,7 @@ var bundleListCmd = &cobra.Command{
 // List of all bundle commands
 var bundlesCmds = []*cobra.Command{
 	bundleAddCmd,
+	bundleRemoveCmd,
 	bundleListCmd,
 }
 
@@ -130,6 +171,10 @@ func init() {
 	bundleAddCmd.Flags().BoolVar(&bundleAddFlags.allLocal, "all-local", false, "Add all local bundles; takes precedence over bundle list")
 	bundleAddCmd.Flags().BoolVar(&bundleAddFlags.allUpstream, "all-upstream", false, "Add all upstream bundles; takes precedence over bundle list")
 	bundleAddCmd.Flags().BoolVar(&bundleAddFlags.git, "git", false, "Automatically apply new git commit")
+
+	bundleRemoveCmd.Flags().BoolVar(&bundleRemoveFlags.mix, "mix", true, "Remove bundle from Mix Bundle List")
+	bundleRemoveCmd.Flags().BoolVar(&bundleRemoveFlags.local, "local", false, "Also remove bundle file from local-bundles (irrevocable)")
+	bundleRemoveCmd.Flags().BoolVar(&bundleRemoveFlags.git, "git", false, "Automatically apply new git commit")
 
 	bundleListCmd.Flags().BoolVar(&bundleListFlags.tree, "tree", false, "Pretty-print the list as a tree.")
 }


### PR DESCRIPTION
Removes bundles from your mix by modifying the Mix Bundle List
(stored in the 'mixbundles' file). The Mix Bundle List is parsed, the bundles
are removed, and the resultant list is written back out in sorted order. If
bundles do not exist in the mix, they are skipped.

Passing `--local` will also remove the corresponding bundle definition file from
local-bundles, if it exists. Please note that this is an irrevocable step.

`--mix` defaults to true. Passing `--mix=false` will prevent the bundle from
being removed from your Mix Bundle List. This is useful when used in conjunction
with `--local` to *only* remove a bundle from local-bundles. If the bundle being
removed is an edited version from upstream, the bundle will remain in your mix
and now reference the original upstream version. If the bundle was custom, and
no upstream alternative exists, a warning will be returned.

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>