### PR TITLE
Build bundle information using dnf commands

### DIFF
--- a/builder/bundleset.go
+++ b/builder/bundleset.go
@@ -32,8 +32,10 @@ type bundle struct {
 	Header   bundleHeader
 
 	DirectIncludes []string
-	DirectPackages []string
+	DirectPackages map[string]bool
 	AllPackages    []string
+
+	Files map[string]bool
 }
 
 type bundleSet map[string]*bundle
@@ -54,7 +56,11 @@ func validateAndFillBundleSet(bundles bundleSet) error {
 	}
 	for _, b := range sortedBundles {
 		var allPackages []string
-		allPackages = append(allPackages, b.DirectPackages...)
+		for k, v := range b.DirectPackages {
+			if v {
+				allPackages = append(allPackages, k)
+			}
+		}
 		for _, include := range b.DirectIncludes {
 			allPackages = append(allPackages, bundles[include].AllPackages...)
 		}
@@ -297,7 +303,10 @@ func parseBundle(contents []byte) (*bundle, error) {
 	}
 
 	b.DirectIncludes = includes
-	b.DirectPackages = packages
+	b.DirectPackages = make(map[string]bool)
+	for _, p := range packages {
+		b.DirectPackages[p] = true
+	}
 
 	return &b, nil
 }

--- a/builder/bundleset_test.go
+++ b/builder/bundleset_test.go
@@ -88,7 +88,7 @@ pkg1 # [TITLE]: wrongtitle
 		failed := err != nil
 		if failed != tt.ShouldFail {
 			if tt.ShouldFail {
-				t.Errorf("unexpected success when parsing bundle\nCONTENTS:\n%s\nPARSED INCLUDES: %s\nPARSED PACKAGES:\n%s", tt.Contents, b.DirectIncludes, b.DirectPackages)
+				t.Errorf("unexpected success when parsing bundle\nCONTENTS:\n%s\nPARSED INCLUDES: %s\nPARSED PACKAGES:\n%v", tt.Contents, b.DirectIncludes, b.DirectPackages)
 			} else {
 				t.Errorf("unexpected error parsing bundle: %s\nCONTENTS:\n%s", err, tt.Contents)
 			}
@@ -107,7 +107,7 @@ pkg1 # [TITLE]: wrongtitle
 		}
 
 		if !reflect.DeepEqual(b.DirectPackages, tt.ExpectedPackages) {
-			t.Errorf("got wrong packages when parsing bundle\nCONTENTS:\n%s\nPARSED PACKAGES (%d):\n%s\nEXPECTED PACKAGES (%d):\n%s", tt.Contents, len(b.DirectPackages), b.DirectPackages, len(tt.ExpectedPackages), tt.ExpectedPackages)
+			t.Errorf("got wrong packages when parsing bundle\nCONTENTS:\n%s\nPARSED PACKAGES (%d):\n%v\nEXPECTED PACKAGES (%d):\n%s", tt.Contents, len(b.DirectPackages), b.DirectPackages, len(tt.ExpectedPackages), tt.ExpectedPackages)
 		}
 	}
 }
@@ -155,7 +155,7 @@ pkg2
 		failed := err != nil
 		if failed != tt.ShouldFail {
 			if tt.ShouldFail {
-				t.Errorf("unexpected success when parsing bundle file\nFILE: %s\nCONTENTS:\n%s\nPARSED INCLUDES: %s\nPARSED PACKAGES:\n%s", tt.Filename, tt.Contents, bundle.DirectIncludes, bundle.DirectPackages)
+				t.Errorf("unexpected success when parsing bundle file\nFILE: %s\nCONTENTS:\n%s\nPARSED INCLUDES: %s\nPARSED PACKAGES:\n%v", tt.Filename, tt.Contents, bundle.DirectIncludes, bundle.DirectPackages)
 			} else {
 				t.Errorf("unexpected error parsing bundle: %s\nCONTENTS:\n%s", err, tt.Contents)
 			}
@@ -170,7 +170,7 @@ pkg2
 		}
 
 		if !reflect.DeepEqual(bundle.DirectPackages, tt.ExpectedPackages) {
-			t.Errorf("got wrong packages when parsing bundle\nCONTENTS:\n%s\nPARSED PACKAGES (%d):\n%s\nEXPECTED PACKAGES (%d):\n%s", tt.Contents, len(bundle.DirectPackages), bundle.DirectPackages, len(tt.ExpectedPackages), tt.ExpectedPackages)
+			t.Errorf("got wrong packages when parsing bundle\nCONTENTS:\n%s\nPARSED PACKAGES (%d):\n%v\nEXPECTED PACKAGES (%d):\n%s", tt.Contents, len(bundle.DirectPackages), bundle.DirectPackages, len(tt.ExpectedPackages), tt.ExpectedPackages)
 		}
 	}
 }

--- a/builder/bundleset_test.go
+++ b/builder/bundleset_test.go
@@ -15,7 +15,7 @@ func TestParseBundle(t *testing.T) {
 		Contents         []byte
 		ExpectedHeader   bundleHeader
 		ExpectedIncludes []string
-		ExpectedPackages []string
+		ExpectedPackages map[string]bool
 		ShouldFail       bool
 	}{
 		{
@@ -38,7 +38,7 @@ pkg2
 				Maintainer:   "the maintainer",
 			},
 			ExpectedIncludes: []string{"a", "b"},
-			ExpectedPackages: []string{"pkg1", "pkg2"},
+			ExpectedPackages: map[string]bool{"pkg1": true, "pkg2": true},
 		},
 		{
 			Contents: []byte(`# Bundle with empty header values
@@ -55,7 +55,7 @@ pkg1
 				Description: "a description",
 			},
 			ExpectedIncludes: []string{"a"},
-			ExpectedPackages: []string{"pkg1"},
+			ExpectedPackages: map[string]bool{"pkg1": true},
 		},
 		{
 			Contents: []byte(`# Bundle with tricky comments
@@ -72,7 +72,7 @@ pkg1 # [TITLE]: wrongtitle
 				Description: "a description",
 			},
 			ExpectedIncludes: []string{"a"},
-			ExpectedPackages: []string{"pkg1"},
+			ExpectedPackages: map[string]bool{"pkg1": true},
 		},
 
 		// Error cases.
@@ -107,7 +107,7 @@ pkg1 # [TITLE]: wrongtitle
 		}
 
 		if !reflect.DeepEqual(b.DirectPackages, tt.ExpectedPackages) {
-			t.Errorf("got wrong packages when parsing bundle\nCONTENTS:\n%s\nPARSED PACKAGES (%d):\n%v\nEXPECTED PACKAGES (%d):\n%s", tt.Contents, len(b.DirectPackages), b.DirectPackages, len(tt.ExpectedPackages), tt.ExpectedPackages)
+			t.Errorf("got wrong packages when parsing bundle\nCONTENTS:\n%s\nPARSED PACKAGES (%d):\n%v\nEXPECTED PACKAGES (%d):\n%v", tt.Contents, len(b.DirectPackages), b.DirectPackages, len(tt.ExpectedPackages), tt.ExpectedPackages)
 		}
 	}
 }
@@ -117,7 +117,7 @@ func TestParseBundleFile(t *testing.T) {
 		Filename         string
 		Contents         []byte
 		ExpectedIncludes []string
-		ExpectedPackages []string
+		ExpectedPackages map[string]bool
 		ShouldFail       bool
 	}{
 		{
@@ -129,7 +129,7 @@ pkg1     # Comment
 pkg2
 `),
 			ExpectedIncludes: []string{"a", "b"},
-			ExpectedPackages: []string{"pkg1", "pkg2"},
+			ExpectedPackages: map[string]bool{"pkg1": true, "pkg2": true},
 		},
 
 		// Bundle contents error (catching parseBundle's error)
@@ -170,7 +170,7 @@ pkg2
 		}
 
 		if !reflect.DeepEqual(bundle.DirectPackages, tt.ExpectedPackages) {
-			t.Errorf("got wrong packages when parsing bundle\nCONTENTS:\n%s\nPARSED PACKAGES (%d):\n%v\nEXPECTED PACKAGES (%d):\n%s", tt.Contents, len(bundle.DirectPackages), bundle.DirectPackages, len(tt.ExpectedPackages), tt.ExpectedPackages)
+			t.Errorf("got wrong packages when parsing bundle\nCONTENTS:\n%s\nPARSED PACKAGES (%d):\n%v\nEXPECTED PACKAGES (%d):\n%v", tt.Contents, len(bundle.DirectPackages), bundle.DirectPackages, len(tt.ExpectedPackages), tt.ExpectedPackages)
 		}
 	}
 }

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -337,7 +337,7 @@ func RunCommandOutput(cmdname string, args ...string) (*bytes.Buffer, error) {
 			// Finish without a newline to wrap well with the err.
 			fmt.Fprintf(&buf, "failed to execute")
 		}
-		return nil, errors.Wrap(err, buf.String())
+		return &outBuf, errors.Wrap(err, buf.String())
 	}
 	return &outBuf, nil
 }

--- a/swupd/bundleinfo.go
+++ b/swupd/bundleinfo.go
@@ -1,0 +1,127 @@
+// Copyright 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swupd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type bundleInfo struct {
+	Name           string
+	Filename       string
+	DirectIncludes []string
+	DirectPackages map[string]bool
+	AllPackages    []string
+	Files          map[string]bool
+}
+
+func (m *Manifest) getBundleInfo(path string) error {
+	var err error
+	if _, err = os.Stat(path); os.IsNotExist(err) {
+		basePath := filepath.Dir(path)
+		err = m.addFilesFromChroot(filepath.Join(filepath.Dir(path), m.Name))
+		if err != nil {
+			return err
+		}
+
+		m.bundleInfo.Files = make(map[string]bool)
+		for _, f := range m.Files {
+			m.bundleInfo.Files[f.Name] = true
+		}
+
+		var includes []string
+		includes, err = readIncludesFile(filepath.Join(basePath, "noship", m.Name+"-includes"))
+		if err != nil {
+			return err
+		}
+		m.bundleInfo.DirectIncludes = includes
+		return nil
+	}
+
+	biBytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(biBytes, &m.bundleInfo)
+}
+
+func (m *Manifest) addFilesFromBundleInfo(c config, version uint32) error {
+	chrootDir := filepath.Join(c.imageBase, fmt.Sprint(version), "full")
+	for fpath := range m.bundleInfo.Files {
+		fullPath := filepath.Join(chrootDir, fpath)
+		fi, err := os.Lstat(fullPath)
+		if err != nil {
+			return err
+		}
+
+		err = m.createFileRecord(chrootDir, fpath, fi)
+		if err != nil {
+			if strings.Contains(err.Error(), "hash calculation error") {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
+		}
+	}
+
+	return nil
+}
+
+func appendUniqueManifest(ms []*Manifest, man *Manifest) []*Manifest {
+	for _, m := range ms {
+		if m.Name == man.Name {
+			return ms
+		}
+	}
+	return append(ms, man)
+}
+
+func (m *Manifest) readIncludesFromBundleInfo(bundles []*Manifest) error {
+	includes := []*Manifest{}
+	// os-core is added as an include for every bundle
+	// handle it manually so we don't have to rely on the includes list having it
+	for _, b := range bundles {
+		if b.Name == "os-core" {
+			includes = append(includes, b)
+		}
+	}
+
+	for _, bn := range m.bundleInfo.DirectIncludes {
+		// just add this one blindly since it is processed later
+		if bn == indexBundle {
+			includes = append(includes, &Manifest{Name: indexBundle})
+			continue
+		}
+
+		if bn == "os-core" {
+			// already added this one
+			continue
+		}
+
+		for _, b := range bundles {
+			if bn == b.Name {
+				includes = appendUniqueManifest(includes, b)
+			}
+		}
+	}
+
+	m.Header.Includes = includes
+	return nil
+}

--- a/swupd/filesystem.go
+++ b/swupd/filesystem.go
@@ -74,7 +74,7 @@ func recordFromFile(rootPath, path string, fi os.FileInfo) (*File, error) {
 		return nil, fmt.Errorf("%v is an unsupported file type", file.Name)
 	}
 
-	fh, err := Hashcalc(rootPath + file.Name)
+	fh, err := Hashcalc(filepath.Join(rootPath, file.Name))
 	if err != nil {
 		return nil, fmt.Errorf("hash calculation error: %v", err)
 	}

--- a/swupd/fullchroot.go
+++ b/swupd/fullchroot.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 )
 
-func createNewFullChroot(version uint32, bundles []string, imageBase string) error {
+func syncToFull(version uint32, bundle string, imageBase string) error {
 	fullPath := filepath.Join(imageBase, fmt.Sprint(version), "full")
 	// MkdirAll returns nil when the path exists, so we continue to do the
 	// full chroot creation over the existing one
@@ -15,13 +15,12 @@ func createNewFullChroot(version uint32, bundles []string, imageBase string) err
 		return err
 	}
 
-	for _, bundle := range bundles {
-		// append trailing slash to get contents only
-		bundlePath := filepath.Join(imageBase, fmt.Sprint(version), bundle) + "/"
-		cmd := exec.Command("rsync", "-aAX", "--ignore-existing", bundlePath, fullPath)
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("rsync error: %v", err)
-		}
+	// append trailing slash to get contents only
+	bundlePath := filepath.Join(imageBase, fmt.Sprint(version), bundle) + "/"
+	cmd := exec.Command("rsync", "-aAX", "--ignore-existing", bundlePath, fullPath)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("rsync error: %v", err)
 	}
+
 	return nil
 }

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -58,6 +58,7 @@ type Manifest struct {
 	Header       ManifestHeader
 	Files        []*File
 	DeletedFiles []*File
+	bundleInfo   bundleInfo
 }
 
 // MoM is a manifest that holds references to bundle manifests.
@@ -673,47 +674,6 @@ func linkDeltaPeersForPack(c *config, oldManifest, newManifest *Manifest) error 
 		of.DeltaPeer = nf
 	}
 
-	return nil
-}
-
-func (m *Manifest) readIncludes(bundles []*Manifest, c config) error {
-	// read in <imageBase>/<version>/noship/<bundle>-includes
-	var err error
-	path := filepath.Join(c.imageBase, fmt.Sprint(m.Header.Version), "noship", m.Name+"-includes")
-	bundleNames, err := readIncludesFile(path)
-	if err != nil {
-		return err
-	}
-
-	includes := []*Manifest{}
-	// os-core is added as an include for every bundle
-	// handle it manually so we don't have to rely on the includes list having it
-	for _, b := range bundles {
-		if b.Name == "os-core" {
-			includes = append(includes, b)
-		}
-	}
-
-	for _, bn := range bundleNames {
-		// just add this one blindly since it is processed later
-		if bn == indexBundle {
-			includes = append(includes, &Manifest{Name: indexBundle})
-			continue
-		}
-
-		if bn == "os-core" {
-			// already added this one
-			continue
-		}
-
-		for _, b := range bundles {
-			if bn == b.Name {
-				includes = append(includes, b)
-			}
-		}
-	}
-
-	m.Header.Includes = includes
 	return nil
 }
 

--- a/swupd/swupd_test.go
+++ b/swupd/swupd_test.go
@@ -13,7 +13,7 @@ func TestIncludeVersionBump(t *testing.T) {
 	// Version 10.
 	ts.Bundles = []string{"test-bundle"}
 	ts.write("image/10/test-bundle/foo", "foo")
-	ts.createManifests(10)
+	ts.createManifestsFromChroots(10)
 	ts.createFullfiles(10)
 	ts.createPack("os-core", 0, 10, ts.path("image"))
 	ts.createPack("test-bundle", 0, 10, ts.path("image"))
@@ -31,7 +31,7 @@ func TestIncludeVersionBump(t *testing.T) {
 	ts.write("image/20/included/bar", "bar")
 	ts.write("image/20/included-two/baz", "baz")
 	ts.write("image/20/noship/test-bundle-includes", "included\nincluded-two")
-	ts.createManifests(20)
+	ts.createManifestsFromChroots(20)
 	ts.createFullfiles(20)
 
 	ts.createPack("os-core", 0, 20, ts.path("image"))
@@ -56,7 +56,7 @@ func TestIncludeVersionBump(t *testing.T) {
 	ts.write("image/30/included-nested/foobarbaz", "foobarbaz")
 	ts.write("image/30/noship/test-bundle-includes", "included\nincluded-two")
 	ts.write("image/30/noship/included-includes", "included-nested")
-	ts.createManifests(30)
+	ts.createManifestsFromChroots(30)
 	ts.createFullfiles(30)
 
 	ts.checkExists("www/30/Manifest.os-core")
@@ -86,7 +86,7 @@ func TestFullRun(t *testing.T) {
 	ts.Bundles = []string{"os-core", "test-bundle"}
 
 	ts.write("image/10/test-bundle/foo", "foo")
-	ts.createManifests(10)
+	ts.createManifestsFromChroots(10)
 	ts.createFullfiles(10)
 
 	infoOsCore := ts.createPack("os-core", 0, 10, "")
@@ -127,7 +127,8 @@ func TestFullRunDelta(t *testing.T) {
 	ts.write("image/10/test-bundle/largefile", content)
 	ts.write("image/10/test-bundle/foo", "foo")
 	ts.write("image/10/test-bundle/foobarbaz", "foobarbaz")
-	ts.createManifests(10)
+	//ts.createManifests(10)
+	ts.createManifestsFromChroots(10)
 	ts.createFullfiles(10)
 
 	ts.createPack("os-core", 0, 10, ts.path("image"))
@@ -153,7 +154,8 @@ func TestFullRunDelta(t *testing.T) {
 	ts.write("image/20/noship/test-bundle-includes", "included\nincluded-two")
 	ts.write("image/20/noship/included-includes", "included-nested")
 
-	ts.createManifests(20)
+	//ts.createManifests(20)
+	ts.createManifestsFromChroots(20)
 	ts.createFullfiles(20)
 
 	ts.createPack("os-core", 0, 20, ts.path("image"))

--- a/validate-swupd.sh
+++ b/validate-swupd.sh
@@ -131,7 +131,7 @@ for i in $(ls update/www); do
 
 	set -x
 	echo $next | sudo tee $(pwd)/update/www/version/format$3/latest
-	swupd update --path os-$i-install -u file://$(pwd)/update/www -C $(pwd)/Swupd_Root.pem
+	swupd update --path "os-$i-install" -F "$3" -u "file://$PWD/update/www" -C "$PWD/Swupd_Root.pem"
 	if [[ $? -ne 0 ]]; then
 		popd
 		exit 1


### PR DESCRIPTION
* Build bundle information using dnf commands
  Deprecate use of chroot-building for each individual bundle. This allows
us to scale much easier on machines with limited disk space. Because
chroots are decoupled from manifest creation this also makes it possible
in the future to move to doing bundle builds on distributed machines and
allows our bundle numbers to scale. The bundle file list is stored in a
JSON file that is read later by the manifest creation step.

  This leaves a fallback in swupd/fullchroot.go to allow users to add
content to a chroot in order to extend a typical build.

* Overhaul tests to use new bundle creation method
  This overhaul leaves several tests using the old method of using chroots
to generate the update to verify we aren't totally deprecating the old
method.

Two other small fixes.

~~**NOTE**: I'm sure there will be changes that need to be made to this, just opening it up for discussion now so we can talk about the general direction. I'll keep working on cleaning it up and ask for reviews when I think it's ready for a full review.~~