### PR TITLE
Install DirectPackages to full chroot

### DIFF
--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -328,6 +328,24 @@ func parseNoopInstall(installOut string) []string {
 		if len(line) == 0 {
 			break
 		}
+
+		// When not running in a TTY dnf sets terminal line-width to a
+		// default 80 characters, then wraps their fields in an
+		// unpredictable way to be pleasing for they eye but not for
+		// the parser. If the line starts with more than one space (' ')
+		// character the previous line was wrapped and continues on
+		// this line.  Since we only care about the first field, the
+		// package name, just continue to the next line.
+		//
+		// example lines:
+		// ^ really-long-package-name-overflows-field$
+		// ^                         x86_64             12-10         clear$
+		// ^ reasonablepkgname       x86_64             deadcafedeadbeefdeadcafedeadbeef$
+		// ^                                                          clear$
+		if strings.HasPrefix(line, "  ") {
+			continue
+		}
+
 		pkgDeps = append(pkgDeps, strings.Fields(line)[0])
 	}
 	return pkgDeps

--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -475,12 +475,20 @@ func genUpdateBundleSpecialFiles(chrootDir string, cfg *buildBundlesConfig, b *B
 }
 
 func installBundleToFull(packagerCmd []string, buildVersionDir string, bundle *bundle) error {
+	var err error
 	baseDir := filepath.Join(buildVersionDir, "full")
 	args := merge(packagerCmd, "--installroot="+baseDir, "install")
-	args = append(args, bundle.AllPackages...)
-	err := helpers.RunCommandSilent(args[0], args[1:]...)
-	if err != nil {
-		return err
+	if len(bundle.DirectPackages) > 0 {
+		// There were packages directly included for this bundle so
+		// install to full chroot. This check is necessary so we don't
+		// call dnf install with no package listed.
+		for p := range bundle.DirectPackages {
+			args = append(args, p)
+		}
+		err = helpers.RunCommandSilent(args[0], args[1:]...)
+		if err != nil {
+			return err
+		}
 	}
 
 	bundleDir := filepath.Join(baseDir, "usr/share/clear/bundles")


### PR DESCRIPTION
Do not just install the AllPackages list to the full chroot, since this
is just the list of all included packages. The DirectPackages need to be
installed instead since this is the fully resolved list for each bundle.
AllPackages do not need to be installed because all bundles are being
installed to the same place.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>

~~**DO NOT MERGE UNTIL I COMPLETE TESTING**~~