### PR TITLE
Clear cache before DNF install to full chroot

### DIFF
--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -492,7 +492,16 @@ func installBundleToFull(packagerCmd []string, buildVersionDir string, bundle *b
 	return ioutil.WriteFile(filepath.Join(bundleDir, bundle.Name), nil, 0644)
 }
 
+func clearDNFCache(packagerCmd []string) error {
+	args := merge(packagerCmd, "clean", "all")
+	return helpers.RunCommandSilent(args[0], args[1:]...)
+}
+
 func buildFullChroot(cfg *buildBundlesConfig, b *Builder, set *bundleSet, packagerCmd []string, buildVersionDir, version string) error {
+	fmt.Println("Cleaning DNF cache before full install")
+	if err := clearDNFCache(packagerCmd); err != nil {
+		return err
+	}
 	fmt.Println("Installing all bundles to full chroot")
 	totalBundles := len(*set)
 	i := 0

--- a/yum.conf.in
+++ b/yum.conf.in
@@ -1,6 +1,6 @@
 [main]
 cachedir=/var/cache/yum/clear/
-keepcache=1
+keepcache=0
 debuglevel=2
 logfile=/var/log/yum.log
 exactarch=1


### PR DESCRIPTION
Keeping the cache around has resulted in interesting errors with invalid
bytes being read from the cache and resulting in DNF tracebacks. As a
fix for this tell DNF not to keepcache and manually clear the cache
before doing the full install. This seems to either be a bug with DNF
itself or maybe with the way Clear Linux is doing its packaging (though
this is just a guess).

The error seen is a UnicodeDecodeError from the DNF source code. It is
trying to decode a non-UTF-8 byte as UTF-8:

Traceback (most recent call last):
  File "/usr/bin/dnf", line 58, in <module>
    main.user_main(sys.argv[1:], exit_code=True)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 179, in user_main
    errcode = main(args)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 64, in main
    return _main(base, args, cli_class, option_parser_class)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 99, in _main
    return cli_run(cli, base)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 123, in cli_run
    ret = resolving(cli, base)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 154, in resolving
    base.do_transaction(display=displays)
  File "/usr/lib/python3.6/site-packages/dnf/cli/cli.py", line 238, in do_transaction
    super(BaseCli, self).do_transaction(display)
  File "/usr/lib/python3.6/site-packages/dnf/base.py", line 781, in do_transaction
    self._run_transaction(cb=cb)
  File "/usr/lib/python3.6/site-packages/dnf/base.py", line 925, in _run_transaction
    self._verify_transaction(cb.verify_tsi_package)
  File "/usr/lib/python3.6/site-packages/dnf/base.py", line 1018, in _verify_transaction
    self.history.sync_alldb(po)
  File "/usr/lib/python3.6/site-packages/dnf/yum/history.py", line 1399, in sync_alldb
    self._save_rpmdb(ipkg) and
  File "/usr/lib/python3.6/site-packages/dnf/yum/history.py", line 1360, in _save_rpmdb
    val = getattr(ipkg, attr, None)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa1 in position 0: invalid start byte

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>