### PR TITLE
Use go-ini for builder.conf parsing

### DIFF
--- a/builder/mixconfig.go
+++ b/builder/mixconfig.go
@@ -1,0 +1,194 @@
+package builder
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/go-ini/ini"
+)
+
+// MixConfig represents the config parameters found in the builder config file.
+type MixConfig struct {
+	// [Builder]
+	BundleDir  string
+	Cert       string
+	StateDir   string
+	VersionDir string
+	YumConf    string
+
+	// [swupd]
+	Bundle     string
+	ContentURL string
+	Format     string
+	VersionURL string
+
+	// [Server]
+	DebugInfoBanned string
+	DebugInfoLib    string
+	DebugInfoSrc    string
+
+	// [Mixer]
+	LocalBundleDir string
+	RepoDir        string
+	RPMDir         string
+}
+
+type configPair struct {
+	key   string
+	value *string
+}
+
+type configMapping struct {
+	section string
+	pairs   []configPair
+}
+
+func (config *MixConfig) getMapping() []configMapping {
+	return []configMapping{
+		{
+			section: "Builder",
+			pairs: []configPair{
+				{key: "BUNDLE_DIR", value: &config.BundleDir},
+				{"CERT", &config.Cert},
+				{"SERVER_STATE_DIR", &config.StateDir},
+				{"VERSIONS_PATH", &config.VersionDir},
+				{"YUM_CONF", &config.YumConf},
+			}},
+		{
+			section: "swupd",
+			pairs: []configPair{
+				{"BUNDLE", &config.Bundle},
+				{"CONTENTURL", &config.ContentURL},
+				{"FORMAT", &config.Format},
+				{"VERSIONURL", &config.VersionURL},
+			}},
+		{
+			section: "Server",
+			pairs: []configPair{
+				{"debuginfo_banned", &config.DebugInfoBanned},
+				{"debuginfo_lib", &config.DebugInfoLib},
+				{"debuginfo_src", &config.DebugInfoSrc},
+			}},
+		{
+			section: "Mixer",
+			pairs: []configPair{
+				{"LOCAL_BUNDLE_DIR", &config.LocalBundleDir},
+				{"LOCAL_REPO_DIR", &config.RepoDir},
+				{"LOCAL_RPM_DIR", &config.RPMDir},
+			}},
+	}
+}
+
+func (config *MixConfig) mapToIni() (*ini.File, error) {
+	cfg := ini.Empty()
+
+	for _, entry := range config.getMapping() {
+		section, err := cfg.NewSection(entry.section)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, pair := range entry.pairs {
+			if _, err = section.NewKey(pair.key, *pair.value); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return cfg, nil
+}
+
+func (config *MixConfig) mapFromIni(cfg *ini.File) {
+	for _, entry := range config.getMapping() {
+		section, err := cfg.GetSection(entry.section)
+		if err != nil {
+			continue
+		}
+
+		for _, pair := range entry.pairs {
+			key, err := section.GetKey(pair.key)
+			if err == nil {
+				*pair.value = key.String()
+			}
+		}
+	}
+}
+
+// LoadDefaults sets sane defaults for all the config values in MixCOnfig
+func (config *MixConfig) LoadDefaults() error {
+	pwd, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+
+	// [Builder]
+	config.BundleDir = filepath.Join(pwd, "mix-bundles")
+	config.Cert = filepath.Join(pwd, "Swupd_Root.pem")
+	config.StateDir = filepath.Join(pwd, "update")
+	config.VersionDir = pwd
+	config.YumConf = filepath.Join(pwd, ".yum-mix.conf")
+
+	// [Swupd]
+	config.Bundle = "os-core-update"
+	config.ContentURL = "<URL where the content will be hosted>"
+	config.Format = "1"
+	config.VersionURL = "<URL where the version of the mix will be hosted>"
+
+	// [Server]
+	config.DebugInfoBanned = "true"
+	config.DebugInfoLib = "/usr/lib/debug"
+	config.DebugInfoSrc = "/usr/src/debug"
+
+	// [Mixer]
+	config.LocalBundleDir = filepath.Join(pwd, "local-bundles")
+	config.RPMDir = ""
+	config.RepoDir = ""
+
+	return nil
+}
+
+// CreateDefaultConfig creates a default builder.conf using the active
+// directory as base path for the variables values.
+func (config *MixConfig) CreateDefaultConfig(localrpms bool) error {
+	if err := config.LoadDefaults(); err != nil {
+		return err
+	}
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	builderconf := filepath.Join(pwd, "builder.conf")
+
+	if localrpms {
+		config.RPMDir = filepath.Join(pwd, "local-rpms")
+		config.RepoDir = filepath.Join(pwd, "local-yum")
+	}
+
+	fmt.Println("Creating new builder.conf configuration file...")
+
+	cfg, err := config.mapToIni()
+	if err != nil {
+		return err
+	}
+
+	return cfg.SaveTo(builderconf)
+}
+
+// LoadConfig loads a configuration file from a provided path or from local directory
+// is none is provided
+func (config *MixConfig) LoadConfig(filename string) error {
+	cfg, err := ini.InsensitiveLoad(filename)
+	if err != nil {
+		return err
+	}
+
+	//Expand Environment Variables
+	cfg.ValueMapper = os.ExpandEnv
+
+	config.mapFromIni(cfg)
+
+	return nil
+}

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -119,9 +119,6 @@ var initCmd = &cobra.Command{
 		if err := b.LoadBuilderConf(config); err != nil {
 			fail(err)
 		}
-		if err := b.ReadBuilderConf(); err != nil {
-			fail(err)
-		}
 		err := b.InitMix(initFlags.clearVer, strconv.Itoa(initFlags.mixver), initFlags.allLocal, initFlags.allUpstream, initFlags.upstreamURL, initFlags.git)
 		if err != nil {
 			fail(err)


### PR DESCRIPTION
So, to @cmarcelo 's delight, I ended up giving go-ini a shot.

This PR separates the all config related structures and functions into a new  `mixconfig.go` file, so if we ever decide to change to a new config system, there shouldn't be much impact in the rest of the code.

Some notes about this implementation:
- Go-Ini has a mapper to map a config file to a structure, but it can't be used in our case  due to a bunch of issues:
-- The section name has the name of a type structure, which means that for section Builder we need another Builder object. This would require moving mixconfig to a separate package to avoid conflict with the actual Builder structure
-- swupd section has lowercase name which mean a structure with that name would not be exported. Go-Ini ignores non-exported structures
-- None of the name converters worked in our case. One converter would have the key names match the variable name (e.g. RepoDir="" instead of REPO_DIR="") and the other would create some funny side effects (e.g. R_P_M_DIR="" instead of RPM_DIR="")
- In order to reduce the change, I embedded the MixConfig structure inside Builder. This is the less verbose solution, but it is simple to move it into its own variable if needed for clarity.
- I made this out of my frustration with viper in the past two days, so I haven't touched the swupd config APIs yet.

Some notes about why go-ini and not Viper:
Even though Viper is much simpler to use, it has so many small issues that at the end of the day it was not paying off. Here are a couple of issues I had with it:
- When loading keys, Viper expects it to be in the format Section.Key. It will pass that string to `ToLower()`, so both the section and the key will be lowercase. This makes the config file incompatible with other tools like 
`bundle-chroot-builder.py`, which expects the section `Builder` instead of `builder`.
- When saving string values, Viper will save them in the format `key="value"` but again it is incompatible with bcb since python's configparser expects it to be in the format `key=value` (no double quote)
- Viper does not work well with config files were the extension does not reflect its format and requires some workaround to deal with them (e.g. .conf instead of .toml)

Given that Viper also had a lot of dependencies (7 iirc), I decided to try and implement an alternative with go-ini using a similar structure to what I had done for viper.
