### PR TITLE
Update Travis to use clearlinux/mixer-ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,4 @@
-FROM clearlinux:latest
-
-ENV GOPATH /home/gopath
-ENV PATH="/home/gopath/bin:${PATH}"
-COPY . / /home/gopath/src/github.com/clearlinux/mixer-tools/
-RUN swupd bundle-add mixer go-basic c-basic os-core-update-dev && \
-    git config --global user.email "travis@example.com" && \
-    git config --global user.name "Travis CI" && \
-    mkdir -p /run/lock && \
-    clrtrust generate && \
-    go get -u gopkg.in/alecthomas/gometalinter.v2 && \
-    gometalinter.v2 --install
-
-ENTRYPOINT ["/bin/sh", "-c", "cd /home/gopath/src/github.com/clearlinux/mixer-tools && make && make install && make lint; make check"]
-
+FROM clearlinux/mixer-ci:latest
+COPY --chown=clr:clr . /home/clr/go/src/github.com/clearlinux/mixer-tools/
+WORKDIR /home/clr/go/src/github.com/clearlinux/mixer-tools
+ENTRYPOINT ["/bin/sh", "-c", "make && sudo -E make install && make lint && make check"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM clearlinux/mixer-ci:latest
+ENV LC_ALL="en_US.UTF-8"
 COPY --chown=clr:clr . /home/clr/go/src/github.com/clearlinux/mixer-tools/
 WORKDIR /home/clr/go/src/github.com/clearlinux/mixer-tools
-ENTRYPOINT ["/bin/sh", "-c", "make && sudo -E make install && make lint && make check"]
+ENTRYPOINT ["/bin/sh", "-c", "make && sudo -E make install && make lint && make check && make batcheck"]


### PR DESCRIPTION

This patch updates the Travis Dockerfile to build off the new
clearlinux/mixer-ci image.

Previously, the Dockerfile built off the base clearlinux:latest image,
which meant it spent quite some time (~7 min) just building the Docker
image (swup bundl-add'ing the packages it needed) before it could build
and test mixer. This patch eliminates nearly all of that time, as the
Docker build only needs to download an image and copy the mixer files
over.

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>