### PR TITLE
Do not keepcache for dnf operations

### DIFF
--- a/yum.conf.in
+++ b/yum.conf.in
@@ -1,6 +1,6 @@
 [main]
 cachedir=/var/cache/yum/clear/
-keepcache=1
+keepcache=0
 debuglevel=2
 logfile=/var/log/yum.log
 exactarch=1


### PR DESCRIPTION
Keeping the cache around has resulted in interesting errors with invalid
bytes being read from the cache and resulting in DNF tracebacks.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>