### PR TITLE
Do not init image directories from manifest creation

### DIFF
--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -45,24 +45,6 @@ func initBuildEnv(c config) error {
 	return os.Mkdir(tmpDir, os.ModePerm)
 }
 
-// initBuildDirs creates the following directory structure
-// StateDir/
-//    image/
-//        <version>/
-//            <bundle1>/
-//            ...
-//    LAST_VER
-func initBuildDirs(version uint32, groups []string, imageBase string) error {
-	verDir := filepath.Join(imageBase, fmt.Sprint(version))
-	for _, bundle := range groups {
-		if err := os.MkdirAll(filepath.Join(verDir, bundle), 0755); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func getOldManifest(path string) (*Manifest, error) {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return &Manifest{}, nil
@@ -240,10 +222,6 @@ func CreateManifests(version uint32, minVersion uint32, format uint, statedir st
 
 	if oldFullManifest.Header.Format > format {
 		return nil, fmt.Errorf("new format %v is lower than old format %v", format, oldFullManifest.Header.Format)
-	}
-
-	if err = initBuildDirs(version, groups, c.imageBase); err != nil {
-		return nil, err
 	}
 
 	timeStamp := time.Now()

--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -27,28 +27,6 @@ func TestInitBuildEnv(t *testing.T) {
 	}
 }
 
-func TestInitBuildDirs(t *testing.T) {
-	var c config
-	var err error
-	bundles := []string{"os-core", "os-core-update", "test-bundle"}
-	c, _ = getConfig("./testdata/state_builddirs")
-	if c.imageBase, err = ioutil.TempDir("testdata", "image"); err != nil {
-		t.Fatalf("Could not initialize image dir for testing: %v", err)
-	}
-
-	defer removeAllIgnoreErr(c.imageBase)
-
-	if err = initBuildDirs(10, bundles, c.imageBase); err != nil {
-		t.Errorf("initBuildDirs raised unexpected error: %v", err)
-	}
-
-	mustDirExistsWithPerm(t, filepath.Join(c.imageBase, "10"), 0755)
-
-	for _, dir := range bundles {
-		mustDirExistsWithPerm(t, filepath.Join(c.imageBase, "10", dir), 0755)
-	}
-}
-
 func TestCreateManifestsBadMinVersion(t *testing.T) {
 	if _, err := CreateManifests(10, 20, 1, "testdir"); err == nil {
 		t.Error("No error raised with invalid minVersion (20) for version 10")
@@ -161,6 +139,7 @@ func TestCreateManifestFormatNoDecrement(t *testing.T) {
 		t.Fatal("unexpected success calling create manifests with decremented format")
 	}
 
+	ts.addFile(20, "os-core", "/bar", "bar")
 	_, err = CreateManifests(20, 0, ts.Format, ts.Dir)
 	if err != nil {
 		t.Fatalf("create manifests with same format as before failed: %s", err)

--- a/swupd/fullchroot.go
+++ b/swupd/fullchroot.go
@@ -17,9 +17,11 @@ func syncToFull(version uint32, bundle string, imageBase string) error {
 
 	// append trailing slash to get contents only
 	bundlePath := filepath.Join(imageBase, fmt.Sprint(version), bundle) + "/"
-	cmd := exec.Command("rsync", "-aAX", "--ignore-existing", bundlePath, fullPath)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("rsync error: %v", err)
+	if _, err := os.Stat(bundlePath); err == nil {
+		cmd := exec.Command("rsync", "-aAX", "--ignore-existing", bundlePath, fullPath)
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("rsync error: %v", err)
+		}
 	}
 
 	return nil

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -17,20 +17,6 @@ func removeAllIgnoreErr(dir string) {
 	_ = os.RemoveAll(dir)
 }
 
-func mustDirExistsWithPerm(t *testing.T, path string, perm os.FileMode) {
-	t.Helper()
-	var err error
-	var info os.FileInfo
-	if info, err = os.Stat(path); err != nil {
-		t.Fatal(err)
-	}
-
-	// check if it is a directory or the perms don't match
-	if !info.Mode().IsDir() || info.Mode().Perm() != perm {
-		t.Fatal(err)
-	}
-}
-
 func mustInitStandardTest(t *testing.T, testDir, lastVer, ver string, bundles []string) {
 	t.Helper()
 	mustInitTestDir(t, testDir)


### PR DESCRIPTION
This step was completely unnecessary and created empty chroot
directories in the image dir. This was a product of a too-direct port of
the old swupd-server for this specific part of the rewrite. It probably
wasn't even needed in the old swupd-server.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>