### PR TITLE
Deprecate and hide --new-swupd and --new-chroots flags

### DIFF
--- a/bat/lib/mixerlib.bash
+++ b/bat/lib/mixerlib.bash
@@ -23,7 +23,7 @@ localize_builder_conf() {
 # the filesystem, and adds only os-core to the mix
 mixer-init-stripped-down() {
   touch $BATS_TEST_DIRNAME/mixbundles
-  mixer init --clear-version $1 --mix-version $2 --new-swupd
+  mixer init --clear-version $1 --mix-version $2
   sed -i 's/os-core-update/os-core/' $BATS_TEST_DIRNAME/builder.conf
   echo "filesystem" > $LOCAL_BUNDLE_DIR/os-core
   mixer bundle add os-core
@@ -34,16 +34,16 @@ mixer-versions-update() {
 }
 
 mixer-build-bundles() {
-  sudo -E mixer build bundles --config $BATS_TEST_DIRNAME/builder.conf --new-swupd --new-chroots
+  sudo -E mixer build bundles --config $BATS_TEST_DIRNAME/builder.conf
 }
 
 mixer-build-update() {
-  sudo -E mixer build update --config $BATS_TEST_DIRNAME/builder.conf --new-swupd
+  sudo -E mixer build update --config $BATS_TEST_DIRNAME/builder.conf
 }
 
 mixer-add-rpms() {
   mkdir -p $BATS_TEST_DIRNAME/local-yum $BATS_TEST_DIRNAME/local-rpms
-  sudo -E mixer add-rpms --config $BATS_TEST_DIRNAME/builder.conf --new-swupd
+  sudo -E mixer add-rpms --config $BATS_TEST_DIRNAME/builder.conf
 }
 
 create-empty-local-bundle() {

--- a/builder/config.go
+++ b/builder/config.go
@@ -42,7 +42,6 @@ type MixConfig struct {
 }
 
 type builderConf struct {
-	BundleDir      string `required:"true" toml:"BUNDLE_DIR"`
 	Cert           string `required:"true" toml:"CERT"`
 	ServerStateDir string `required:"true" toml:"SERVER_STATE_DIR"`
 	VersionPath    string `required:"true" toml:"VERSIONS_PATH"`
@@ -80,7 +79,6 @@ func (config *MixConfig) LoadDefaults() error {
 	}
 
 	// [Builder]
-	config.Builder.BundleDir = filepath.Join(pwd, "mix-bundles")
 	config.Builder.Cert = filepath.Join(pwd, "Swupd_Root.pem")
 	config.Builder.ServerStateDir = filepath.Join(pwd, "update")
 	config.Builder.VersionPath = pwd
@@ -239,7 +237,6 @@ func (config *MixConfig) legacyParse(filename string) error {
 		required bool
 	}{
 		// [Builder]
-		{`^BUNDLE_DIR\s*=\s*`, &config.Builder.BundleDir, true}, //Note: Can be removed once UseNewChrootBuilder is obsolete
 		{`^CERT\s*=\s*`, &config.Builder.Cert, true},
 		{`^SERVER_STATE_DIR\s*=\s*`, &config.Builder.ServerStateDir, true},
 		{`^VERSIONS_PATH\s*=\s*`, &config.Builder.VersionPath, true},

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -187,9 +187,6 @@ var buildDeltaPacksCmd = &cobra.Command{
 	Short: "Build packs used to optimize update between versions",
 	Long: `Build packs used to optimize update between versions
 
-EXPERIMENTAL: this command only works with --new-swupd. For the
-current swupd-server implementation use mixer-pack-maker.sh program.
-
 When a swupd client updates a bundle, it looks for a pack file from
 its current version to the new version. If not available, the client
 will download the individual files necessary for the update. If a
@@ -221,12 +218,6 @@ var buildDeltaPacksFlags struct {
 }
 
 func runBuildDeltaPacks(cmd *cobra.Command, args []string) error {
-	if !builder.UseNewSwupdServer {
-		// TODO: Depending on how long we are going to live with both implementations, it
-		// might be worth making this command call the script when not using new swupd-server.
-		failf("build delta packs is only available with --new-swupd\nUse mixer-pack-maker.sh instead.")
-	}
-
 	fromChanged := cmd.Flags().Changed("from")
 	prevChanged := cmd.Flags().Changed("previous-versions")
 	if fromChanged == prevChanged {

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -279,7 +279,10 @@ func init() {
 	RootCmd.AddCommand(buildCmd)
 
 	buildBundlesCmd.Flags().BoolVar(&buildFlags.noSigning, "no-signing", false, "Do not generate a certificate to sign the Manifest.MoM")
-	buildBundlesCmd.Flags().BoolVar(&builder.UseNewChrootBuilder, "new-chroots", false, "EXPERIMENTAL: Use new implementation of build chroots")
+	unusedBoolFlag := false
+	buildBundlesCmd.Flags().BoolVar(&unusedBoolFlag, "new-chroots", false, "")
+	_ = buildBundlesCmd.Flags().MarkHidden("new-chroots")
+	_ = buildBundlesCmd.Flags().MarkDeprecated("new-chroots", "new functionality is now the standard behavior, this flag is obsolete and no longer used")
 
 	buildImageCmd.Flags().StringVar(&buildFlags.format, "format", "", "Supply the format used for the Mix")
 	buildImageCmd.Flags().StringVar(&buildFlags.template, "template", "", "Path to template file to use")

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -141,7 +141,10 @@ func init() {
 	_ = RootCmd.PersistentFlags().MarkHidden("cpu-profile")
 
 	// TODO: Remove this once we migrate to new implementation.
-	RootCmd.PersistentFlags().BoolVar(&builder.UseNewSwupdServer, "new-swupd", false, "EXPERIMENTAL: Use new implementation of swupd-server when possible")
+	unusedBoolFlag := false
+	RootCmd.PersistentFlags().BoolVar(&unusedBoolFlag, "new-swupd", false, "")
+	_ = RootCmd.Flags().MarkHidden("new-swupd")
+	_ = RootCmd.Flags().MarkDeprecated("new-swupd", "new functionality is now the standard behavior, this flag is obsolete and no longer used")
 
 	// TODO: Remove this once we drop the old config format
 	RootCmd.PersistentFlags().BoolVar(&builder.UseNewConfig, "new-config", false, "EXPERIMENTAL: use the new TOML config format")

--- a/validate-swupd.sh
+++ b/validate-swupd.sh
@@ -57,20 +57,20 @@ for i in $(seq $1 10 $2); do
 	# increase the number of bundle-workers on larger systems
 	# keep in mind that this is network bound due to dnf installs
 	# of upstream tarballs
-	mixer build bundles --new-swupd --bundle-workers 8
+	mixer build bundles --bundle-workers 8
 	if [[ $? -ne 0 ]]; then
 		echo "failed to build mix bundles"
 		exit 1
 	fi
 	# increase the number of fullfile-workers on larger systems
-	mixer build update --new-swupd --fullfile-workers 8 --min-version $1 --format $3
+	mixer build update --fullfile-workers 8 --min-version $1 --format $3
 	if [[ $? -ne 0 ]]; then
 		echo "failed to build mix update"
 		exit 1
 	fi
 	# increase the number of delta-workers on larger systems
 	# this is memory-bound instead of cpu-bound
-	mixer build delta-packs --previous-versions 1 --new-swupd --delta-workers 4
+	mixer build delta-packs --previous-versions 1 --delta-workers 4
 	if [[ $? -ne 0 ]]; then
 		echo "failed to build delta packs"
 		exit 1

--- a/validate-swupd.sh
+++ b/validate-swupd.sh
@@ -57,7 +57,7 @@ for i in $(seq $1 10 $2); do
 	# increase the number of bundle-workers on larger systems
 	# keep in mind that this is network bound due to dnf installs
 	# of upstream tarballs
-	mixer build bundles --new-swupd --new-chroots --bundle-workers 8
+	mixer build bundles --new-swupd --bundle-workers 8
 	if [[ $? -ne 0 ]]; then
 		echo "failed to build mix bundles"
 		exit 1


### PR DESCRIPTION
Deprecate these flags as the new implementation has been heavily tested and can now be default.

bat tests pass.