### PR TITLE
Keep yum cache around when building mixes

### DIFF
--- a/yum.conf.in
+++ b/yum.conf.in
@@ -1,6 +1,6 @@
 [main]
 cachedir=/var/cache/yum/clear/
-keepcache=0
+keepcache=1
 debuglevel=2
 logfile=/var/log/yum.log
 exactarch=1


### PR DESCRIPTION
This helps when doing more than one mix back-to-back or when packages
are installed in more than one bundle.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>