### PR TITLE
Mixer bundle basic validation change

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -604,10 +604,7 @@ func (b *Builder) getBundleFromName(name string) (*bundle, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = validateBundle(bundle, BasicValidation); err != nil {
-		return nil, err
-	}
-	if err = validateBundleFileName(name, bundle); err != nil {
+	if err = validateBundleFilename(path); err != nil {
 		return nil, err
 	}
 

--- a/mixer/cmd/bundles.go
+++ b/mixer/cmd/bundles.go
@@ -213,12 +213,13 @@ var bundleValidateCmd = &cobra.Command{
 checked; upstream bundles are trusted as valid. Valid bundles yield no output.
 Any invalid bundles will yield a non-zero return code.
 
-Basic validation includes checking syntax and structure, that the bundle has
-a valid name, and that the header 'Title' matches the bundle filename. Commands
-like 'mixer bundle edit' run basic validation automatically.
+Basic validation includes checking syntax and structure, and that the bundle has
+a valid name. Commands like 'mixer bundle edit' run basic validation
+automatically.
 
-An optional '--strict' flag allows you to additionally check that the other
-bundle header flags are parsable and non-empty.
+An optional '--strict' flag allows you to additionally check that the bundle 
+header fields are parsable and non-empty, and that the header 'Title' is itself
+valid and matches the bundle filename.
 
 Passing '--all-local' will run validation on all bundles in local-bundles.`,
 	RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Previously, "basic" bundle validation included checking that the
bundle filename (currently used as the "bundle name") matched the
"Title" field in the bundle header (currently not used), and that
the "Title" field itself was valid. This was a step toward future
usage, where mixer will use the header "Title" itself.

This caused mixer to be incompatible with previous versions of CLR,
for which these filename-to-title missmatches were allowed and thus
present.

This patch moves this checking exclusively to "--strict" validation,
and removes bundle content validation from "basic" altogether. Basic
validation now only checks that the bundle filename is valid and that
the bundle contents syntax can be parsed.

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>