### PR TITLE
[DO NOT MERGE] -ETOOMANYCONFIGS

### DIFF
--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -21,65 +21,47 @@ import (
 )
 
 // TODO: Move this to the more general configuration handling.
-type buildBundlesConfig struct {
-	// [Server] section.
-	HasServerSection bool
-	DebugInfoBanned  string
-	DebugInfoLib     string
-	DebugInfoSrc     string
-
-	// [swupd] section.
-	UpdateBundle string
-	ContentURL   string
-	VersionURL   string
-	// Format is already in b.Config.Swupd.Format.
-}
-
-// TODO: Move this to the more general configuration handling.
-func readBuildBundlesConfig(path string) (*buildBundlesConfig, error) {
-	iniFile, err := ini.InsensitiveLoad(path)
+func readBuildBundlesConfig(b *Builder) error {
+	iniFile, err := ini.InsensitiveLoad(b.BuildConf)
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	cfg := &buildBundlesConfig{}
 
 	// TODO: Validate early the fields we read.
 	server, err := iniFile.GetSection("Server")
 	if err == nil {
-		cfg.HasServerSection = true
-		cfg.DebugInfoBanned = server.Key("debuginfo_banned").Value()
-		cfg.DebugInfoLib = server.Key("debuginfo_lib").Value()
-		cfg.DebugInfoSrc = server.Key("debuginfo_src").Value()
+		b.Config.Server.DebugInfoBanned = server.Key("debuginfo_banned").Value()
+		b.Config.Server.DebugInfoLib = server.Key("debuginfo_lib").Value()
+		b.Config.Server.DebugInfoSrc = server.Key("debuginfo_src").Value()
 	}
 
 	swupd, err := iniFile.GetSection("swupd")
 	if err != nil {
-		return nil, fmt.Errorf("error in configuration file %s: %s", path, err)
+		return fmt.Errorf("error in configuration file %s: %s", b.BuildConf, err)
 	}
 
 	getKey := func(section *ini.Section, name string) (string, error) {
 		key, kerr := section.GetKey(name)
 		if kerr != nil {
-			return "", fmt.Errorf("error in configuration file %s: %s", path, kerr)
+			return "", fmt.Errorf("error in configuration file %s: %s", b.BuildConf, kerr)
 		}
 		return key.Value(), nil
 	}
 
-	cfg.UpdateBundle, err = getKey(swupd, "BUNDLE")
+	b.Config.Swupd.Bundle, err = getKey(swupd, "BUNDLE")
 	if err != nil {
-		return nil, err
+		return err
 	}
-	cfg.ContentURL, err = getKey(swupd, "CONTENTURL")
+	b.Config.Swupd.ContentURL, err = getKey(swupd, "CONTENTURL")
 	if err != nil {
-		return nil, err
+		return err
 	}
-	cfg.VersionURL, err = getKey(swupd, "VERSIONURL")
+	b.Config.Swupd.VersionURL, err = getKey(swupd, "VERSIONURL")
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return cfg, nil
+	return nil
 }
 
 var bannedPaths = [...]string{
@@ -466,16 +448,16 @@ func buildOsCore(packagerCmd []string, chrootDir, version string) error {
 	return nil
 }
 
-func genUpdateBundleSpecialFiles(chrootDir string, cfg *buildBundlesConfig, b *Builder) error {
+func genUpdateBundleSpecialFiles(chrootDir string, b *Builder) error {
 	swupdDir := filepath.Join(chrootDir, "usr/share/defaults/swupd")
 	if err := os.MkdirAll(swupdDir, 0755); err != nil {
 		return err
 	}
-	cURLBytes := []byte(cfg.ContentURL)
+	cURLBytes := []byte(b.Config.Swupd.ContentURL)
 	if err := ioutil.WriteFile(filepath.Join(swupdDir, "contenturl"), cURLBytes, 0644); err != nil {
 		return err
 	}
-	vURLBytes := []byte(cfg.VersionURL)
+	vURLBytes := []byte(b.Config.Swupd.VersionURL)
 	if err := ioutil.WriteFile(filepath.Join(swupdDir, "versionurl"), vURLBytes, 0644); err != nil {
 		return err
 	}
@@ -550,7 +532,7 @@ func rmDNFStatePaths(fullDir string) {
 	}
 }
 
-func buildFullChroot(cfg *buildBundlesConfig, b *Builder, set *bundleSet, packagerCmd []string, buildVersionDir, version string) error {
+func buildFullChroot(b *Builder, set *bundleSet, packagerCmd []string, buildVersionDir, version string) error {
 	fmt.Println("Cleaning DNF cache before full install")
 	if err := clearDNFCache(packagerCmd); err != nil {
 		return err
@@ -575,9 +557,9 @@ func buildFullChroot(cfg *buildBundlesConfig, b *Builder, set *bundleSet, packag
 		}
 
 		// special handling for update bundle
-		if bundle.Name == cfg.UpdateBundle {
+		if bundle.Name == b.Config.Swupd.Bundle {
 			fmt.Printf("... Adding swupd default values to %s bundle\n", bundle.Name)
-			if err := genUpdateBundleSpecialFiles(fullDir, cfg, b); err != nil {
+			if err := genUpdateBundleSpecialFiles(fullDir, b); err != nil {
 				return err
 			}
 		}
@@ -625,13 +607,15 @@ func (b *Builder) buildBundles(set bundleSet) error {
 	// TODO: Do not touch config code that is in flux at the moment, reparsing it here to grab
 	// information that previously Mixer didn't care about. Move that to the configuration part
 	// of Mixer.
-	cfg, err := readBuildBundlesConfig(b.BuildConf)
-	if err != nil {
-		return err
+	if !UseNewConfig {
+		err := readBuildBundlesConfig(b)
+		if err != nil {
+			return err
+		}
 	}
 
-	if _, ok := set[cfg.UpdateBundle]; !ok {
-		return fmt.Errorf("couldn't find bundle %q specified in configuration as the update bundle", cfg.UpdateBundle)
+	if _, ok := set[b.Config.Swupd.Bundle]; !ok {
+		return fmt.Errorf("couldn't find bundle %q specified in configuration as the update bundle", b.Config.Swupd.Bundle)
 	}
 
 	// Write INI files. These are used to communicate to the next step of mixing (build update).
@@ -640,15 +624,13 @@ func (b *Builder) buildBundles(set bundleSet) error {
 emptydir=%s/empty
 imagebase=%s/image/
 outputdir=%s/www/
-`, b.Config.Builder.ServerStateDir, b.Config.Builder.ServerStateDir, b.Config.Builder.ServerStateDir)
-	if cfg.HasServerSection {
-		fmt.Fprintf(&serverINI, `
 [Debuginfo]
 banned=%s
 lib=%s
 src=%s
-`, cfg.DebugInfoBanned, cfg.DebugInfoLib, cfg.DebugInfoSrc)
-	}
+`, b.Config.Builder.ServerStateDir, b.Config.Builder.ServerStateDir, b.Config.Builder.ServerStateDir,
+		b.Config.Server.DebugInfoBanned, b.Config.Server.DebugInfoLib, b.Config.Server.DebugInfoSrc)
+
 	err = ioutil.WriteFile(filepath.Join(b.Config.Builder.ServerStateDir, "server.ini"), serverINI.Bytes(), 0644)
 	if err != nil {
 		return err
@@ -724,7 +706,7 @@ src=%s
 		return err
 	}
 
-	updateBundle := set[cfg.UpdateBundle]
+	updateBundle := set[b.Config.Swupd.Bundle]
 	var osCore *bundle
 	for _, bundle := range set {
 		if bundle.Name == "os-core" {
@@ -743,7 +725,7 @@ src=%s
 	}
 
 	// install all bundles in the set (including os-core) to the full chroot
-	err = buildFullChroot(cfg, b, &set, packagerCmd, buildVersionDir, version)
+	err = buildFullChroot(b, &set, packagerCmd, buildVersionDir, version)
 	if err != nil {
 		return err
 	}

--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -666,12 +666,12 @@ src=%s
 
 	// Mixer is used to create both Clear Linux or a mix of it.
 	var version string
-	if b.MixVer != "" {
-		fmt.Printf("Creating bundles for version %s based on Clear Linux %s\n", b.MixVer, b.UpstreamVer)
-		version = b.MixVer
+	if b.Config.Builder.MixVer != "" {
+		fmt.Printf("Creating bundles for version %s based on Clear Linux %s\n", b.Config.Builder.MixVer, b.Config.Builder.UpstreamVer)
+		version = b.Config.Builder.MixVer
 	} else {
-		fmt.Printf("Creating bundles for version %s\n", b.UpstreamVer)
-		version = b.UpstreamVer
+		fmt.Printf("Creating bundles for version %s\n", b.Config.Builder.UpstreamVer)
+		version = b.Config.Builder.UpstreamVer
 		// TODO: This validation should happen when reading the configuration.
 		if version == "" {
 			return errors.Errorf("no Mixver or Clearver set, unable to proceed")
@@ -702,7 +702,7 @@ src=%s
 		"dnf",
 		"--config=" + b.Config.Builder.DNFConf,
 		"-y",
-		"--releasever=" + b.UpstreamVer,
+		"--releasever=" + b.Config.Builder.UpstreamVer,
 	}
 
 	fmt.Printf("Packager command-line: %s\n", strings.Join(packagerCmd, " "))

--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -619,23 +619,6 @@ func (b *Builder) buildBundles(set bundleSet) error {
 		return fmt.Errorf("couldn't find bundle %q specified in configuration as the update bundle", b.Config.Swupd.Bundle)
 	}
 
-	// Write INI files. These are used to communicate to the next step of mixing (build update).
-	var serverINI bytes.Buffer
-	fmt.Fprintf(&serverINI, `[Server]
-emptydir=%s/empty
-imagebase=%s/image/
-outputdir=%s/www/
-[Debuginfo]
-banned=%s
-lib=%s
-src=%s
-`, b.Config.Builder.ServerStateDir, b.Config.Builder.ServerStateDir, b.Config.Builder.ServerStateDir,
-		b.Config.Server.DebugInfoBanned, b.Config.Server.DebugInfoLib, b.Config.Server.DebugInfoSrc)
-
-	err = ioutil.WriteFile(filepath.Join(b.Config.Builder.ServerStateDir, "server.ini"), serverINI.Bytes(), 0644)
-	if err != nil {
-		return err
-	}
 	// TODO: If we are using INI files that are case insensitive, we need to be more restrictive
 	// in bundleset to check for that. See also readGroupsINI in swupd package.
 	var groupsINI bytes.Buffer

--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/clearlinux/mixer-tools/config"
 	"github.com/clearlinux/mixer-tools/helpers"
 	"github.com/go-ini/ini"
 	"github.com/pkg/errors"
@@ -607,7 +608,7 @@ func (b *Builder) buildBundles(set bundleSet) error {
 	// TODO: Do not touch config code that is in flux at the moment, reparsing it here to grab
 	// information that previously Mixer didn't care about. Move that to the configuration part
 	// of Mixer.
-	if !UseNewConfig {
+	if !config.UseNewConfig {
 		err := readBuildBundlesConfig(b)
 		if err != nil {
 			return err

--- a/builder/config.go
+++ b/builder/config.go
@@ -46,6 +46,10 @@ type builderConf struct {
 	ServerStateDir string `required:"true" toml:"SERVER_STATE_DIR"`
 	VersionPath    string `required:"true" toml:"VERSIONS_PATH"`
 	DNFConf        string `required:"true" toml:"YUM_CONF"`
+	//TODO: Change required to true when old config is removed
+	MixVer      string `required:"false" toml:"MIX_VERSION"`
+	UpstreamVer string `required:"false" toml:"UPSTREAM_VERSION"`
+	UpstreamURL string `required:"false" toml:"UPSTREAM_URL"`
 }
 
 type swupdConf struct {
@@ -83,6 +87,9 @@ func (config *MixConfig) LoadDefaults() error {
 	config.Builder.ServerStateDir = filepath.Join(pwd, "update")
 	config.Builder.VersionPath = pwd
 	config.Builder.DNFConf = filepath.Join(pwd, ".yum-mix.conf")
+	config.Builder.MixVer = "10"
+	config.Builder.UpstreamVer = "latest"
+	config.Builder.UpstreamURL = "https://download.clearlinux.org"
 
 	// [Swupd]
 	config.Swupd.Bundle = "os-core-update"

--- a/config/config.go
+++ b/config/config.go
@@ -73,10 +73,6 @@ type mixerConf struct {
 
 // LoadDefaults sets sane values for the config properties
 func (config *MixConfig) LoadDefaults() error {
-	if !UseNewConfig {
-		return nil
-	}
-
 	pwd, err := os.Getwd()
 	if err != nil {
 		return err

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package builder
+package config
 
 import (
 	"bytes"
@@ -359,4 +359,18 @@ func (config *MixConfig) Print() error {
 	fmt.Println(sb.String())
 
 	return nil
+}
+
+// GetConfigPath returns the default config path if the provided path is empty
+func GetConfigPath(path string) (string, error) {
+	if path != "" {
+		return path, nil
+	}
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(pwd, "builder.conf"), nil
 }

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -97,7 +97,7 @@ var buildBundlesCmd = &cobra.Command{
 	Short:   "Build the bundles for your mix",
 	Long:    `Build the bundles for your mix`,
 	Run: func(cmd *cobra.Command, args []string) {
-		b, err := builder.NewFromConfig(config)
+		b, err := builder.NewFromConfig(configFile)
 		if err != nil {
 			fail(err)
 		}
@@ -114,7 +114,7 @@ var buildUpdateCmd = &cobra.Command{
 	Short: "Build the update content for your mix",
 	Long:  `Build the update content for your mix`,
 	Run: func(cmd *cobra.Command, args []string) {
-		b, err := builder.NewFromConfig(config)
+		b, err := builder.NewFromConfig(configFile)
 		if err != nil {
 			fail(err)
 		}
@@ -137,7 +137,7 @@ var buildAllCmd = &cobra.Command{
 	Short: "Build all content for mix with default options",
 	Long:  `Build all content for mix with default options`,
 	Run: func(cmd *cobra.Command, args []string) {
-		b, err := builder.NewFromConfig(config)
+		b, err := builder.NewFromConfig(configFile)
 		if err != nil {
 			fail(err)
 		}
@@ -169,7 +169,7 @@ var buildImageCmd = &cobra.Command{
 	Short: "Build an image from the mix content",
 	Long:  `Build an image from the mix content`,
 	Run: func(cmd *cobra.Command, args []string) {
-		b, err := builder.NewFromConfig(config)
+		b, err := builder.NewFromConfig(configFile)
 		if err != nil {
 			fail(err)
 		}
@@ -223,7 +223,7 @@ func runBuildDeltaPacks(cmd *cobra.Command, args []string) error {
 		return errors.Errorf("either --from or --previous-versions must be set, but not both")
 	}
 
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}
@@ -260,7 +260,7 @@ var buildCmds = []*cobra.Command{
 func init() {
 	for _, cmd := range buildCmds {
 		buildCmd.AddCommand(cmd)
-		cmd.Flags().StringVarP(&config, "config", "c", "", "Builder config to use")
+		cmd.Flags().StringVarP(&configFile, "config", "c", "", "Builder config to use")
 	}
 
 	buildCmd.PersistentFlags().IntVar(&buildFlags.numFullfileWorkers, "fullfile-workers", 0, "Number of parallel workers when creating fullfiles, 0 means number of CPUs")

--- a/mixer/cmd/bundles.go
+++ b/mixer/cmd/bundles.go
@@ -50,7 +50,7 @@ resultant list is written back out in sorted order.`,
 			}
 		}
 
-		b, err := builder.NewFromConfig(config)
+		b, err := builder.NewFromConfig(configFile)
 		if err != nil {
 			fail(err)
 		}
@@ -92,7 +92,7 @@ and now reference the original upstream version. If the bundle was custom, and
 no upstream alternative exists, a warning will be returned.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		b, err := builder.NewFromConfig(config)
+		b, err := builder.NewFromConfig(configFile)
 		if err != nil {
 			fail(err)
 		}
@@ -125,7 +125,7 @@ var bundleListCmd = &cobra.Command{
 			return errors.New("bundle list takes at most one argument")
 		}
 
-		b, err := builder.NewFromConfig(config)
+		b, err := builder.NewFromConfig(configFile)
 		if err != nil {
 			fail(err)
 		}
@@ -186,7 +186,7 @@ bundles are added after all bundles are edited, and thus will not be added if
 any errors are encountered earlier on.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		b, err := builder.NewFromConfig(config)
+		b, err := builder.NewFromConfig(configFile)
 		if err != nil {
 			fail(err)
 		}
@@ -227,7 +227,7 @@ Passing '--all-local' will run validation on all bundles in local-bundles.`,
 			return errors.New("bundle validate requires at least 1 argument if --all-local is not passed")
 		}
 
-		b, err := builder.NewFromConfig(config)
+		b, err := builder.NewFromConfig(configFile)
 		if err != nil {
 			fail(err)
 		}
@@ -264,7 +264,7 @@ var bundlesCmds = []*cobra.Command{
 func init() {
 	for _, cmd := range bundlesCmds {
 		bundleCmd.AddCommand(cmd)
-		cmd.Flags().StringVarP(&config, "config", "c", "", "Builder config to use")
+		cmd.Flags().StringVarP(&configFile, "config", "c", "", "Builder config to use")
 	}
 
 	RootCmd.AddCommand(bundleCmd)

--- a/mixer/cmd/config.go
+++ b/mixer/cmd/config.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	"github.com/clearlinux/mixer-tools/builder"
+	"github.com/clearlinux/mixer-tools/config"
 	"github.com/spf13/cobra"
 )
 
@@ -32,13 +32,13 @@ var configValidateCmd = &cobra.Command{
 environment variables will be expanded`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
-		if configFile, err = builder.GetConfigPath(configFile); err != nil {
+		if configFile, err = config.GetConfigPath(configFile); err != nil {
 			// Print error, but don't print command usage
 			fail(err)
 			return
 		}
 
-		var mc builder.MixConfig
+		var mc config.MixConfig
 		if err := mc.LoadConfig(configFile); err != nil {
 			fail(err)
 			return
@@ -60,12 +60,12 @@ a backup file of the old config and will replace it with the converted one. Envi
 variables will not be expanded and the values will not be validated`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
-		if configFile, err = builder.GetConfigPath(configFile); err != nil {
+		if configFile, err = config.GetConfigPath(configFile); err != nil {
 			fail(err)
 			return
 		}
 
-		var mc builder.MixConfig
+		var mc config.MixConfig
 		if err := mc.Convert(configFile); err != nil {
 			fail(err)
 			return

--- a/mixer/cmd/config.go
+++ b/mixer/cmd/config.go
@@ -32,14 +32,14 @@ var configValidateCmd = &cobra.Command{
 environment variables will be expanded`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
-		if config, err = builder.GetConfigPath(config); err != nil {
+		if configFile, err = builder.GetConfigPath(configFile); err != nil {
 			// Print error, but don't print command usage
 			fail(err)
 			return
 		}
 
 		var mc builder.MixConfig
-		if err := mc.LoadConfig(config); err != nil {
+		if err := mc.LoadConfig(configFile); err != nil {
 			fail(err)
 			return
 		}
@@ -60,13 +60,13 @@ a backup file of the old config and will replace it with the converted one. Envi
 variables will not be expanded and the values will not be validated`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
-		if config, err = builder.GetConfigPath(config); err != nil {
+		if configFile, err = builder.GetConfigPath(configFile); err != nil {
 			fail(err)
 			return
 		}
 
 		var mc builder.MixConfig
-		if err := mc.Convert(config); err != nil {
+		if err := mc.Convert(configFile); err != nil {
 			fail(err)
 			return
 		}
@@ -83,7 +83,7 @@ var configCmds = []*cobra.Command{
 func init() {
 	for _, cmd := range configCmds {
 		configCmd.AddCommand(cmd)
-		cmd.Flags().StringVarP(&config, "config", "c", "", "Builder config to use")
+		cmd.Flags().StringVarP(&configFile, "config", "c", "", "Builder config to use")
 	}
 
 	RootCmd.AddCommand(configCmd)

--- a/mixer/cmd/repos.go
+++ b/mixer/cmd/repos.go
@@ -75,7 +75,7 @@ var repoCmds = []*cobra.Command{
 func init() {
 	for _, cmd := range repoCmds {
 		repoCmd.AddCommand(cmd)
-		cmd.Flags().StringVarP(&config, "config", "c", "", "Builder config to use")
+		cmd.Flags().StringVarP(&configFile, "config", "c", "", "Builder config to use")
 	}
 
 	RootCmd.AddCommand(repoCmd)
@@ -85,7 +85,7 @@ func runAddRepo(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
 		fail(errors.New("add requires exactly two arguments: <repo-name> <repo-url>"))
 	}
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}
@@ -101,7 +101,7 @@ func runRemoveRepo(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		fail(errors.New("remove requires exactly one argument: <name>"))
 	}
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}
@@ -114,7 +114,7 @@ func runRemoveRepo(cmd *cobra.Command, args []string) {
 }
 
 func runListRepos(cmd *cobra.Command, args []string) {
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}
@@ -126,7 +126,7 @@ func runListRepos(cmd *cobra.Command, args []string) {
 }
 
 func runInitRepo(cmd *cobra.Command, args []string) {
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}
@@ -142,7 +142,7 @@ func runSetURLRepo(cmd *cobra.Command, args []string) {
 		fail(errors.New("set-url requires exactly two arguments: <name> <url>"))
 	}
 
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -29,7 +29,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var config string
+var configFile string
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
@@ -110,13 +110,13 @@ var initCmd = &cobra.Command{
 		}
 
 		b := builder.New()
-		if config == "" {
+		if configFile == "" {
 			// Create default config if necessary
 			if err := b.Config.CreateDefaultConfig(initFlags.localRPMs); err != nil {
 				fail(err)
 			}
 		}
-		if err := b.LoadBuilderConf(config); err != nil {
+		if err := b.LoadBuilderConf(configFile); err != nil {
 			fail(err)
 		}
 		err := b.InitMix(initFlags.clearVer, strconv.Itoa(initFlags.mixver), initFlags.allLocal, initFlags.allUpstream, initFlags.upstreamURL, initFlags.git)
@@ -161,7 +161,7 @@ func init() {
 	initCmd.Flags().StringVar(&initFlags.clearVer, "upstream-version", "latest", "Alias to --clear-version")
 	initCmd.Flags().IntVar(&initFlags.mixver, "mix-version", 10, "Supply the Mix version to build")
 	initCmd.Flags().BoolVar(&initFlags.localRPMs, "local-rpms", false, "Create and configure local RPMs directories")
-	initCmd.Flags().StringVar(&config, "config", "", "Supply a specific builder.conf to use for mixing")
+	initCmd.Flags().StringVar(&configFile, "config", "", "Supply a specific builder.conf to use for mixing")
 	initCmd.Flags().StringVar(&initFlags.upstreamURL, "upstream-url", "https://download.clearlinux.org", "Supply an upstream URL to use for mixing")
 	initCmd.Flags().BoolVar(&initFlags.git, "git", false, "Track mixer's internal work dir with git")
 

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/clearlinux/mixer-tools/builder"
+	"github.com/clearlinux/mixer-tools/config"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -147,7 +148,7 @@ func init() {
 	_ = RootCmd.Flags().MarkDeprecated("new-swupd", "new functionality is now the standard behavior, this flag is obsolete and no longer used")
 
 	// TODO: Remove this once we drop the old config format
-	RootCmd.PersistentFlags().BoolVar(&builder.UseNewConfig, "new-config", false, "EXPERIMENTAL: use the new TOML config format")
+	RootCmd.PersistentFlags().BoolVar(&config.UseNewConfig, "new-config", false, "EXPERIMENTAL: use the new TOML config format")
 
 	RootCmd.PersistentFlags().BoolVar(&builder.Offline, "offline", false, "Skip caching upstream-bundles; work entirely with local-bundles")
 

--- a/mixer/cmd/rpms.go
+++ b/mixer/cmd/rpms.go
@@ -35,7 +35,7 @@ var rpmCmds = []*cobra.Command{
 func init() {
 	for _, cmd := range rpmCmds {
 		RootCmd.AddCommand(cmd)
-		cmd.Flags().StringVarP(&config, "config", "c", "", "Builder config to use")
+		cmd.Flags().StringVarP(&configFile, "config", "c", "", "Builder config to use")
 	}
 
 	externalDeps[addRPMCmd] = []string{
@@ -45,7 +45,7 @@ func init() {
 }
 
 func runAddRPM(cmd *cobra.Command, args []string) {
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}

--- a/mixer/cmd/versions.go
+++ b/mixer/cmd/versions.go
@@ -63,7 +63,7 @@ func init() {
 	versionsCmd.AddCommand(versionsUpdateCmd)
 	RootCmd.AddCommand(versionsCmd)
 
-	versionsUpdateCmd.Flags().StringVarP(&config, "config", "c", "", "Builder config to use")
+	versionsUpdateCmd.Flags().StringVarP(&configFile, "config", "c", "", "Builder config to use")
 	versionsUpdateCmd.Flags().Uint32Var(&versionsUpdateFlags.mixVersion, "mix-version", 0, "Set a specific mix version")
 	versionsUpdateCmd.Flags().StringVar(&versionsUpdateFlags.upstreamVersion, "upstream-version", "", "Next upstream version (either version number or 'latest')")
 	versionsUpdateCmd.Flags().StringVar(&versionsUpdateFlags.upstreamVersion, "clear-version", "", "Alias to --upstream-version")
@@ -71,7 +71,7 @@ func init() {
 }
 
 func runVersions(cmd *cobra.Command, args []string) {
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}
@@ -82,7 +82,7 @@ func runVersions(cmd *cobra.Command, args []string) {
 }
 
 func runVersionsUpdate(cmd *cobra.Command, args []string) {
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}

--- a/swupd/bundleinfo.go
+++ b/swupd/bundleinfo.go
@@ -86,7 +86,7 @@ func (m *Manifest) getBundleInfo(path string) error {
 	return nil
 }
 
-func (m *Manifest) addFilesFromBundleInfo(c config, version uint32) error {
+func (m *Manifest) addFilesFromBundleInfo(c swupdData, version uint32) error {
 	chrootDir := filepath.Join(c.imageBase, fmt.Sprint(version), "full")
 	for fpath := range m.bundleInfo.Files {
 		fullPath := filepath.Join(chrootDir, fpath)

--- a/swupd/cmd/create-pack/main.go
+++ b/swupd/cmd/create-pack/main.go
@@ -9,6 +9,7 @@ import (
 	"runtime/pprof"
 	"strconv"
 
+	"github.com/clearlinux/mixer-tools/config"
 	"github.com/clearlinux/mixer-tools/swupd"
 )
 
@@ -108,6 +109,9 @@ func main() {
 		bundles["name"] = bundle
 	}
 
+	var c config.MixConfig
+	c.LoadDefaults()
+
 	// TODO: Use goroutines.
 	for _, b := range bundles {
 		// Unless we are forcing, skip the packs already on disk.
@@ -124,7 +128,7 @@ func main() {
 
 		fmt.Printf("Packing %s from %d to %d...\n", b.Name, b.FromVersion, b.ToVersion)
 
-		info, err := swupd.CreatePack(b.Name, b.FromVersion, b.ToVersion, filepath.Join(stateDir, "www"), chrootDir, 0)
+		info, err := swupd.CreatePack(c, b.Name, b.FromVersion, b.ToVersion, filepath.Join(stateDir, "www"), chrootDir, 0)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/swupd/data_test.go
+++ b/swupd/data_test.go
@@ -5,29 +5,6 @@ import (
 	"testing"
 )
 
-func TestReadServerINI(t *testing.T) {
-	if c, _ := readServerINI("nowhere", "noINI"); !reflect.DeepEqual(c, defaultConfig) {
-		// should just leave the defaults in place
-		t.Error("generated config was the not the expected default config")
-	}
-
-	var c config
-	c, _ = readServerINI("/var/lib/update", "testdata/server.ini")
-	if reflect.DeepEqual(c, defaultConfig) {
-		t.Error("generated config was the same as the default config")
-	}
-
-	if c.emptyDir != "/var/lib/update/emptytest/" ||
-		c.imageBase != "/var/lib/update/imagetest/" ||
-		c.outputDir != "/var/lib/update/wwwtest/" ||
-		c.debuginfo.banned != true ||
-		c.debuginfo.lib != "/usr/lib/debugtest/" ||
-		c.debuginfo.src != "/usr/src/debugtest/" {
-		t.Errorf("%v\n%v\n%v\n%v\n%v\n",
-			c.imageBase, c.outputDir, c.debuginfo.banned, c.debuginfo.lib, c.debuginfo.src)
-	}
-}
-
 func TestReadGroupsINI(t *testing.T) {
 	var err error
 	if _, err = readGroupsINI("nowhere"); err == nil {

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -11,6 +11,8 @@ import (
 	"regexp"
 	"testing"
 	"text/template"
+
+	"github.com/clearlinux/mixer-tools/config"
 )
 
 func removeAllIgnoreErr(dir string) {
@@ -171,8 +173,11 @@ func mustCreateManifestsStandard(t *testing.T, ver uint32, testDir string) *MoM 
 }
 
 func mustCreateManifests(t *testing.T, ver uint32, minVer uint32, format uint, testDir string) *MoM {
+	var c config.MixConfig
+	c.LoadDefaults()
+
 	t.Helper()
-	mom, err := CreateManifests(ver, minVer, format, testDir)
+	mom, err := CreateManifests(c, ver, minVer, format, testDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,7 +234,12 @@ func checkManifestMatches(t *testing.T, testDir, ver, name string, res ...*regex
 
 func mustCreateAllDeltas(t *testing.T, manifest, statedir string, from, to uint32) {
 	t.Helper()
-	deltas, err := CreateDeltas(manifest, statedir, from, to, 0)
+
+	var c config.MixConfig
+	c.LoadDefaults()
+	c.Builder.ServerStateDir = statedir
+
+	deltas, err := CreateDeltas(c, manifest, from, to, 0)
 	if err != nil {
 		t.Fatalf("couldn't create deltas for %s: %s", manifest, err)
 	}
@@ -686,7 +696,10 @@ func (ts *testSwupd) createManifests(version uint32) *MoM {
 	osRelease := fmt.Sprintf("VERSION_ID=%d\n", version)
 	ts.addFile(version, "os-core", "/usr/lib/os-release", osRelease)
 
-	mom, err := CreateManifests(version, ts.MinVersion, ts.Format, ts.Dir)
+	var c config.MixConfig
+	c.LoadDefaults()
+
+	mom, err := CreateManifests(c, version, ts.MinVersion, ts.Format, ts.Dir)
 	if err != nil {
 		ts.t.Fatalf("error creating manifests for version %d: %s", version, err)
 	}
@@ -707,7 +720,10 @@ func (ts *testSwupd) createManifestsFromChroots(version uint32) *MoM {
 	osRelease := fmt.Sprintf("VERSION_ID=%d\n", version)
 	ts.write(filepath.Join("image", fmt.Sprint(version), "os-core", "usr/lib/os-release"), osRelease)
 
-	mom, err := CreateManifests(version, ts.MinVersion, ts.Format, ts.Dir)
+	var c config.MixConfig
+	c.LoadDefaults()
+
+	mom, err := CreateManifests(c, version, ts.MinVersion, ts.Format, ts.Dir)
 	if err != nil {
 		ts.t.Fatalf("error creating manifests for version %d: %s", version, err)
 	}

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -375,7 +375,7 @@ func (m *Manifest) sortFilesVersionName() {
 // in the chroot for that manifest. Link delta peers with the oldManifest
 // if the file in the oldManifest is not deleted or ghosted.
 // Expects m and oldManifest files lists to be sorted by name only
-func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, c config, minVersion uint32) (int, int, int) {
+func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, c swupdData, minVersion uint32) (int, int, int) {
 	// set previous version to oldManifest version
 	m.Header.Previous = oldManifest.Header.Version
 
@@ -478,7 +478,7 @@ func (m *Manifest) newDeleted(df *File) {
 
 // linkDeltaPeersForPack sets the DeltaPeer of the files in newManifest that have the corresponding files
 // in oldManifest.
-func linkDeltaPeersForPack(c *config, oldManifest, newManifest *Manifest) error {
+func linkDeltaPeersForPack(c *swupdData, oldManifest, newManifest *Manifest) error {
 	newIndex := 0
 	oldIndex := 0
 	added := []*File{}
@@ -707,7 +707,7 @@ type bundleIndex struct {
 	bsize uint64
 }
 
-func constructIndex(c *config, ui *UpdateInfo, f2b []*bundleIndex) error {
+func constructIndex(c *swupdData, ui *UpdateInfo, f2b []*bundleIndex) error {
 	// sort by filename then by bundle size
 	sort.Slice(f2b[:], func(i, j int) bool {
 		if f2b[i].fname == f2b[j].fname {
@@ -744,7 +744,7 @@ func constructIndex(c *config, ui *UpdateInfo, f2b []*bundleIndex) error {
 // sorts the index first by filename then by bundle name. writeIndexManifest creates a new
 // bundle in which the file will live. This bundle is added to the "full" manifest which
 // is part of the bundles slice. A pointer to the new manifest is returned on success.
-func writeIndexManifest(c *config, ui *UpdateInfo, bundles []*Manifest) (*Manifest, error) {
+func writeIndexManifest(c *swupdData, ui *UpdateInfo, bundles []*Manifest) (*Manifest, error) {
 	fileToBundles := []*bundleIndex{}
 	var newFull, newOsCore *Manifest
 	for _, b := range bundles {

--- a/swupd/manifest_test.go
+++ b/swupd/manifest_test.go
@@ -10,6 +10,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/clearlinux/mixer-tools/config"
 )
 
 func TestReadManifestHeaderManifest(t *testing.T) {
@@ -398,11 +400,15 @@ func TestLinkPeersAndChange(t *testing.T) {
 		"6": {false, ""},
 	}
 
+	var c config.MixConfig
+	c.LoadDefaults()
+	sdata := swupdDataFromConfig(c)
+
 	// linkPeersAndChange requires mNew and mOld to have file lists sorted
 	// by name.
 	mNew.sortFilesName()
 	mOld.sortFilesName()
-	changed, added, deleted := mNew.linkPeersAndChange(&mOld, config{}, 0)
+	changed, added, deleted := mNew.linkPeersAndChange(&mOld, sdata, 0)
 	if changed != 2 {
 		t.Errorf("%v files detected as changed when 2 was expected", changed)
 	}

--- a/swupd/rename.go
+++ b/swupd/rename.go
@@ -22,16 +22,16 @@ import (
 	"strings"
 )
 
-func renameDetection(manifest *Manifest, added []*File, removed []*File, c config) {
+func renameDetection(manifest *Manifest, added []*File, removed []*File, sdata swupdData) {
 	if len(added) == 0 || len(removed) == 0 {
 		return // nothing to rename
 	}
 	added = trimRenamed(added) // Make copies of input slices, tidy up whilst we are here
 	removed = trimRenamed(removed)
-	if err := fixupStatFields(removed, manifest, &c); err != nil {
+	if err := fixupStatFields(removed, manifest, &sdata); err != nil {
 		panic(err)
 	}
-	if err := fixupStatFields(added, manifest, &c); err != nil {
+	if err := fixupStatFields(added, manifest, &sdata); err != nil {
 		panic(err)
 	}
 	// Handle pure renames first, don't need to worry about size. Should we skip zero size?
@@ -177,16 +177,16 @@ func makePairedNames(list []*File) []pairedNames {
 }
 
 // fixupstatfields adds the missing stat fields
-// construct the path to the old chroot by Joining the c.imageBase
+// construct the path to the old chroot by Joining the sdata.imageBase
 // file.Previous, bundle name, and file.Name fields
 // Note this is horrible
-func fixupStatFields(needed []*File, m *Manifest, c *config) error {
+func fixupStatFields(needed []*File, m *Manifest, sdata *swupdData) error {
 	var bundleChroot string
 	for i := range needed {
 		if needed[i].Info != nil {
 			continue
 		}
-		bundleChroot = filepath.Join(c.imageBase, fmt.Sprint(needed[i].Version), "full")
+		bundleChroot = filepath.Join(sdata.imageBase, fmt.Sprint(needed[i].Version), "full")
 		path := filepath.Join(bundleChroot, needed[i].Name)
 		fi, err := os.Lstat(path)
 		if err != nil {

--- a/swupd/rename_test.go
+++ b/swupd/rename_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"syscall"
 	"testing"
+
+	"github.com/clearlinux/mixer-tools/config"
 )
 
 // Need to set up a type to hold the FileInfo
@@ -134,10 +136,14 @@ func TestRename(t *testing.T) {
 			remove: []string{"S1", "L3", "S2", "L1"}, add: []string{"L4", "L2"},
 			partner: []int{-1, 0, -1, 1}},
 	}
+	var c config.MixConfig
+	c.LoadDefaults()
+	sdata := swupdDataFromConfig(c)
+
 	for _, tc := range tests {
 		add := filelist(t, sn, tc.add)
 		remove := markdelete(filelist(t, sn, tc.remove))
-		renameDetection(&Manifest{}, add, remove, config{})
+		renameDetection(&Manifest{}, add, remove, sdata)
 		if len(tc.partner) != len(tc.remove) {
 			t.Fatalf("Invalid testcase %v, wrong partner length", tc)
 		}


### PR DESCRIPTION
This is the first 100% test coverage version of the config unification patch.

The first big change with this patch is the move of config from builder to its own package. While inside builder it could not be used inside swupd since that would generate a cyclic dependency. Moving it outside allows for reuse in both parts of the code.

Another change is the rename of a bunch of stuff called config. With config now in its own package, it had conflicts with the config object defined inside swupd and the config global variable used to hold the config file name in the cmd package. Both are now renamed properly.

Note that most of this patch is focused on removing the extra config files (namely mixversion, upstreamversion, upstreamurl and server.ini) and not in reworking the communication API between builder and swupd. That part still need some work to remove redundant parameter passing. Since that rework is also a big patch, I decided to split the PR and send that on top of this one.

Also, note that while test coverage is 100%, that does not include use with --new-config, so there might be crashes that sliped through my review. Adding --new-config to tests is something that I'm evaluating atm and wasn't included mostly because I don't wanna duplicate all tests just to remove then later when new config becomes default. 