### PR TITLE
build-deltas: Do not fail on missing previous versions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY . / /home/gopath/src/github.com/clearlinux/mixer-tools/
 RUN swupd bundle-add mixer go-basic c-basic os-core-update-dev && \
     git config --global user.email "travis@example.com" && \
     git config --global user.name "Travis CI" && \
+    mkdir -p /run/lock && \
     clrtrust generate && \
     go get -u gopkg.in/alecthomas/gometalinter.v2 && \
     gometalinter.v2 --install

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -1900,7 +1900,8 @@ func (b *Builder) BuildDeltaPacksPreviousVersions(prev, to uint32, printReport b
 		var m *swupd.Manifest
 		m, err = swupd.ParseManifestFile(filepath.Join(outputDir, fmt.Sprint(cur), "Manifest.MoM"))
 		if err != nil {
-			return errors.Wrapf(err, "couldn't find manifest of previous version %d", cur)
+			fmt.Fprintf(os.Stderr, "could not find manifest for previous version %d, skipping...", cur)
+			continue
 		}
 		previousManifests = append(previousManifests, m)
 		cur = m.Header.Previous


### PR DESCRIPTION
A version can be missing if the minversion is newer than the previous
version being checked. This is not an error, but should be printed as a
warning to the user in case this is not expected.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>