### PR TITLE
Add hack to fix bogus contentsize check in client

### DIFF
--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -276,6 +276,12 @@ func CreateManifests(version uint32, minVersion uint32, format uint, statedir st
 			continue
 		}
 
+		// TODO: remove this after a format bump in Clear Linux
+		// this is a hack to set maximum contentsize to the incorrect maximum
+		// set in swupd-client v3.15.3
+		bMan.setMaxContentSizeHack()
+		// end hack
+
 		// sort by version then by filename, previously to this sort these bundles
 		// were sorted by file name only to make processing easier
 		bMan.sortFilesVersionName()

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -984,3 +984,16 @@ func writeIndexManifest(c *config, ui *UpdateInfo, bundles []*Manifest) (*Manife
 
 	return idxMan, nil
 }
+
+// this is a hack to allow users to update using swupd-client v3.15.3 which performs a
+// check on contentsize with a maximum a couple of orders off the intended maximum.
+// Remove this code (and the caller) when a format bump has occurred in Clear.
+var badMax uint64 = 2000000000
+
+func (m *Manifest) setMaxContentSizeHack() {
+	if m.Header.ContentSize >= badMax {
+		m.Header.ContentSize = badMax - 1
+	}
+}
+
+// end hack


### PR DESCRIPTION
A recent bug in swupd-client prevents users from updating due to a
maximum contensize check that was a couple orders of magnitude off.
These clients are broken and cannot update if they have installed
bundles that violate this maximum.

To allow these broken clients to update temporarily set the maximum
contentsize to the bogus contentsize expected by the client.

Remove this check once a format bump has occurred.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>