### PR TITLE
Add support for adding extra files to a bundle

### DIFF
--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -137,7 +137,7 @@ func processBundles(ui UpdateInfo, c config) ([]*Manifest, error) {
 	for _, bundle := range tmpManifests {
 		if bundle.Name != "os-core" && bundle != newFull {
 			// read in bundle includes
-			if err := bundle.readIncludesFromBundleInfo(tmpManifests); err != nil {
+			if err = bundle.readIncludesFromBundleInfo(tmpManifests); err != nil {
 				return nil, err
 			}
 		}

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -499,6 +499,22 @@ func (fs *testFileSystem) addDir(version uint32, bundle, dir string) {
 	fs.addToBundleInfo(version, bundle, dir)
 }
 
+func (fs *testFileSystem) addExtraFile(version uint32, bundle, file, content string) {
+	fs.t.Helper()
+	path := filepath.Join(fs.Dir, "image", fmt.Sprint(version), bundle+"-extra-files")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		fs.t.Fatal(err)
+	}
+
+	_, err = f.WriteString(file + "\n")
+	if err != nil {
+		fs.t.Fatal(err)
+	}
+
+	fs.addToFullChroot(version, file, content)
+}
+
 func (fs *testFileSystem) addIncludes(version uint32, bundle string, includes []string) {
 	fs.t.Helper()
 	path := filepath.Join(fs.Dir, "image", fmt.Sprint(version), bundle+"-info")

--- a/swupd/swupd_test.go
+++ b/swupd/swupd_test.go
@@ -186,3 +186,18 @@ func TestFullRunDelta(t *testing.T) {
 	// NOTE: original test checked whether the packs had the manifests inside. This is
 	// not done by new swupd since it seems the client doesn't take advantage of them.
 }
+
+func TestAddFilesToBundleInfo(t *testing.T) {
+	ts := newTestSwupd(t, "extra-files")
+	defer ts.cleanup()
+	ts.Bundles = []string{"os-core", "test-bundle"}
+	ts.addFile(10, "test-bundle", "/foo", "foo content")
+	ts.addExtraFile(10, "test-bundle", "/bar", "bar content")
+	ts.addExtraFile(10, "test-bundle", "/baz", "baz content")
+	ts.createManifests(10)
+
+	m := ts.parseManifest(10, "test-bundle")
+	fileInManifest(t, m, 10, "/foo")
+	fileInManifest(t, m, 10, "/bar")
+	fileInManifest(t, m, 10, "/baz")
+}


### PR DESCRIPTION
Allow a user to add extra files to a bundle by adding a file per line to
`<imageDir>/<version>/<bundleName>-extra-files`. Each file must be an
absolute path. At this point the user must manually create the file in
the full chroot as well.

The workflow for a user adding additional files to a bundle would be
this:

```bash
$ mixer build chroots
$ echo /path/to/bar >> update/image/my-bundle-extra-files
$ mkdir -p update/image/full/path/to
$ cp /local/path/to/bar update/image/full/path/to/bar
$ mixer build update
```

This can definitely be improved in the future but this is a first step
that allows additional content on top of what dnf installs.

In the rare case that a post-install action for dnf install adds a file,
this file would already exist in the full chroot and would not need to
be copied in. The user would only need to append the path to that file
to the `<bundle>-extra-files` file to make sure it is included in that
bundle's manifests.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>

**based on #215** last commit is the relevant one here.