### PR TITLE
 Remove DNF state files from full chroot

### DIFF
--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -540,11 +540,11 @@ func buildFullChroot(cfg *buildBundlesConfig, b *Builder, set *bundleSet, packag
 	}
 	fmt.Println("Installing all bundles to full chroot")
 	totalBundles := len(*set)
+	fullDir := filepath.Join(buildVersionDir, "full")
 	i := 0
 	for _, bundle := range *set {
 		i++
 		fmt.Printf("[%d/%d] %s\n", i, totalBundles, bundle.Name)
-		fullDir := filepath.Join(buildVersionDir, "full")
 		// special handling for os-core
 		if bundle.Name == "os-core" {
 			fmt.Println("... building special os-core content")


### PR DESCRIPTION
When building the full chroot DNF lays down some state directories/files
which end up in the Manifest.full later on just by virtue of them being
there. These files should be removed from the chroot when all package
operations are completed.

Also
The fullDir path does not change for each bundle. Move it outside the
bundle install loop so it is not reassigned every iteration.