### PR TITLE
Add an "offline" mode for mixer

### DIFF
--- a/mixer-completion/cmd/completion.go
+++ b/mixer-completion/cmd/completion.go
@@ -29,7 +29,6 @@ type completionCmdFlags struct {
 
 var completionFlags completionCmdFlags
 
-
 // CompletionCmd represents the base command for mixer-completion
 var CompletionCmd = &cobra.Command{
 	Use:   "mixer-completion",

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -146,6 +146,8 @@ func init() {
 	// TODO: Remove this once we migrate to new implementation.
 	RootCmd.PersistentFlags().BoolVar(&builder.UseNewSwupdServer, "new-swupd", false, "EXPERIMENTAL: Use new implementation of swupd-server when possible")
 
+	RootCmd.PersistentFlags().BoolVar(&builder.Offline, "offline", false, "Skip caching upstream-bundles; work entirely with local-bundles")
+
 	RootCmd.AddCommand(initCmd)
 	RootCmd.Flags().BoolVar(&rootCmdFlags.version, "version", false, "Print version information and quit")
 	RootCmd.Flags().BoolVar(&rootCmdFlags.check, "check", false, "Check all dependencies needed by mixer and quit")


### PR DESCRIPTION
This patch adds a persistent `--offline` flag to the top-level mixer
command, which means every command can pass this flag to make mixer
work offline.

When mixer works offline, it skips caching upstream bundle definition
files. This has the implication that every bundle in the user's mix
must be available in `local-bundles`.

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>