### PR TITLE
mixer: add a default value for mix version in init

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -238,6 +238,8 @@ func (b *Builder) InitMix(upstreamVer string, mixVer string, allLocal bool, allU
 		upstreamVer = ver
 	}
 
+	fmt.Printf("Initializing mix version %s from upstream version %s\n", mixVer, upstreamVer)
+
 	// Deprecate '.clearversion' --> 'upstreamversion'
 	if _, err := os.Stat(filepath.Join(b.VersionDir, ".clearversion")); err == nil {
 		b.UpstreamVerFile = ".clearversion"

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -153,14 +153,11 @@ func init() {
 	initCmd.Flags().BoolVar(&initFlags.allLocal, "all-local", false, "Initialize mix with all local bundles automatically included")
 	initCmd.Flags().BoolVar(&initFlags.allUpstream, "all-upstream", false, "Initialize mix with all upstream bundles automatically included")
 	initCmd.Flags().StringVar(&initFlags.clearVer, "clear-version", "latest", "Supply the Clear version to compose the mix from")
-	initCmd.Flags().IntVar(&initFlags.mixver, "mix-version", 0, "Supply the Mix version to build")
+	initCmd.Flags().IntVar(&initFlags.mixver, "mix-version", 10, "Supply the Mix version to build")
 	initCmd.Flags().BoolVar(&initFlags.localRPMs, "local-rpms", false, "Create and configure local RPMs directories")
 	initCmd.Flags().StringVar(&config, "config", "", "Supply a specific builder.conf to use for mixing")
 	initCmd.Flags().StringVar(&initFlags.upstreamURL, "upstream-url", "https://download.clearlinux.org", "Supply an upstream URL to use for mixing")
 	initCmd.Flags().BoolVar(&initFlags.git, "git", false, "Track mixer's internal work dir with git")
-
-	// mark required flags
-	_ = cobra.MarkFlagRequired(initCmd.Flags(), "mix-version")
 
 	externalDeps[initCmd] = []string{
 		"git",


### PR DESCRIPTION
And print the versions being used.

Fixes #123. (in combination with #153 that was already merged)

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>