### PR TITLE
Parse version numbers on init

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -281,6 +281,17 @@ func (b *Builder) InitMix(upstreamVer string, mixVer string, allLocal bool, allU
 	}
 	b.MixVer = mixVer
 
+	// Parse strings into valid version numbers.
+	var err error
+	b.MixVerUint32, err = parseUint32(b.MixVer)
+	if err != nil {
+		return errors.Wrapf(err, "Couldn't parse mix version")
+	}
+	b.UpstreamVerUint32, err = parseUint32(b.UpstreamVer)
+	if err != nil {
+		return errors.Wrapf(err, "Couldn't parse upstream version")
+	}
+
 	// Initialize the Mix Bundles List
 	if _, err := os.Stat(filepath.Join(b.VersionDir, b.MixBundlesFile)); os.IsNotExist(err) {
 		// Add default bundles (or all)


### PR DESCRIPTION
Recently, code was added to ReadVersions to parse the mixversion
and upstreamversion string values as uint32 values. This patch
adds the same logic to init (the only command that does not
result in a call to ReadVersions), so that the parsed versions
will be consistently available.

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>