### PR TITLE
Fix version url bug

### DIFF
--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -458,7 +458,8 @@ func genUpdateBundleSpecialFiles(chrootDir string, cfg *buildBundlesConfig, b *B
 	if err := ioutil.WriteFile(filepath.Join(swupdDir, "contenturl"), cURLBytes, 0644); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(swupdDir, "versionurl"), cURLBytes, 0644); err != nil {
+	vURLBytes := []byte(cfg.VersionURL)
+	if err := ioutil.WriteFile(filepath.Join(swupdDir, "versionurl"), vURLBytes, 0644); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Previously, --new-chroots was accidentally using the 'CONTENTURL' value
from builder.conf for both the 'contenturl' and 'versionurl' files.

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>