### PR TITLE
New Command: Mixer bundle create

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -290,9 +290,16 @@ func Git(args ...string) error {
 
 // RunCommand runs the given command with args and prints output
 func RunCommand(cmdname string, args ...string) error {
+	return RunCommandInput(nil, cmdname, args...)
+}
+
+// RunCommandInput runs the given command with args and input from an io.Reader,
+// and prints output
+func RunCommandInput(in io.Reader, cmdname string, args ...string) error {
 	cmd := exec.Command(cmdname, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Stdin = in
 	err := cmd.Run()
 	if err != nil {
 		return errors.Wrapf(err, "Failed to run %s %s: %v\n", cmdname, strings.Join(args, " "), err)

--- a/mixer/cmd/bundles.go
+++ b/mixer/cmd/bundles.go
@@ -158,11 +158,54 @@ any errors are encountered earlier on.`,
 	},
 }
 
+// Bundle Edit command ('mixer bundle edit')
+type bundleCreateCmdFlags struct {
+	createOnly bool
+	add        bool
+	git        bool
+}
+
+var bundleCreateFlags bundleCreateCmdFlags
+
+var bundleCreateCmd = &cobra.Command{
+	Use:   "create [bundle(s)]",
+	Short: "Create custom local bundles",
+	Long: `Create custom local bundle definition files. This command will generate an
+empty bundle definition file template with the appropriate name in your
+local-bundles directory, and launch an editor to edit it. When the editor
+closes, the bundle file is then parsed for validity.
+
+The editor is configured via environment variables. VISUAL takes precedence to
+EDITOR. If neither are set, the tool defaults to nano. If nano is not installed,
+the tool will skip editing, and act as if '--create-only' had been passed.
+
+Passing '--create-only' will suppress launching the editor, and will thus only
+create the empty bundle template in local-bundles. This can be useful if you
+want to create a new bundle, but wish to edit it at a later time.
+
+Passing '--add' will also add the bundle(s) to your mix. Please note that
+bundles are added after all bundles are created, and thus will not be added if
+any errors are encountered earlier on.`,
+	Args: cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		b, err := builder.NewFromConfig(config)
+		if err != nil {
+			fail(err)
+		}
+
+		err = b.CreateBundles(args, bundleCreateFlags.createOnly, bundleCreateFlags.add, bundleCreateFlags.git)
+		if err != nil {
+			fail(err)
+		}
+	},
+}
+
 // List of all bundle commands
 var bundlesCmds = []*cobra.Command{
 	bundleAddCmd,
 	bundleListCmd,
 	bundleEditCmd,
+	bundleCreateCmd,
 }
 
 func init() {
@@ -181,4 +224,8 @@ func init() {
 	bundleEditCmd.Flags().BoolVar(&bundleEditFlags.copyOnly, "copy-only", false, "Suppress launching editor (only copy to local-bundles if upstream)")
 	bundleEditCmd.Flags().BoolVar(&bundleEditFlags.add, "add", false, "Add the bundle(s) to your mix")
 	bundleEditCmd.Flags().BoolVar(&bundleEditFlags.git, "git", false, "Automatically apply new git commit")
+
+	bundleCreateCmd.Flags().BoolVar(&bundleCreateFlags.createOnly, "create-only", false, "Suppress launching editor (only create empty template in local-bundles)")
+	bundleCreateCmd.Flags().BoolVar(&bundleCreateFlags.add, "add", false, "Add the bundle(s) to your mix")
+	bundleCreateCmd.Flags().BoolVar(&bundleCreateFlags.git, "git", false, "Automatically apply new git commit")
 }


### PR DESCRIPTION
**Note**: This PR is based on top of #155, because it uses the `EditBundles` function introduced there. **If you are reviewing code, please only review the new commit.**

-------

Create custom local bundle definition files. This command will generate an
empty bundle definition file template with the appropriate name in your
local-bundles directory, and launch an editor to edit it. When the editor
closes, the bundle file is then parsed for validity. If a bundle already exists
in local-bundles, it will be skipped.

The editor is configured via environment variables. VISUAL takes precedence to
EDITOR. If neither are set, the tool defaults to nano. If nano is not installed,
the tool will skip editing, and act as if '--create-only' had been passed.

Passing '--create-only' will suppress launching the editor, and will thus only
create the empty bundle template in local-bundles. This can be useful if you
want to create a new bundle, but wish to edit it at a later time.

Passing '--add' will also add the bundle(s) to your mix. Please note that
bundles are added after all bundles are created, and thus will not be added if
any errors are encountered earlier on.

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>