### PR TITLE
Mixer Bundle Add: List bundles as separate args

### DIFF
--- a/mixer/cmd/bundles.go
+++ b/mixer/cmd/bundles.go
@@ -15,8 +15,6 @@
 package cmd
 
 import (
-	"strings"
-
 	"github.com/clearlinux/mixer-tools/builder"
 
 	"github.com/pkg/errors"
@@ -39,28 +37,29 @@ type bundleAddCmdFlags struct {
 var bundleAddFlags bundleAddCmdFlags
 
 var bundleAddCmd = &cobra.Command{
-	Use:   "add [bundle(s)]",
+	Use:   "add <bundle> [<bundle>...]",
 	Short: "Add local or upstream bundles to your mix",
 	Long: `Adds local or upstream bundles to your mix by modifying the Mix Bundle List
 (stored in the 'mixbundles' file). The Mix Bundle List is parsed, the new
 bundles are confirmed to exist and are added, duplicates are removed, and the
 resultant list is written back out in sorted order.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		var bundles []string
 		if !bundleAddFlags.allLocal && !bundleAddFlags.allUpstream {
 			if len(args) == 0 {
 				return errors.New("bundle add requires at least 1 argument if neither --all-local nor --all-upstream are passed")
 			}
-			bundles = strings.Split(args[0], ",")
 		}
+
 		b, err := builder.NewFromConfig(config)
 		if err != nil {
 			fail(err)
 		}
-		err = b.AddBundles(bundles, bundleAddFlags.allLocal, bundleAddFlags.allUpstream, bundleAddFlags.git)
+
+		err = b.AddBundles(args, bundleAddFlags.allLocal, bundleAddFlags.allUpstream, bundleAddFlags.git)
 		if err != nil {
 			fail(err)
 		}
+
 		return nil
 	},
 }
@@ -75,7 +74,7 @@ type bundleRemoveCmdFlags struct {
 var bundleRemoveFlags bundleRemoveCmdFlags
 
 var bundleRemoveCmd = &cobra.Command{
-	Use:   "remove [bundle(s)]",
+	Use:   "remove <bundle> [<bundle>...]",
 	Short: "Remove bundles from your mix",
 	Long: `Removes bundles from your mix by modifying the Mix Bundle List
 (stored in the 'mixbundles' file). The Mix Bundle List is parsed, the bundles
@@ -164,7 +163,7 @@ type bundleEditCmdFlags struct {
 var bundleEditFlags bundleEditCmdFlags
 
 var bundleEditCmd = &cobra.Command{
-	Use:   "edit [bundle(s)]",
+	Use:   "edit <bundle> [<bundle>...]",
 	Short: "Edit local and upstream bundles, or create new bundles",
 	Long: `Edits local and upstream bundle definition files. This command will locate the
 bundle (looking first in local-bundles, then in upstream-bundles), and launch


### PR DESCRIPTION
When 'mixer add-bundle' was first introduced, the list of bundles
being added was implemented as a single-argument comma-separated
list. It is more intuitive to specify bundles as separate arguments,
and this is the format all of the new 'mixer bundle ___' commands are
taking. (This also simplifies forthcoming mixer autocomplete code.)

This patch changes 'mixer bundle add' to support this new usage.
To make it more clear how bundles are to be specified, the "Usage"
string of help output has been updated for all commands to comply with
more standard conventions. The output now uses square brackets to
indicate optional elements, ellipses to indicate optional expansion,
and angle brackets to indicate variables as opposed to literal constants.
For example:

`Usage: mixer bundle add <bundle> [<bundle>...] [flags]`

and

`Usage: mixer bundle list [mix|local|upstream] [flags]`

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>