### PR TITLE
Update 'mixer bundle add' to skip existing bundles

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -738,6 +738,11 @@ func (b *Builder) AddBundles(bundles []string, allLocal bool, allUpstream bool, 
 
 	// Add the ones passed in to the set
 	for _, bName := range bundles {
+		if _, exists := set[bName]; exists {
+			fmt.Printf("Bundle %s already in mix; skipping\n", bName)
+			continue
+		}
+
 		bundle, err := b.getBundleFromName(bName)
 		if err != nil {
 			return err
@@ -758,6 +763,11 @@ func (b *Builder) AddBundles(bundles []string, allLocal bool, allUpstream bool, 
 		}
 
 		for _, bundle := range localSet {
+			if _, exists := set[bundle.Name]; exists {
+				fmt.Printf("Bundle %s already in mix; skipping\n", bundle.Name)
+				continue
+			}
+
 			set[bundle.Name] = bundle
 			fmt.Printf("Adding bundle %s from local bundles\n", bundle.Name)
 		}
@@ -772,6 +782,11 @@ func (b *Builder) AddBundles(bundles []string, allLocal bool, allUpstream bool, 
 		}
 
 		for _, bundle := range upstreamSet {
+			if _, exists := set[bundle.Name]; exists {
+				fmt.Printf("Bundle %s already in mix; skipping\n", bundle.Name)
+				continue
+			}
+
 			set[bundle.Name] = bundle
 			fmt.Printf("Adding bundle %s from upstream bundles\n", bundle.Name)
 		}


### PR DESCRIPTION
Fixes #213 
------
Previously, repeated calls to `mixer bundle add <bundle>` would yield
the same `Adding bundle <bundle> from <source>` output. Because the
Mix Bundle List is treated as a set, and duplicate bundles are removed,
these redundant additions do not change the resultant list, and are
effectively no-ops.

This patch:
a) Explictly skips the bundles if they already exist.
b) Reports this case to the user

As a result, functionality is equivalent, but the no-op behavior is
more explicit and output is more clear.

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>