### PR TITLE
Perform Lstat instead of Stat on rename files

### DIFF
--- a/swupd/rename.go
+++ b/swupd/rename.go
@@ -188,7 +188,7 @@ func fixupStatFields(needed []*File, m *Manifest, c *config) error {
 			bundleChroot = filepath.Join(c.imageBase, fmt.Sprint(m.Header.Previous), "full")
 		}
 		path := filepath.Join(bundleChroot, needed[i].Name)
-		fi, err := os.Stat(path)
+		fi, err := os.Lstat(path)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
We want information about the link, not the linked file, when doing a
stat on files in the update. The File.Info field holds FileInfo about
the file, not the linked file.

Doing a 'Stat' instead of an 'Lstat' caused an issue where a link was
changed in an update but the target file was not. The target file
therefore did not exist in the full chroot for that update. Performing a
'Stat' caused a panic because the target file could not be found.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>