### PR TITLE
Ignore filenames starting with '.'

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -340,4 +341,27 @@ func RunCommandOutput(cmdname string, args ...string) (*bytes.Buffer, error) {
 		return &outBuf, errors.Wrap(err, buf.String())
 	}
 	return &outBuf, nil
+}
+
+// ListVisibleFiles reads the directory named by dirname and returns a sorted list
+// of names
+func ListVisibleFiles(dirname string) ([]string, error) {
+	f, err := os.Open(dirname)
+	if err != nil {
+		return nil, err
+	}
+
+	list, err := f.Readdirnames(-1)
+	_ = f.Close()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	filtered := make([]string, 0, len(list))
+	for i := range list {
+		if list[i][0] != '.' {
+			filtered = append(filtered, list[i])
+		}
+	}
+	sort.Strings(filtered)
+	return filtered, nil
 }

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 
@@ -143,7 +142,7 @@ var buildAllCmd = &cobra.Command{
 			fail(err)
 		}
 		setWorkers(b)
-		rpms, err := ioutil.ReadDir(b.Config.Mixer.LocalRPMDir)
+		rpms, err := helpers.ListVisibleFiles(b.Config.Mixer.LocalRPMDir)
 		if err == nil {
 			err = b.AddRPMList(rpms)
 			if err != nil {

--- a/mixer/cmd/rpms.go
+++ b/mixer/cmd/rpms.go
@@ -15,9 +15,8 @@
 package cmd
 
 import (
-	"io/ioutil"
-
 	"github.com/clearlinux/mixer-tools/builder"
+	"github.com/clearlinux/mixer-tools/helpers"
 
 	"github.com/spf13/cobra"
 )
@@ -53,7 +52,7 @@ func runAddRPM(cmd *cobra.Command, args []string) {
 	if b.Config.Mixer.LocalRPMDir == "" {
 		failf("LOCAL_RPM_DIR not set in configuration")
 	}
-	rpms, err := ioutil.ReadDir(b.Config.Mixer.LocalRPMDir)
+	rpms, err := helpers.ListVisibleFiles(b.Config.Mixer.LocalRPMDir)
 	if err != nil {
 		failf("cannot read LOCAL_RPM_DIR: %s", err)
 	}


### PR DESCRIPTION
Previously the code was using ioutils.ReadDir which does a stat call
on every file, but none of the code required the results of the stat
calls, just the names.

In addition programs such as git would like to hold information in the
directories. The usual unix way to do this is to have filenames
beginning with '.', and these are ignored by default by things such as
shell globbing and the ls program.

fixes #269

Signed-off-by: Icarus Sparry <icarus.w.sparry@intel.com>