### PR TITLE
build delta-packs: do not error when --to matches --from

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -1945,7 +1945,10 @@ func (b *Builder) BuildDeltaPacks(from, to uint32, printReport bool) error {
 			return errors.Errorf("--to version must be at most the latest mix version (%d)", b.MixVerUint32)
 		}
 	}
-	if from >= to {
+	if from == to {
+		fmt.Println("the --from version matches the --to version, nothing to do")
+		return nil
+	} else if from > to {
 		return errors.Errorf("the --from version must be smaller than the --to version")
 	}
 


### PR DESCRIPTION
The use case for this is when you want to always allow scripted calls to
build delta-packs to create a delta-pack from the min-version, which
might match the current version for a full min-version. This is
conceptually equivalent to finding 0 previous versions. Print the
information and return nil.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>