### PR TITLE
[AFB] Format bump update

### DIFF
--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -249,6 +249,11 @@ var buildNewFormatCmd = &cobra.Command{
 			failf("Couldn't build update: %s", err)
 		}
 
+		// Reset upstreamversion if necessary
+		if err = b.UnstageMixFromBump(); err != nil {
+			fail(errors.Wrapf(err, "Failed to reset upstreamversion after bump"))
+		}
+
 		if buildFlags.increment {
 			if err = b.UpdateMixVer(); err != nil {
 				failf("Couldn't update Mix Version")

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -124,11 +124,6 @@ var buildOldFormatCmd = &cobra.Command{
 			fail(err)
 		}
 
-		// Stage the upstreamversion file for bump
-		if err = b.StageMixForBump(); err != nil {
-			fail(errors.Wrap(err, "Failed to stage mix for format bump"))
-		}
-
 		// Update the mixversion just in case the user did not pass --increment
 		// This must be the +20 to write the new format data files even though we
 		// will build a +10 from the same content

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -91,7 +91,6 @@ var RootCmd = &cobra.Command{
 
 		// For build commands (except format bump commands), check if building
 		// across a format; if so, inform and exit.
-		// If it's a build command, but *NOT* a build format bump command
 		if !cmdContains(cmd, "format-new") && !cmdContains(cmd, "format-old") && cmdContains(cmd, "build") {
 			if bumpNeeded, err := b.CheckBumpNeeded(); err != nil {
 				return err


### PR DESCRIPTION
This PR fixes some issues with the `upstreamversion.bump` file:

- Previously "stage the mix for a bump" command was being called at the start of `mixer build format-old`, but it needs to only happen for format bump builds intended to cross an upstream format boundary. If you're just bumping your mix format, your `upstreamversion` file should remain unchanged.

- Adds a `UnstageMixFromBump` function that cleans up the `.bump` file and reverts the `upstreamversion` file if necessary. This is now called at the end of `mixer build format-new`.