### PR TITLE
Add mixer repo set-url capability

### DIFF
--- a/mixer/cmd/repos.go
+++ b/mixer/cmd/repos.go
@@ -83,7 +83,7 @@ func init() {
 
 func runAddRepo(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
-		fail(errors.New("add requires 2 arguments: <repo-name> <repo-url>"))
+		fail(errors.New("add requires exactly two arguments: <repo-name> <repo-url>"))
 	}
 	b, err := builder.NewFromConfig(config)
 	if err != nil {
@@ -99,7 +99,7 @@ func runAddRepo(cmd *cobra.Command, args []string) {
 
 func runRemoveRepo(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fail(errors.New("remove requires one argument: <name>"))
+		fail(errors.New("remove requires exactly one argument: <name>"))
 	}
 	b, err := builder.NewFromConfig(config)
 	if err != nil {
@@ -139,7 +139,7 @@ func runInitRepo(cmd *cobra.Command, args []string) {
 
 func runSetURLRepo(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
-		fail(errors.New("set-url requires two arguments: <name> <url>"))
+		fail(errors.New("set-url requires exactly two arguments: <name> <url>"))
 	}
 
 	b, err := builder.NewFromConfig(config)

--- a/mixer/cmd/repos.go
+++ b/mixer/cmd/repos.go
@@ -57,11 +57,19 @@ var initRepoCmd = &cobra.Command{
 	Run:   runInitRepo,
 }
 
+var setURLRepoCmd = &cobra.Command{
+	Use:   "set-url <name> <url>",
+	Short: "Sets the URL for repo <name> to <url>",
+	Long:  `Sets the URL, for repo <name> to <url>. If <name> does not exist the repo will be added to the configuration.`,
+	Run:   runSetURLRepo,
+}
+
 var repoCmds = []*cobra.Command{
 	addRepoCmd,
 	removeRepoCmd,
 	listReposCmd,
 	initRepoCmd,
+	setURLRepoCmd,
 }
 
 func init() {
@@ -82,7 +90,7 @@ func runAddRepo(cmd *cobra.Command, args []string) {
 		fail(err)
 	}
 
-	err = b.AddRepo(args)
+	err = b.AddRepo(args[0], args[1])
 	if err != nil {
 		fail(err)
 	}
@@ -127,4 +135,21 @@ func runInitRepo(cmd *cobra.Command, args []string) {
 	if err != nil {
 		fail(err)
 	}
+}
+
+func runSetURLRepo(cmd *cobra.Command, args []string) {
+	if len(args) != 2 {
+		fail(errors.New("set-url requires two arguments: <name> <url>"))
+	}
+
+	b, err := builder.NewFromConfig(config)
+	if err != nil {
+		fail(err)
+	}
+
+	err = b.SetURLRepo(args[0], args[1])
+	if err != nil {
+		fail(err)
+	}
+	fmt.Printf("Set %s baseurl to %s.\n", args[0], args[1])
 }


### PR DESCRIPTION
'mixer repo set-url' allows the user to set the url of a RPM repo to the
url they provide. This is helpful when users want to build mixes off a
mirror of upstream Clear Linux instead of the CDN when the CDN is slow.

mixer repo set-url clear \<mirror-url\>

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>