### PR TITLE
Allow for 'm' flag to be used in rename flag spot, fail on invalid manifests

### DIFF
--- a/swupd/files.go
+++ b/swupd/files.go
@@ -192,6 +192,9 @@ func renameFromFlag(flag byte) (frename, error) {
 		return renameSet, nil
 	case '.':
 		return renameUnset, nil
+	case 'm':
+		// this is a special flag used by mixer-integration client-side
+		return renameUnset, nil
 	default:
 		return renameUnset, fmt.Errorf("invalid file rename flag: %v", flag)
 	}

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -982,7 +982,10 @@ func writeIndexManifest(c *config, ui *UpdateInfo, bundles []*Manifest) (*Manife
 	// link in old manifest for version information
 	// first get old MoM
 	oldMoMPath := filepath.Join(c.outputDir, fmt.Sprint(ui.lastVersion), "Manifest.MoM")
-	oldMoM := getOldManifest(oldMoMPath)
+	oldMoM, err := getOldManifest(oldMoMPath)
+	if err != nil {
+		return nil, err
+	}
 
 	// get old version
 	ver := getManifestVerFromMoM(oldMoM, idxMan)
@@ -991,7 +994,10 @@ func writeIndexManifest(c *config, ui *UpdateInfo, bundles []*Manifest) (*Manife
 	}
 
 	oldMPath := filepath.Join(c.outputDir, fmt.Sprint(ver), "Manifest."+idxMan.Name)
-	oldM := getOldManifest(oldMPath)
+	oldM, err := getOldManifest(oldMPath)
+	if err != nil {
+		return nil, err
+	}
 	oldM.sortFilesName()
 	// linkPeersAndChange will update file versions correctly
 	_, _, _ = idxMan.linkPeersAndChange(oldM, *c, ui.minVersion)


### PR DESCRIPTION
The 'm' flag is used as a special flag by mixer-integration on the
client side to indicate a manifest record in the Manifest.MoM was
created by a local mix. Allow this flag and just set the rename flag to
renameUnset.

Fail when the old manifest exists but is invalid and cannot be parsed.
This is a clear failure case because the old manifest does exist at that
path and therefore the user expects it to be used.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>