### PR TITLE
[AFB] Dockerize mixer.

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -45,7 +45,7 @@ const Version = "4.2.1"
 
 // Native controls whether mixer runs the command on the native machine or in a
 // container.
-var Native = false
+var Native = true
 
 // UseNewSwupdServer controls whether to use the new implementation of
 // swupd-server (package swupd) when possible. This is an experimental feature.

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -43,6 +43,10 @@ import (
 // Version of Mixer. Also used by the Makefile for releases.
 const Version = "4.2.1"
 
+// Native controls whether mixer runs the command on the native machine or in a
+// container.
+var Native = false
+
 // UseNewSwupdServer controls whether to use the new implementation of
 // swupd-server (package swupd) when possible. This is an experimental feature.
 var UseNewSwupdServer = false
@@ -160,42 +164,90 @@ func (b *Builder) initDirs() error {
 
 // Get latest CLR version
 func (b *Builder) getLatestUpstreamVersion() (string, error) {
-	return b.DownloadFileFromUpstream("/latest")
+	ver, err := b.DownloadFileFromUpstreamAsString("/latest")
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to retrieve latest published upstream version")
+	}
+
+	return ver, nil
 }
 
-// DownloadFileFromUpstream will download a file from the Upstream URL
-// joined with the passed subpath. It will trim spaces from the result.
-func (b *Builder) DownloadFileFromUpstream(subpath string) (string, error) {
+func (b *Builder) getUpstreamFileReader(subpath string) (*io.ReadCloser, error) {
 	// Build the URL
 	end, err := url.Parse(subpath)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	base, err := url.Parse(b.UpstreamURL)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-
 	resolved := base.ResolveReference(end).String()
-	// Fetch the version and parse it
+
 	resp, err := http.Get(resolved)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("got status %q when downloading: %s", resp.Status, resolved)
+		return nil, fmt.Errorf("got status %q when downloading: %s", resp.Status, resolved)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	return &resp.Body, nil
+}
+
+// DownloadFileFromUpstream will download a file from the Upstream URL
+// joined with the passed subpath and write that file to the supplied filename.
+func (b *Builder) DownloadFileFromUpstream(subpath string, filename string) error {
+	fr, err := b.getUpstreamFileReader(subpath)
+	if err != nil {
+		return errors.Wrap(err, "Failed to download file from upstream")
+	}
+	defer func() {
+		_ = (*fr).Close()
+	}()
+
+	// If no filename, infer from download path
+	if filename == "" {
+		_, filename = filepath.Split(subpath)
+	}
+
+	out, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = out.Close()
+	}()
+
+	_, err = io.Copy(out, *fr)
+	if err != nil {
+		if rmErr := os.RemoveAll(filename); err != nil {
+			return errors.Wrap(err, rmErr.Error())
+		}
+		return err
+	}
+
+	return nil
+}
+
+// DownloadFileFromUpstreamAsString will download a file from the Upstream URL
+// joined with the passed subpath. It will trim spaces from the result.
+func (b *Builder) DownloadFileFromUpstreamAsString(subpath string) (string, error) {
+	fr, err := b.getUpstreamFileReader(subpath)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to download file from upstream")
+	}
+	defer func() {
+		_ = (*fr).Close()
+	}()
+
+	content, err := ioutil.ReadAll(*fr)
 	if err != nil {
 		return "", err
 	}
 
-	return strings.TrimSpace(string(body)), nil
+	return strings.TrimSpace(string(content)), nil
 }
 
 const mixDirGitIgnore = `upstream-bundles/
@@ -223,7 +275,7 @@ func (b *Builder) InitMix(upstreamVer string, mixVer string, allLocal bool, allU
 	if upstreamVer == "latest" {
 		ver, err := b.getLatestUpstreamVersion()
 		if err != nil {
-			return errors.Wrap(err, "Failed to retrieve latest published upstream version")
+			return err
 		}
 		upstreamVer = ver
 	}
@@ -2103,14 +2155,14 @@ func writeMetaFiles(path, format, version string) error {
 	return ioutil.WriteFile(filepath.Join(path, "mixer-src-version"), []byte(version), 0644)
 }
 
-func (b *Builder) getUpstreamFormatRange() (format string, first, latest uint32, err error) {
-	format, err = b.DownloadFileFromUpstream(fmt.Sprintf("update/%d/format", b.UpstreamVerUint32))
+func (b *Builder) getUpstreamFormatRange(version string) (format string, first, latest uint32, err error) {
+	format, err = b.DownloadFileFromUpstreamAsString(fmt.Sprintf("update/%s/format", version))
 	if err != nil {
 		return "", 0, 0, errors.Wrap(err, "couldn't download information about upstream")
 	}
 
 	readUint32 := func(subpath string) (uint32, error) {
-		str, rerr := b.DownloadFileFromUpstream(subpath)
+		str, rerr := b.DownloadFileFromUpstreamAsString(subpath)
 		if rerr != nil {
 			return 0, rerr
 		}
@@ -2139,7 +2191,7 @@ func (b *Builder) getUpstreamFormatRange() (format string, first, latest uint32,
 // PrintVersions prints the current mix and upstream versions, and the
 // latest version of upstream.
 func (b *Builder) PrintVersions() error {
-	format, first, latest, err := b.getUpstreamFormatRange()
+	format, first, latest, err := b.getUpstreamFormatRange(b.UpstreamVer)
 	if err != nil {
 		return err
 	}
@@ -2158,7 +2210,7 @@ Latest upstream in format: %d
 // UpdateVersions will validate then update both mix and upstream versions. If upstream
 // version is 0, then the latest upstream version possible will be taken instead.
 func (b *Builder) UpdateVersions(nextMix, nextUpstream uint32) error {
-	format, first, latest, err := b.getUpstreamFormatRange()
+	format, first, latest, err := b.getUpstreamFormatRange(b.UpstreamVer)
 	if err != nil {
 		return err
 	}
@@ -2176,7 +2228,7 @@ func (b *Builder) UpdateVersions(nextMix, nextUpstream uint32) error {
 	}
 
 	// Verify the version exists by checking if its Manifest.MoM is around.
-	_, err = b.DownloadFileFromUpstream(fmt.Sprintf("/update/%d/Manifest.MoM", nextUpstream))
+	_, err = b.DownloadFileFromUpstreamAsString(fmt.Sprintf("/update/%d/Manifest.MoM", nextUpstream))
 	if err != nil {
 		return errors.Wrapf(err, "invalid upstream version %d", nextUpstream)
 	}
@@ -2203,4 +2255,28 @@ Updated upstream: %d (format: %s)
 	fmt.Printf("Wrote %s.\n", b.UpstreamVerFile)
 
 	return nil
+}
+
+// StageMixForBump prepares the mix for the two format bumps to be executed. The
+// current upstreamversion is saved in a backup ".bump" file, and replaced with
+// the latest version in the format range of the most recent build.
+func (b *Builder) StageMixForBump() error {
+	lastBuildVer, err := b.getLastBuildUpstreamVersion()
+	if err != nil {
+		return err
+	}
+	_, _, latest, err := b.getUpstreamFormatRange(lastBuildVer)
+	if err != nil {
+		return err
+	}
+
+	// Copy current upstreamversion to upstreamversion.bump
+	vFile := filepath.Join(b.Config.Builder.VersionPath, b.MixVerFile)
+	vBFile := filepath.Join(b.Config.Builder.VersionPath, b.MixVerFile+".bump")
+	if err := helpers.CopyFile(vBFile, vFile); err != nil {
+		return err
+	}
+
+	// Set current upstreamversion to latest
+	return ioutil.WriteFile(vFile, []byte(strconv.FormatUint(uint64(latest), 10)), 0644)
 }

--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -162,7 +162,7 @@ func addFileAndPath(destination map[string]bool, absPathsToFiles ...string) {
 				continue
 			}
 			path = filepath.Join(path, part)
-			destination[filepath.Join(path)] = true
+			destination[path] = true
 		}
 		destination[file] = true
 	}

--- a/builder/docker.go
+++ b/builder/docker.go
@@ -1,0 +1,271 @@
+// Copyright © 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+import (
+	"crypto/sha512"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/clearlinux/mixer-tools/helpers"
+)
+
+// GetHostAndUpstreamFormats retreives the formats for the host and the mix's
+// upstream version. It attempts to determine the format for the host machine,
+// and if successful, looks up the format for the desired upstream version.
+func (b *Builder) GetHostAndUpstreamFormats() (string, string, error) {
+	// Determine the host's format
+	hostFormat, err := ioutil.ReadFile("/usr/share/defaults/swupd/format")
+	if err != nil && !os.IsNotExist(err) {
+		return "", "", err
+	}
+
+	// Get the upstream format
+	upstreamFormat, err := b.DownloadFileFromUpstreamAsString(fmt.Sprintf("update/%s/format", b.UpstreamVer))
+	if err != nil {
+		return "", "", err
+	}
+
+	return string(hostFormat), upstreamFormat, nil
+}
+
+const dockerfile = `FROM scratch
+ADD mixer.tar.xz /
+ENV LC_ALL="en_US.UTF-8"
+RUN clrtrust generate
+CMD ["/bin/bash"]
+`
+
+func createDockerfile(dir string) error {
+	filename := filepath.Join(dir, "Dockerfile")
+
+	f, err := os.Create(filename)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create Dockerfile")
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	_, err = f.Write([]byte(dockerfile))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getCheckSum(filename string) string {
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return ""
+	}
+	checksum := sha512.Sum512(content)
+	return hex.EncodeToString(checksum[:])
+}
+
+func (b *Builder) dockerImageIsStale(upstreamFile, localFile string) bool {
+	if _, err := os.Stat(localFile); err == nil {
+		checksum, err := b.DownloadFileFromUpstreamAsString(upstreamFile + "-SHA512SUMS")
+		if err == nil {
+			checksum = strings.Split(checksum, " ")[0]
+			if checksum == getCheckSum(localFile) {
+				// File exists and is not stale
+				return false
+			}
+		}
+	}
+	// File does not exist or is stale
+	return true
+}
+
+func getDockerImageName(format string) string {
+	return fmt.Sprintf("mixer-tools/mixer:%s", format)
+}
+
+func (b *Builder) buildDockerImage(format, ver string) error {
+	// Make docker root dir if it doens't exist
+	wd, _ := os.Getwd()
+	dockerRoot := filepath.Join(wd, fmt.Sprintf("docker/mixer-%s", format))
+	if err := os.MkdirAll(dockerRoot, 0777); err != nil {
+		return errors.Wrapf(err, "Failed to generate docker work dir: %s", dockerRoot)
+	}
+
+	upstreamFile := fmt.Sprintf("/releases/%s/clear/clear-%s-mixer.tar.xz", ver, ver)
+	localFile := filepath.Join(dockerRoot, "mixer.tar.xz")
+
+	// Return early if docker image is already built and is not stale
+	cmd := []string{
+		"docker",
+		"images",
+		"-q", getDockerImageName(format),
+	}
+	output, err := helpers.RunCommandOutput(cmd[0], cmd[1:]...)
+	if err != nil {
+		return errors.Wrapf(err, "Error checking for docker image %q", getDockerImageName(format))
+	}
+	stale := b.dockerImageIsStale(upstreamFile, localFile)
+	if !stale && output.String() != "" {
+		return nil
+	}
+
+	// Download the mixer base image from upstream if it's stale
+	if stale {
+		fmt.Println("Downloading image from upstream...")
+		if err := b.DownloadFileFromUpstream(upstreamFile, localFile); err != nil {
+			return errors.Wrapf(err, "Failed to download docker image base for ver %s", ver)
+		}
+	}
+
+	// Generate Dockerfile
+	if err := createDockerfile(dockerRoot); err != nil {
+		return err
+	}
+
+	// Build Docker image
+	fmt.Println("Building Docker image...")
+	cmd = []string{
+		"docker",
+		"build",
+		"-t", getDockerImageName(format),
+		"--rm",
+		filepath.Join(dockerRoot, "."),
+	}
+	if err := helpers.RunCommandSilent(cmd[0], cmd[1:]...); err != nil {
+		return errors.Wrap(err, "Failed to build Docker image")
+	}
+
+	return nil
+}
+
+// reduceDockerMounts takes a list of directory paths and reduces it to a
+// minimal, non-redundant list. For example, if the list includes both "/foo"
+// and "/foo/bar", then "/foo/bar" would be removed, as its parent is already
+// in the list. This function requires paths to have no trailing slash.
+func reduceDockerMounts(paths []string) []string {
+	if len(paths) <= 1 {
+		return paths
+	}
+
+	sort.Strings(paths) // Puts "/foo" before "/foo/bar"
+
+	for i := 1; i < len(paths); i++ {
+		if paths[i] == paths[i-1] || strings.HasPrefix(paths[i], paths[i-1]+"/") { // "/" is to prevent "/foobar" matching "/foo"
+			paths = append(paths[:i], paths[i+1:]...)
+			i-- // Because removal shifts things left
+		}
+	}
+
+	return paths
+}
+
+// getDockerMounts returns a minimal list of all directories in the config that
+// need to be mounted inside the container. Only the "Buiilder" and "Mixer"
+// sections of the conf are parsed.
+func (b *Builder) getDockerMounts() []string {
+	// Returns the longest substring of path that is the path to a directory.
+	var getMaxPath func(path string) string
+	getMaxPath = func(path string) string {
+		f, err := os.Stat(path)
+		if os.IsNotExist(err) {
+			// Try again on parent. This happens because some values in config
+			// are paths to files that get created by the commands, but their
+			// parent directory exists and needs to be mounted.
+			path = filepath.Dir(path)
+			return getMaxPath(path)
+		} else if err != nil {
+			return ""
+		}
+		if f.Mode().IsDir() {
+			return path
+		}
+		return filepath.Dir(path)
+	}
+
+	wd, _ := os.Getwd()
+	mounts := []string{wd}
+
+	config := reflect.ValueOf(b.Config.Builder)
+	for i := 0; i < config.NumField(); i++ {
+		field := getMaxPath(config.Field(i).String())
+		if !strings.HasPrefix(field, "/") {
+			continue
+		}
+		mounts = append(mounts, field)
+	}
+	config = reflect.ValueOf(b.Config.Mixer)
+	for i := 0; i < config.NumField(); i++ {
+		field := getMaxPath(config.Field(i).String())
+		if !strings.HasPrefix(field, "/") {
+			continue
+		}
+		mounts = append(mounts, field)
+	}
+
+	return reduceDockerMounts(mounts)
+}
+
+// RunCommandInContainer will pull the content necessary to build a docker
+// image capable of running the desired command, build that image, and then
+// run the command in that image.
+func (b *Builder) RunCommandInContainer(cmd []string) error {
+	format, _, latest, err := b.getUpstreamFormatRange(b.UpstreamVer)
+	if err != nil {
+		return err
+	}
+
+	if err := b.buildDockerImage(format, fmt.Sprint(latest)); err != nil {
+		return err
+	}
+
+	fmt.Printf("Running command in container: %q\n", strings.Join(cmd, " "))
+
+	wd, _ := os.Getwd()
+
+	// Build Docker image
+	dockerCmd := []string{
+		"docker",
+		"run",
+		"-i",
+		"--network=host",
+		"--rm",
+		"--workdir", wd,
+		"--entrypoint", cmd[0],
+	}
+
+	mounts := b.getDockerMounts()
+	for _, path := range mounts {
+		dockerCmd = append(dockerCmd, "-v", fmt.Sprintf("%s:%s", path, path))
+	}
+
+	dockerCmd = append(dockerCmd, getDockerImageName(format))
+	dockerCmd = append(dockerCmd, cmd[1:]...)
+	dockerCmd = append(dockerCmd, "--native")
+
+	// Run command
+	if err := helpers.RunCommand(dockerCmd[0], dockerCmd[1:]...); err != nil {
+		return errors.Wrap(err, "Failed to run command in container")
+	}
+
+	return nil
+}

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -124,6 +124,11 @@ var buildOldFormatCmd = &cobra.Command{
 			fail(err)
 		}
 
+		// Stage the upstreamversion file for bump
+		if err = b.StageMixForBump(); err != nil {
+			fail(errors.Wrap(err, "Failed to stage mix for format bump"))
+		}
+
 		// Update the mixversion just in case the user did not pass --increment
 		// This must be the +20 to write the new format data files even though we
 		// will build a +10 from the same content

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var config string
@@ -62,6 +63,57 @@ var RootCmd = &cobra.Command{
 				os.Exit(0)
 			}
 		}
+
+		// Init needs to be handled differently because there is no config yet
+		if cmdContains(cmd, "init") {
+			return checkCmdDeps(cmd)
+		}
+
+		b, err := builder.NewFromConfig(config)
+		if err != nil {
+			fail(err)
+		}
+
+		// If running natively, check for format missmatch and warn
+		if builder.Native {
+			hostFormat, upstreamFormat, err := b.GetHostAndUpstreamFormats()
+			if err != nil {
+				fail(err)
+			}
+
+			if hostFormat == "" {
+				fmt.Println("Warning: Unable to determine host format. Running natively may fail.")
+			} else if hostFormat != upstreamFormat {
+				fmt.Println("Warning: The host format and mix upstream format do not match.",
+					"Mixer may be incompatible with this format; running natively may fail.")
+			}
+		}
+
+		// For build commands (except format bump commands), check if building
+		// across a format; if so, inform and exit.
+		// If it's a build command, but *NOT* a build format bump command
+		if !cmdContains(cmd, "format-new") && !cmdContains(cmd, "format-old") && cmdContains(cmd, "build") {
+			if bumpNeeded, err := b.CheckBumpNeeded(); err != nil {
+				return err
+			} else if bumpNeeded {
+				// Cancel native run and return
+				cmd.RunE = nil
+				cmd.Run = func(cmd *cobra.Command, args []string) {} // No-op
+				return nil
+			}
+		}
+
+		// If Native==false, run ONLY build commands in container
+		if !builder.Native && cmdContains(cmd, "build") {
+			if err := b.RunCommandInContainer(reconstructCommand(cmd, args)); err != nil {
+				fail(err)
+			}
+			// Cancel native run and return
+			cmd.RunE = nil
+			cmd.Run = func(cmd *cobra.Command, args []string) {} // No-op
+			return nil
+		}
+
 		return checkCmdDeps(cmd)
 	},
 
@@ -119,6 +171,7 @@ var initCmd = &cobra.Command{
 		if err := b.LoadBuilderConf(config); err != nil {
 			fail(err)
 		}
+
 		err := b.InitMix(initFlags.clearVer, strconv.Itoa(initFlags.mixver), initFlags.allLocal, initFlags.allUpstream, initFlags.upstreamURL, initFlags.git)
 		if err != nil {
 			fail(err)
@@ -146,6 +199,7 @@ func init() {
 	// TODO: Remove this once we drop the old config format
 	RootCmd.PersistentFlags().BoolVar(&builder.UseNewConfig, "new-config", false, "EXPERIMENTAL: use the new TOML config format")
 
+	RootCmd.PersistentFlags().BoolVar(&builder.Native, "native", false, "Run mixer command on native host instead of in a container")
 	RootCmd.PersistentFlags().BoolVar(&builder.Offline, "offline", false, "Skip caching upstream-bundles; work entirely with local-bundles")
 
 	RootCmd.AddCommand(initCmd)
@@ -165,6 +219,34 @@ func init() {
 	externalDeps[initCmd] = []string{
 		"git",
 	}
+}
+
+// cmdContains returns true if cmd or any of its parents are named name
+func cmdContains(cmd *cobra.Command, name string) bool {
+	if cmd.Name() == name {
+		return true
+	}
+	if cmd.HasParent() {
+		return cmdContains(cmd.Parent(), name)
+	}
+	return false
+}
+
+func reconstructCommand(cmd *cobra.Command, args []string) []string {
+	command := []string{cmd.Name()}
+
+	// Loop back up parents, prepending command name
+	for p := cmd.Parent(); p != nil; p = p.Parent() {
+		command = append([]string{p.Name()}, command...)
+	}
+	// For each flag that was set, append its name and value
+	cmd.Flags().Visit(func(flag *pflag.Flag) {
+		command = append(command, "--"+flag.Name+"="+flag.Value.String())
+	})
+	// Append args
+	command = append(command, args...)
+
+	return command
 }
 
 // externalDeps let commands keep track of their external program dependencies. Those will be

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -199,7 +199,7 @@ func init() {
 	// TODO: Remove this once we drop the old config format
 	RootCmd.PersistentFlags().BoolVar(&builder.UseNewConfig, "new-config", false, "EXPERIMENTAL: use the new TOML config format")
 
-	RootCmd.PersistentFlags().BoolVar(&builder.Native, "native", false, "Run mixer command on native host instead of in a container")
+	RootCmd.PersistentFlags().BoolVar(&builder.Native, "native", true, "Run mixer command on native host instead of in a container")
 	RootCmd.PersistentFlags().BoolVar(&builder.Offline, "offline", false, "Skip caching upstream-bundles; work entirely with local-bundles")
 
 	RootCmd.AddCommand(initCmd)
@@ -241,6 +241,9 @@ func reconstructCommand(cmd *cobra.Command, args []string) []string {
 	}
 	// For each flag that was set, append its name and value
 	cmd.Flags().Visit(func(flag *pflag.Flag) {
+		if flag.Name == "native" {
+			return
+		}
 		command = append(command, "--"+flag.Name+"="+flag.Value.String())
 	})
 	// Append args


### PR DESCRIPTION
**DO NOT MERGE YET**
- This has a test command (`mixer build docker [command as args]`) that needs to be removed
- This will currently fail to run unless you've already downloaded the test docker image content and put it in the right directory, as it's not actually being published yet.

The key command here is `RunCommandInContainer(cmd []string) error`

I intend to squash these commits before merging.

------------------

This patch Dockerizes mixer. A new '--native' flag is added that, if
passed, will make mixer run on the host system the way it always did.
This defaults to false.

Before every command runs, if '--native' is false, mixer now pulls an
image file published by upstream that contains the core Clear Linux OS and
mixer toolchain for the version of Clear Linux defined in the upstreamversion
file, which mixer than uses to build a Docker image. Mixer then re-runs the
original mixer command within a container of that Docker image.

This ensures that you are always using a version of the mixer toolchain
compatible with the upstream version you are building off of. This is
required for building across format boundaries.

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>