### PR TITLE
mixer: add --report flag to build delta-packs

### DIFF
--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -188,6 +188,7 @@ var buildDeltaPacksFlags struct {
 	previousVersions uint32
 	from             uint32
 	to               uint32
+	report           bool
 }
 
 func runBuildDeltaPacks(cmd *cobra.Command, args []string) error {
@@ -208,9 +209,9 @@ func runBuildDeltaPacks(cmd *cobra.Command, args []string) error {
 		fail(err)
 	}
 	if fromChanged {
-		err = b.BuildDeltaPacks(buildDeltaPacksFlags.from, buildDeltaPacksFlags.to)
+		err = b.BuildDeltaPacks(buildDeltaPacksFlags.from, buildDeltaPacksFlags.to, buildDeltaPacksFlags.report)
 	} else {
-		err = b.BuildDeltaPacksPreviousVersions(buildDeltaPacksFlags.previousVersions, buildDeltaPacksFlags.to)
+		err = b.BuildDeltaPacksPreviousVersions(buildDeltaPacksFlags.previousVersions, buildDeltaPacksFlags.to, buildDeltaPacksFlags.report)
 	}
 	if err != nil {
 		fail(err)
@@ -253,6 +254,7 @@ func init() {
 	buildDeltaPacksCmd.Flags().Uint32Var(&buildDeltaPacksFlags.from, "from", 0, "Generate packs from a specific version")
 	buildDeltaPacksCmd.Flags().Uint32Var(&buildDeltaPacksFlags.previousVersions, "previous-versions", 0, "Generate packs for multiple previous versions")
 	buildDeltaPacksCmd.Flags().Uint32Var(&buildDeltaPacksFlags.to, "to", 0, "Generate packs targeting a specific version")
+	buildDeltaPacksCmd.Flags().BoolVar(&buildDeltaPacksFlags.report, "report", false, "Report reason each file in to manifest was packed or not")
 
 	setUpdateFlags(buildUpdateCmd)
 	setUpdateFlags(buildAllCmd)


### PR DESCRIPTION
If flag is passed we print the report with all the files in the
manifest and whether they were included or not. The report stays right
above the count of fullfiles and deltas.

The output looks like (modified to fit in the commit message):

Creating delta packs from 10 to 20
  Creating delta pack for bundle caio from 10 to 20
    Pack report:
      /usr/bin/2to3                      packed fullfile (from chroot)
      /usr/bin/c_hash                    not packed (already in from manifest)
      /usr/bin/clrtrust                  not packed (already in from manifest)
      /usr/bin/corelist                  not packed (already in from manifest)
      /usr/bin/cpan                      not packed (already in from manifest)
      /usr/bin/ebrowse                   not packed (file deleted)
      /usr/bin/emacs                     not packed (file deleted)

(...)

  Creating delta pack for bundle os-core-update-index from 10 to 20
    Pack report:
      /usr/share/clear/os-core-update-index packed delta (10-20-3a480a802244c61eefd24009b0b24d1ba6d822aa4358ef51bfd4492244589a5e-74fba7851c7bb474588f0321fe4715c8e6f83bba8889cc917f6a0490f3a777b7)

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>