### PR TITLE
Only unset file type when deprecating rename-from files

### DIFF
--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -542,7 +542,9 @@ func deprecateOldRenames(oldRenames []*File) {
 	for _, f := range oldRenames {
 		if f.DeltaPeer == nil {
 			f.Rename = false
-			f.Type = TypeUnset
+			if !f.Present() {
+				f.Type = TypeUnset
+			}
 			f.Hash = 0
 		}
 	}


### PR DESCRIPTION
Unsetting the rename-to file type causes a file with no flags set (e.g.
....).  Do not unset the file type when deprecating a rename-to file,
(e.g. F..r). Only unset the file type when deprecating a rename-from
file (e.g. .d.r).

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>