### PR TITLE
Add trailing newline to mixbundles

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -676,7 +676,7 @@ func (b *Builder) getDirBundlesListAsSet(dir string) (bundleSet, error) {
 // writeMixBundleList writes the contents of a bundle set out to the Mix Bundles
 // List file. Values will be in sorted order.
 func (b *Builder) writeMixBundleList(set bundleSet) error {
-	data := []byte(strings.Join(getBundleSetKeysSorted(set), "\n"))
+	data := []byte(strings.Join(getBundleSetKeysSorted(set), "\n") + "\n")
 	if err := ioutil.WriteFile(filepath.Join(b.VersionDir, b.MixBundlesFile), data, 0644); err != nil {
 		return errors.Wrap(err, "Failed to write out Mix Bundle List")
 	}


### PR DESCRIPTION
Previously mixer wrote the mix bundle list as a newline-separated list,
rather than as a newline-delimited list. This made things like "wc -l"
report one fewer than expected, as the final line contained no newline.

This trailing newline does not affect the existing parsing code.

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>