### PR TITLE
Sensitively load groups.ini file

### DIFF
--- a/swupd/config.go
+++ b/swupd/config.go
@@ -113,7 +113,7 @@ func readGroupsINI(path string) ([]string, error) {
 		return nil, errors.New("no groups.ini file to define bundles")
 	}
 
-	cfg, err := ini.InsensitiveLoad(path)
+	cfg, err := ini.Load(path)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func readGroupsINI(path string) ([]string, error) {
 	osCoreFound := false
 	groups := []string{}
 	for _, section := range sections {
-		if section == "default" {
+		if section == "DEFAULT" {
 			// skip "default" set by go-ini/ini
 			continue
 		}

--- a/swupd/config_test.go
+++ b/swupd/config_test.go
@@ -43,7 +43,7 @@ func TestReadGroupsINI(t *testing.T) {
 		t.Error(err)
 	}
 
-	expected := []string{"os-core", "test-bundle", "test-bundle2"}
+	expected := []string{"os-core", "test-bundle", "Test-bundle2"}
 	if !reflect.DeepEqual(groups, expected) {
 		t.Errorf("groups %v did not match expected %v", groups, expected)
 	}

--- a/swupd/testdata/groups.ini
+++ b/swupd/testdata/groups.ini
@@ -4,5 +4,5 @@ group=os-core
 [test-bundle]
 group=test-bundle
 
-[test-bundle2]
-group=test-bundle2
+[Test-bundle2]
+group=Test-bundle2


### PR DESCRIPTION
Some bundles have uppercase letters in their names. DO NOT make these
lowercase - this has the result of a manifest not being generated for
them because it cannot find the chroot to walk.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>