### PR TITLE
Clean up tmp dir after building bundles

### DIFF
--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -672,6 +672,9 @@ src=%s
 	if err != nil {
 		return err
 	}
+	defer func() {
+		_ = os.RemoveAll(emptyDir)
+	}()
 
 	resolvePackages(numWorkers, set, packagerCmd, emptyDir)
 


### PR DESCRIPTION
`mixer build bundles` creates a temp dir to use for one of the dnf
commands. This patch cleans that dir up when mixer is done building the
bundles.

This is really minor, as by default it writes to /tmp, which gets
cleaned up eventually anyway. However, `ioutil.TempDir()` will write to
wherever `$TMPDIR` points, which could be anywhere.

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>