### PR TITLE
Add /usr/src/linux- to setBootFromPathname

### DIFF
--- a/swupd/heuristics.go
+++ b/swupd/heuristics.go
@@ -101,6 +101,7 @@ func (f *File) setBootFromPathname() {
 		"/usr/lib/kernel/",
 		"/usr/lib/gummiboot",
 		"/usr/bin/gummiboot",
+		"/usr/src/linux-",
 	}
 
 	for _, path := range bootPaths {


### PR DESCRIPTION
In setStateFromPathname(), paths with /usr/src/ are assigned
ModifierState, so excluded from being written. Kernel source (for
building out-of-tree modules) is intended to be stored under
/usr/src/linux-<release>, so is flagged by this rule. Add a rule in
setBootFromPathname to set ModifierBoot for these paths so that they're
handled the same as kernel modules (/usr/lib/modules) and other kernel
artifacts (/usr/lib/kernel).

Fixes #264

**Probably requires additional support in cbm to ensure cleanup along with kernel image**