### PR TITLE
Fix manifest 'previous' header for minversions

### DIFF
--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -147,6 +147,7 @@ func processBundles(ui UpdateInfo, c config) ([]*Manifest, error) {
 		if ver == 0 {
 			ver = ui.lastVersion
 		}
+		bundle.Header.Previous = ver
 
 		oldMPath := filepath.Join(c.outputDir, fmt.Sprint(ver), "Manifest."+bundle.Name)
 		oldM := getOldManifest(oldMPath)
@@ -204,6 +205,10 @@ func CreateManifests(version uint32, minVersion uint32, format uint, statedir st
 	lastVersion, err = readLastVerFile(filepath.Join(c.imageBase, "LAST_VER"))
 	if err != nil {
 		return nil, err
+	}
+
+	if minVersion > lastVersion {
+		lastVersion = minVersion
 	}
 
 	oldFullManifestPath := filepath.Join(c.outputDir, fmt.Sprint(lastVersion), "Manifest.full")

--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -412,6 +412,7 @@ func TestCreateManifestsMinVersion(t *testing.T) {
 
 	// since the minVersion was set to this version the file version should
 	// be updated despite there being no change to the file.
+	ts.checkContains("www/20/Manifest.test-bundle", "previous:\t20")
 	ts.checkContains("www/20/Manifest.test-bundle", "20\t/foo\n")
 	ts.checkContains("www/20/Manifest.full", "20\t/foo\n")
 	ts.checkNotContains("www/20/Manifest.test-bundle", "10\t/foo\n")

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -571,7 +571,7 @@ func (fs *testFileSystem) checkNotContains(subpath, sub string) {
 		fs.t.Errorf("couldn't open %s to check its contents: %s", subpath, err)
 	}
 	if bytes.Contains(contents, []byte(sub)) {
-		fs.t.Errorf("%s did not contain expected %q", subpath, sub)
+		fs.t.Errorf("%s contained unexpected %q", subpath, sub)
 	}
 }
 

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -375,9 +375,6 @@ func (m *Manifest) sortFilesVersionName() {
 // if the file in the oldManifest is not deleted or ghosted.
 // Expects m and oldManifest files lists to be sorted by name only
 func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, c config, minVersion uint32) (int, int, int) {
-	// set previous version to oldManifest version
-	m.Header.Previous = oldManifest.Header.Version
-
 	var changed, removed, added []*File
 	nx := 0 // new manifest file index
 	ox := 0 // old manifest file index


### PR DESCRIPTION
The 'previous' header for a minversion manifest should be set to itself
instead of the usual previous manifest.

Also fix test error wording.