### PR TITLE
Add `--chroot-workers` to build command

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -80,6 +80,7 @@ type Builder struct {
 
 	NumFullfileWorkers int
 	NumDeltaWorkers    int
+	NumChrootWorkers   int
 }
 
 // New will return a new instance of Builder with some predetermined sane

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -39,6 +39,7 @@ type buildCmdFlags struct {
 
 	numFullfileWorkers int
 	numDeltaWorkers    int
+	numChrootWorkers   int
 }
 
 var buildFlags buildCmdFlags
@@ -55,6 +56,11 @@ func setWorkers(b *builder.Builder) {
 		workers = runtime.NumCPU()
 	}
 	b.NumDeltaWorkers = workers
+	workers = buildFlags.numChrootWorkers
+	if workers < 1 {
+		workers = runtime.NumCPU()
+	}
+	b.NumChrootWorkers = workers
 }
 
 // buildCmd represents the base build command when called without any subcommands
@@ -268,6 +274,7 @@ func init() {
 
 	buildCmd.PersistentFlags().IntVar(&buildFlags.numFullfileWorkers, "fullfile-workers", 0, "Number of parallel workers when creating fullfiles, 0 means number of CPUs")
 	buildCmd.PersistentFlags().IntVar(&buildFlags.numDeltaWorkers, "delta-workers", 0, "Number of parallel workers when creating deltas, 0 means number of CPUs")
+	buildCmd.PersistentFlags().IntVar(&buildFlags.numChrootWorkers, "chroot-workers", 0, "Number of parallel workers when creating chroots, 0 means number of CPUs")
 	RootCmd.AddCommand(buildCmd)
 
 	buildChrootsCmd.Flags().BoolVar(&buildFlags.noSigning, "no-signing", false, "Do not generate a certificate to sign the Manifest.MoM")


### PR DESCRIPTION
By default, do the same as BCB and use NumCPUs. After this commit our `--new-chroots` should be on par with BCB.

This PR is for the last commit. The others are part of #182.