### PR TITLE
swupd: return information about fullfile creation

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -1504,11 +1504,21 @@ func (b *Builder) buildUpdateWithNewSwupd(timer *stopWatch, mixVersion uint32, m
 	timer.Start("CREATE FULLFILES")
 	fullfilesDir := filepath.Join(outputDir, b.MixVer, "files")
 	fullChrootDir := filepath.Join(b.StateDir, "image", b.MixVer, "full")
-	// TODO: CreateFullfiles should return us feedback on what was
-	// done so we can report here.
-	err = swupd.CreateFullfiles(mom.FullManifest, fullChrootDir, fullfilesDir)
+	info, err := swupd.CreateFullfiles(mom.FullManifest, fullChrootDir, fullfilesDir)
 	if err != nil {
 		return err
+	}
+	// Print summary of fullfile generation.
+	{
+		total := info.Skipped + info.NotCompressed
+		fmt.Printf("- Already created: %d\n", info.Skipped)
+		fmt.Printf("- Not compressed:  %d\n", info.NotCompressed)
+		fmt.Printf("- Compressed\n")
+		for k, v := range info.CompressedCounts {
+			total += v
+			fmt.Printf("  - %-20s %d\n", k, v)
+		}
+		fmt.Printf("Total fullfiles: %d\n", total)
 	}
 	timer.Stop()
 

--- a/swupd/cmd/create-fullfiles/main.go
+++ b/swupd/cmd/create-fullfiles/main.go
@@ -79,7 +79,7 @@ func main() {
 	}
 
 	log.Printf("Output directory: %s", *outputDir)
-	err = swupd.CreateFullfiles(m, chrootDir, *outputDir)
+	_, err = swupd.CreateFullfiles(m, chrootDir, *outputDir)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/swupd/fullfiles_test.go
+++ b/swupd/fullfiles_test.go
@@ -107,7 +107,7 @@ func TestCreateFullfiles(t *testing.T) {
 		m.Files = append(m.Files, f)
 	}
 
-	err = CreateFullfiles(m, chrootDir, outputDir)
+	_, err = CreateFullfiles(m, chrootDir, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -679,7 +679,7 @@ func (ts *testSwupd) createFullfiles(version uint32) {
 	}
 	chrootDir := ts.path(filepath.Join("image", fmt.Sprint(version), "full"))
 	outputDir := ts.path(filepath.Join("www", fmt.Sprint(version), "files"))
-	err = CreateFullfiles(m, chrootDir, outputDir)
+	_, err = CreateFullfiles(m, chrootDir, outputDir)
 	if err != nil {
 		ts.t.Fatalf("couldn't create fullfiles: %s", err)
 	}

--- a/swupd/packs_test.go
+++ b/swupd/packs_test.go
@@ -487,7 +487,7 @@ func mustHaveNoWarnings(t *testing.T, info *PackInfo) {
 
 func mustCreateFullfiles(t *testing.T, m *Manifest, chrootDir, outputDir string) {
 	t.Helper()
-	err := CreateFullfiles(m, chrootDir, outputDir)
+	_, err := CreateFullfiles(m, chrootDir, outputDir)
 	if err != nil {
 		t.Fatalf("couldn't create fullfiles: %s", err)
 	}


### PR DESCRIPTION
Fix an old TODO, this gives visibility in every build about the
compression algorithms being used.

Note the accounting "gzip" (and not "external-gzip") because at the
moment it is being used for links and directories. It probably should
just migrate to use the external gzip later.

```
Output looks like:

=> CREATE FULLFILES
- Already created: 0
- Not compressed:  0
- Compressed
  - external-bzip2       40
  - gzip                 389
  - external-xz          2520
  - external-gzip        953
Total fullfiles: 3902
```

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>