### PR TITLE
swupd: Do not track ContentSize for subtracted files

### DIFF
--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -478,7 +478,7 @@ func TestContentSizeAcrossVersionsIncludes(t *testing.T) {
 	fullSize := manifests["full"].Header.ContentSize
 
 	checkSize(manifests["test-bundle1"], 4+7+emptySize)
-	checkSize(manifests["test-bundle2"], 5+emptySize)
+	checkSize(manifests["test-bundle2"], 5) // emptySize subtracted out
 
 	// Check that content size does add files from previous updates.
 	ts.copyChroots(10, 20)
@@ -490,7 +490,7 @@ func TestContentSizeAcrossVersionsIncludes(t *testing.T) {
 	manifests = mustParseAllManifests(t, 20, ts.path("www"))
 
 	checkSize(manifests["test-bundle1"], 4+7+10+emptySize)
-	checkSize(manifests["test-bundle2"], 5+8+emptySize)
+	checkSize(manifests["test-bundle2"], 5+8) // emptySize subtracted out
 
 	// os-core should have the same size as before.
 	checkSize(manifests["os-core"], osCoreSize)

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -757,6 +757,7 @@ func (m *Manifest) subtractManifestFromManifest(m2 *Manifest) {
 				// this is expensive because we care about order at this point
 				m.Files = append(m.Files[:i], m.Files[i+1:]...)
 				m.Header.FileCount--
+				m.Header.ContentSize -= uint64(f1.Info.Size())
 			}
 
 			// only need to advance the m2.Files index since i now points to the next


### PR DESCRIPTION
When files are subtracted from the manifest also subtract the size of
the file from manifest.Header.ContentSize. This makes the ContentSize
field only reflect the size of the files listed in the current manifest
and not subtracted files. One can then calculate the complete installed
size of that bundle by adding the ContentSize of all the includes
because there will be no overlap from subtracted files.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>