### PR TITLE
New Command: mixer bundle validate

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -560,6 +560,13 @@ func (b *Builder) getBundleFromName(name string) (*bundle, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err = validateBundle(bundle, BasicValidation); err != nil {
+		return nil, err
+	}
+	if err = validateBundleFileName(name, bundle); err != nil {
+		return nil, err
+	}
+
 	return bundle, nil
 }
 
@@ -1026,7 +1033,7 @@ editLoop:
 		// Ignore return from command; parsing below is what will reveal errors
 		_ = helpers.RunCommandInput(os.Stdin, editorCmd, path)
 
-		_, err := parseBundleFile(path)
+		err := validateBundleFile(path, BasicValidation)
 		if err == nil {
 			// Clean-up backup
 			if err = os.Remove(backup); err != nil {
@@ -1146,6 +1153,42 @@ func (b *Builder) EditBundles(bundles []string, suppressEditor bool, add bool, g
 		if err := helpers.Git("commit", "-q", "-m", commitMsg); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+// ValidateLocalBundles runs bundle parsing validation on all local bundles.
+func (b *Builder) ValidateLocalBundles(lvl ValidationLevel) error {
+	files, err := ioutil.ReadDir(b.LocalBundleDir)
+	if err != nil {
+		return errors.Wrap(err, "Failed to read local-bundles")
+	}
+
+	bundles := make([]string, len(files))
+	for i, file := range files {
+		bundles[i] = file.Name()
+	}
+
+	return b.ValidateBundles(bundles, lvl)
+}
+
+// ValidateBundles runs bundle parsing validation on a list of local bundles. In
+// addition to parsing errors, errors are generated if the bundle is not found
+// in local-bundles.
+func (b *Builder) ValidateBundles(bundles []string, lvl ValidationLevel) error {
+	invalid := false
+	for _, bundle := range bundles {
+		path := filepath.Join(b.LocalBundleDir, bundle)
+
+		if err := validateBundleFile(path, lvl); err != nil {
+			invalid = true
+			fmt.Printf("Invalid: %q:\n%s\n\n", bundle, err)
+		}
+	}
+
+	if invalid {
+		return errors.New("Invalid bundles found")
 	}
 
 	return nil


### PR DESCRIPTION
New command checks local bundle definition files for validity as a separate step. While
'mixer bundle edit' will automatically validate bundles as you edit them, it can
be useful to manually run this validation step on bundles you have previously
written, or have edited using a different tool. Only local bundle files are
checked; upstream bundles are trusted as valid. Valid bundles yield no output.
Any invalid bundles will yield a non-zero return code.

An optional '--strictness-level' flag allows you to control how strictly bundles
are checked. All levels check basic syntax and structure.
  low:   Check file name and bundle Title match and are valid bundle names
  med:   All of 'low', plus check Description and Maintainer are non-empty
  high:  All of 'med', plus check Status and Capabilities are non-empty

Passing '--all-local' will run validation on all bundles in local-bundles.

This patch also adds tests to check that bundle header parsing is working
and that different types of validation errors are indeed being caught, and calls
the new validation command in a few new places.

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>