### PR TITLE
 Add a default value for LOCAL_BUNDLE_DIR

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -356,7 +356,7 @@ func (b *Builder) ReadBuilderConf() error {
 		{`^CERT\s*=\s*`, &b.Cert, true},
 		{`^CLEARVER\s*=\s*`, &b.UpstreamVer, false},
 		{`^FORMAT\s*=\s*`, &b.Format, true},
-		{`^LOCAL_BUNDLE_DIR\s*=\s*`, &b.LocalBundleDir, true},
+		{`^LOCAL_BUNDLE_DIR\s*=\s*`, &b.LocalBundleDir, false},
 		{`^MIXVER\s*=\s*`, &b.MixVer, false},
 		{`^LOCAL_REPO_DIR\s*=\s*`, &b.RepoDir, false},
 		{`^LOCAL_RPM_DIR\s*=\s*`, &b.RPMDir, false},
@@ -393,6 +393,16 @@ func (b *Builder) ReadBuilderConf() error {
 
 			return errors.Errorf("buildconf missing entry for variable: %s", missing)
 		}
+	}
+
+	if b.LocalBundleDir == "" {
+		pwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		b.LocalBundleDir = filepath.Join(pwd, "local-bundles")
+		fmt.Printf("WARNING: LOCAL_BUNDLE_DIR not found in builder.conf. Falling back to %q.\n", b.LocalBundleDir)
+		fmt.Println("Please set this value to the location you want local bundle definition files to be stored.")
 	}
 
 	return nil

--- a/mixer-completion/cmd/completion.go
+++ b/mixer-completion/cmd/completion.go
@@ -29,7 +29,6 @@ type completionCmdFlags struct {
 
 var completionFlags completionCmdFlags
 
-
 // CompletionCmd represents the base command for mixer-completion
 var CompletionCmd = &cobra.Command{
 	Use:   "mixer-completion",


### PR DESCRIPTION
`LOCAL_BUNDLE_DIR` is a new `builder.conf` field introduced in mixer 4.0. It is included in the auto-generated conf from `mixer init`, and it is referenced in the updated documentation (tbd).

Previously, however, it was marked as a "required" flag in the `ReadBuilderConf` function. This meant that existing users, who did not already have this value, were given an error message saying it was
missing, but no useful information about how to fix this.

This patch provides default fall-back value of the user's `PWD + "/local-bundles"` if the field is missing. If this happens, a warning message is output, informing the user to update their conf.

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>