### PR TITLE
Add mixer bash and zsh completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,13 @@ endif
 
 build: gopath
 	go install ${GO_PACKAGE_PREFIX}/mixer
+	go install ${GO_PACKAGE_PREFIX}/mixer-completion
 
 install: gopath
 	test -d $(DESTDIR)/usr/bin || install -D -d -m 00755 $(DESTDIR)/usr/bin;
 	install -m 00755 $(GOPATH)/bin/mixer $(DESTDIR)/usr/bin/.
+	$(GOPATH)/bin/mixer-completion bash
+	$(GOPATH)/bin/mixer-completion zsh
 	install -m 00755 pack-maker.sh $(DESTDIR)/usr/bin/mixer-pack-maker.sh
 	install -m 00755 superpack-maker.sh $(DESTDIR)/usr/bin/mixer-superpack-maker.sh
 	install -D -m 00644 yum.conf.in $(DESTDIR)/usr/share/defaults/mixer/yum.conf.in

--- a/mixer-completion/cmd/completion.go
+++ b/mixer-completion/cmd/completion.go
@@ -1,0 +1,68 @@
+// Copyright © 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"errors"
+	"os"
+
+	mixerCmd "github.com/clearlinux/mixer-tools/mixer/cmd"
+	"github.com/spf13/cobra"
+)
+
+// CompletionCmd represents the base command for mixer-completion
+var CompletionCmd = &cobra.Command{
+	Use:   "mixer-completion",
+	Short: "Generate autocomplete files for mixer",
+	Long: `Generates autocomplete files for mixer. If no arguments are passed, or if
+'bash' is passed, a bash completion file is written to /etc/bash_completion.d/.
+If 'zsh' is passed, a zsh completion file is written to
+/usr/share/zsh/site-functions/.
+
+These files allow you to type, for example:
+  mixer bun[TAB] -> mixer bundle a[TAB] -> mixer bundle add
+
+Note that this command must be run as root.`,
+	Args:      cobra.OnlyValidArgs,
+	ValidArgs: []string{"bash", "zsh"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 1 {
+			return errors.New("mixer-completion takes at most one argument")
+		}
+
+		var shell string
+		if len(args) > 0 {
+			shell = args[0]
+		} else {
+			shell = "bash"
+		}
+
+		var err error
+		switch shell {
+		case "bash":
+			if err = os.MkdirAll("/usr/share/bash-completion/completions", 0755); err != nil {
+				return err
+			}
+			err = mixerCmd.RootCmd.GenBashCompletionFile("/usr/share/bash-completion/completions/mixer")
+		case "zsh":
+			if err = os.MkdirAll("/usr/share/zsh/site-functions", 0755); err != nil {
+				return err
+			}
+			err = mixerCmd.RootCmd.GenZshCompletionFile("/usr/share/zsh/site-functions/_mixer")
+		}
+
+		return err
+	},
+}

--- a/mixer-completion/main.go
+++ b/mixer-completion/main.go
@@ -1,0 +1,27 @@
+// Copyright © 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+
+	"github.com/clearlinux/mixer-tools/mixer-completion/cmd"
+)
+
+func main() {
+	if err := cmd.CompletionCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Please see #77 (as well as the commit message below) for info on why I implemented this as a separate executable, and what the alternatives were.

Please also note that, as addressed in #77, this only implements _basic_ completion, which includes all of mixer's subcommands and their flags (and known valid arguments for some commands, like `mixer bundle list`). More sophisticated completion (e.g., `mixer bundle add ed[TAB] --> mixer bundle add editors`) is also possible, but will be added on a command-by-command basis.

----

This patch introduces a new `mixer-completion` executable that generates `bash`
and `zsh` completion files for `mixer`. The executable is built via `make`, but not
installed via `make install`. Instead, `make install` runs the executable,
which writes the `bash` and `zsh` completion files to `/etc/bash_completion.d/` and
`/usr/share/zsh/site-functions/`, respectively.

This patch uses Cobra's built-in `bash`/`zsh` completion generation functionality.
Some Cobra applications choose to have this completion-file generation as a
permanent command off the root command (e.g., `kubectl completion bash`). This
patch makes this a stand-alone executable to avoid cluttering the main `mixer`
tool with this functionality. Many Cobra applications also leave creating/
installing these completion files up to the user as a manual, secondary step.
This patch completes these tasks at mixer install time.

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>