### PR TITLE
Add add-repo feature to mixer

### DIFF
--- a/mixer/cmd/rpms.go
+++ b/mixer/cmd/rpms.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
 	"io/ioutil"
 
 	"github.com/clearlinux/mixer-tools/builder"
@@ -29,8 +31,16 @@ var addRPMCmd = &cobra.Command{
 	Run:   runAddRPM,
 }
 
+var addRepoCmd = &cobra.Command{
+	Use:   "add-repo NAME URL",
+	Short: "Add repo NAME at URL",
+	Long:  `Add the repo at URL as a repo from which to pull RPMs for building bundles`,
+	Run:   runAddRepo,
+}
+
 var rpmCmds = []*cobra.Command{
 	addRPMCmd,
+	addRepoCmd,
 }
 
 func init() {
@@ -61,4 +71,20 @@ func runAddRPM(cmd *cobra.Command, args []string) {
 	if err != nil {
 		fail(err)
 	}
+}
+
+func runAddRepo(cmd *cobra.Command, args []string) {
+	if len(args) != 2 {
+		fail(errors.New("add-repo requires 2 arguments: <repo-name> <repo-url>"))
+	}
+	b, err := builder.NewFromConfig(config)
+	if err != nil {
+		fail(err)
+	}
+
+	err = b.AddRepo(args)
+	if err != nil {
+		fail(err)
+	}
+	fmt.Printf("Added %s repo at %s url.\n", args[0], args[1])
 }


### PR DESCRIPTION
The add-repo subcommand adds a remote repo configuration to the DNF conf
defined in the builder.conf. This allows users to configure mixer to use
remote RPM repositories when building mixes instead of being limited to
just local RPMs and upstream Clear Linux RPMs.

This feature is an important pre-requisite for enabling PPA-style repos
on the client side.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>