### PR TITLE
Fix Mix Bundle List file bug

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -602,7 +602,7 @@ func (b *Builder) getBundleFromName(name string) (*bundle, error) {
 func (b *Builder) getMixBundlesListAsSet() (bundleSet, error) {
 	set := make(bundleSet)
 
-	bundles, err := helpers.ReadFileAndSplit(b.MixBundlesFile)
+	bundles, err := helpers.ReadFileAndSplit(filepath.Join(b.VersionDir, b.MixBundlesFile))
 	if os.IsNotExist(err) {
 		return set, nil
 	} else if err != nil {
@@ -649,7 +649,7 @@ func (b *Builder) getDirBundlesListAsSet(dir string) (bundleSet, error) {
 // List file. Values will be in sorted order.
 func (b *Builder) writeMixBundleList(set bundleSet) error {
 	data := []byte(strings.Join(getBundleSetKeysSorted(set), "\n"))
-	if err := ioutil.WriteFile(b.MixBundlesFile, data, 0644); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(b.VersionDir, b.MixBundlesFile), data, 0644); err != nil {
 		return errors.Wrap(err, "Failed to write out Mix Bundle List")
 	}
 	return nil

--- a/mixer-completion/cmd/completion.go
+++ b/mixer-completion/cmd/completion.go
@@ -29,7 +29,6 @@ type completionCmdFlags struct {
 
 var completionFlags completionCmdFlags
 
-
 // CompletionCmd represents the base command for mixer-completion
 var CompletionCmd = &cobra.Command{
 	Use:   "mixer-completion",


### PR DESCRIPTION
Fixes a bug in the location for where the Mix Bundle List
(stored in the 'mixbundles' file) is read/write during 'mixer
bundle add' and 'mixer bundle remove' commands.

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>