### PR TITLE
swupd: don't pack fullfiles if delta already available

### DIFF
--- a/swupd/delta_test.go
+++ b/swupd/delta_test.go
@@ -74,7 +74,10 @@ func TestNoDeltasForTypeChangesOrDereferencedSymlinks(t *testing.T) {
 
 	mustHaveNoWarnings(t, info)
 	mustHaveDeltaCount(t, info, 3)
-	mustHaveFullfileCount(t, info, 5)
+
+	// NOTE: This was 5 for old swupd-server, but the new code doesn't pack a fullfile
+	// if a delta already targets that file.
+	mustHaveFullfileCount(t, info, 4)
 
 	// Check that only the regular file to regular file deltas exist.
 	{

--- a/swupd/packs.go
+++ b/swupd/packs.go
@@ -170,7 +170,7 @@ func WritePack(w io.Writer, fromManifest, toManifest *Manifest, outputDir, chroo
 	}
 
 	// Add all deltas that have not failed.
-	hasDelta := make(map[*File]*Delta)
+	hasDelta := make(map[Hashval]*Delta)
 	for i := range deltas {
 		d := &deltas[i]
 		if d.Error != nil {
@@ -190,7 +190,7 @@ func WritePack(w io.Writer, fromManifest, toManifest *Manifest, outputDir, chroo
 		}
 
 		info.DeltaCount++
-		hasDelta[d.to] = d
+		hasDelta[d.to.Hash] = d
 	}
 
 	// TODO: In some cases we could be packing both a delta and the fullfile. Should
@@ -205,7 +205,7 @@ func WritePack(w io.Writer, fromManifest, toManifest *Manifest, outputDir, chroo
 			entry.Reason = "already in from manifest"
 			continue
 		}
-		if delta, ok := hasDelta[f]; ok {
+		if delta, ok := hasDelta[f.Hash]; ok {
 			entry.State = PackedDelta
 			entry.Reason = filepath.Base(delta.Path)
 			continue


### PR DESCRIPTION
This is different than the old swupd-server. Added a note to the
imported test.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>