### PR TITLE
Resolve /lib to /usr/lib instead of /usr/lib64

### DIFF
--- a/builder/chroots.go
+++ b/builder/chroots.go
@@ -141,7 +141,7 @@ func resolveFileName(path string) string {
 		return filepath.Join("/usr", path)
 	}
 	if path[:5] == "/lib/" {
-		return filepath.Join("/usr/lib64", path[4:])
+		return filepath.Join("/usr/lib", path[4:])
 	}
 	if pathLen < 6 {
 		return path


### PR DESCRIPTION
Fix a typo that resolved /lib paths to /usr/lib64.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>