### PR TITLE
Perform all DNF transactions in bulk

### DIFF
--- a/builder/bundleset.go
+++ b/builder/bundleset.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 )
 
@@ -33,7 +32,7 @@ type bundle struct {
 
 	DirectIncludes []string
 	DirectPackages map[string]bool
-	AllPackages    []string
+	AllPackages    map[string]bool
 
 	Files map[string]bool
 }
@@ -55,22 +54,14 @@ func validateAndFillBundleSet(bundles bundleSet) error {
 		return err
 	}
 	for _, b := range sortedBundles {
-		var allPackages []string
+		b.AllPackages = make(map[string]bool)
 		for k, v := range b.DirectPackages {
-			if v {
-				allPackages = append(allPackages, k)
-			}
+			b.AllPackages[k] = v
 		}
 		for _, include := range b.DirectIncludes {
-			allPackages = append(allPackages, bundles[include].AllPackages...)
-		}
-		// Remove redundant packages.
-		sort.Strings(allPackages)
-		for i, p := range allPackages {
-			if i != 0 && allPackages[i-1] == p {
-				continue
+			for k, v := range bundles[include].AllPackages {
+				b.AllPackages[k] = v
 			}
-			b.AllPackages = append(b.AllPackages, p)
 		}
 	}
 

--- a/swupd/bundleinfo.go
+++ b/swupd/bundleinfo.go
@@ -28,7 +28,7 @@ type bundleInfo struct {
 	Filename       string
 	DirectIncludes []string
 	DirectPackages map[string]bool
-	AllPackages    []string
+	AllPackages    map[string]bool
 	Files          map[string]bool
 }
 


### PR DESCRIPTION
When building bundles perform all DNF transactions in bulk. There are
two reasons to do this.

1. DNF is too smart for its own good. It will resolve dependencies
   differently depending on the packages listed in the transaction.
   Therefore we must perform these transactions with all relevant
   packages listed for the bundle being processed.
2. DNF transactions take time. When performing much fewer transactions
   in bulk the bundle builder can execute in a shorter time.

Certain manifest validation tools also require a complete dep-solved
list of all packages and included packages for a bundle to validate the
bundle manifest. For this reason use the bundle.AllPackages list and
leave the bundle.DirectPackages list as an informational list of just
the direct packages specified in the bundle definition file.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>