### PR TITLE
Config Set and Battest for --new-config

### DIFF
--- a/bat/lib/mixerlib.bash
+++ b/bat/lib/mixerlib.bash
@@ -15,7 +15,11 @@ global_setup() {
 }
 
 localize_builder_conf() {
-  echo -e "LOCAL_RPM_DIR=$BATS_TEST_DIRNAME/local-rpms\nLOCAL_REPO_DIR=$BATS_TEST_DIRNAME/local-yum" >> $BATS_TEST_DIRNAME/builder.conf
+  if $(mixer $MIXARGS config set Mixer.LocalRPMDir $BATS_TEST_DIRNAME/local-rpms); then
+    mixer $MIXARGS config set  Mixer.LocalRepoDir $BATS_TEST_DIRNAME/local-yum
+  else
+    echo -e "LOCAL_RPM_DIR=$BATS_TEST_DIRNAME/local-rpms\nLOCAL_REPO_DIR=$BATS_TEST_DIRNAME/local-yum" >> $BATS_TEST_DIRNAME/builder.conf
+  fi
 }
 
 # Initializes a mix with the desired versions. Then for efficiency converts 

--- a/bat/lib/mixerlib.bash
+++ b/bat/lib/mixerlib.bash
@@ -23,27 +23,27 @@ localize_builder_conf() {
 # the filesystem, and adds only os-core to the mix
 mixer-init-stripped-down() {
   touch $BATS_TEST_DIRNAME/mixbundles
-  mixer init --clear-version $1 --mix-version $2
+  mixer $MIXARGS init --clear-version $1 --mix-version $2
   sed -i 's/os-core-update/os-core/' $BATS_TEST_DIRNAME/builder.conf
   echo "filesystem" > $LOCAL_BUNDLE_DIR/os-core
-  mixer bundle add os-core
+  mixer $MIXARGS bundle add os-core
 }
 
 mixer-versions-update() {
-  mixer versions update --mix-version $1
+  mixer $MIXARGS versions update --mix-version $1
 }
 
 mixer-build-bundles() {
-  sudo -E mixer build bundles --config $BATS_TEST_DIRNAME/builder.conf
+  sudo -E mixer $MIXARGS build bundles --config $BATS_TEST_DIRNAME/builder.conf
 }
 
 mixer-build-update() {
-  sudo -E mixer build update --config $BATS_TEST_DIRNAME/builder.conf
+  sudo -E mixer $MIXARGS build update --config $BATS_TEST_DIRNAME/builder.conf
 }
 
 mixer-add-rpms() {
   mkdir -p $BATS_TEST_DIRNAME/local-yum $BATS_TEST_DIRNAME/local-rpms
-  sudo -E mixer add-rpms --config $BATS_TEST_DIRNAME/builder.conf
+  sudo -E mixer $MIXARGS add-rpms --config $BATS_TEST_DIRNAME/builder.conf
 }
 
 create-empty-local-bundle() {
@@ -59,11 +59,11 @@ remove-package-from-local-bundle() {
 }
 
 mixer-bundle-add() {
-  mixer bundle add $1
+  mixer $MIXARGS bundle add $1
 }
 
 mixer-bundle-remove() {
-  mixer bundle remove $1
+  mixer $MIXARGS bundle remove $1
 }
 
 download-rpm() {

--- a/bat/tests/01-bundle-commands/run.bats
+++ b/bat/tests/01-bundle-commands/run.bats
@@ -8,7 +8,7 @@ setup() {
 }
 
 @test "Initialize a mix at version 10" {
-  mixer init --clear-version $CLRVER --mix-version 10
+  mixer $MIXARGS init --clear-version $CLRVER --mix-version 10
   [[ -f $BATS_TEST_DIRNAME/builder.conf ]]
   [[ -f $BATS_TEST_DIRNAME/mixbundles ]]
   [[ $(wc -l < $BATS_TEST_DIRNAME/mixbundles) == 4 ]]
@@ -17,7 +17,7 @@ setup() {
 }
 
 @test "List the bundles in the mix" {
-  run mixer bundle list
+  run mixer $MIXARGS bundle list
   [[ ${#lines[@]} -eq 4 ]]              # Exactly 4 bundles in the mix
   [[ "$output" =~ os-core[[:space:]] ]] # To avoid just matching os-core-update
   [[ "$output" =~ os-core-update ]]
@@ -26,61 +26,61 @@ setup() {
 }
 
 @test "Add an upstream bundle to the mix" {
-  mixer bundle add editors
+  mixer $MIXARGS bundle add editors
 
-  run mixer bundle list
+  run mixer $MIXARGS bundle list
   [[ ${#lines[@]} -gt 4 ]]                         # More bundles in list now
   [[ "$output" =~ editors[[:space:]]+\(upstream ]] # "editors" bundle is from upstream
 }
 
 @test "Edit upstream bundle" {
-  run mixer bundle list
+  run mixer $MIXARGS bundle list
   [[ "$output" =~ editors[[:space:]]+\(upstream ]]              # "editors" bundle is from upstream
   [[ $(ls -1q $BATS_TEST_DIRNAME/local-bundles | wc -l) == 0 ]] # Nothing in local-bundles
 
-  run mixer bundle list local
+  run mixer $MIXARGS bundle list local
   [[ ${#lines[@]} -eq 0 ]]                                      # 'list local' returns no results
 
-  mixer bundle edit editors --suppress-editor
+  mixer $MIXARGS bundle edit editors --suppress-editor
   [[ $(ls -1q $BATS_TEST_DIRNAME/local-bundles) = "editors" ]]  # local-bundles only has "editors"
 
-  run mixer bundle list
+  run mixer $MIXARGS bundle list
   [[ "$output" =~ editors[[:space:]]+\(local ]]                 # "editors" bundle is now from local
 
-  run mixer bundle list local
+  run mixer $MIXARGS bundle list local
   [[ ${#lines[@]} -eq 1 ]]                                      # 'list local' returns 1 result
   [[ "$output" =~ editors.*masking ]]                           # "editors" bundle is masking upstream
 }
 
 @test "Create original bundle and add to mix" {
-  mixer bundle edit foobar --suppress-editor --add
+  mixer $MIXARGS bundle edit foobar --suppress-editor --add
 
   run ls -1q $BATS_TEST_DIRNAME/local-bundles
   [[ ${#lines[@]} -eq 2 ]]                     # 2 bundles in local-bundles
   [[ "$output" =~ foobar ]]                    # local-bundles now contains "foobar"
 
-  run mixer bundle list
+  run mixer $MIXARGS bundle list
   [[ "$output" =~ foobar[[:space:]]+\(local ]] # "foobar" bundle is from local
 
-  run mixer bundle list local
+  run mixer $MIXARGS bundle list local
   [[ ${#lines[@]} -eq 2 ]]                     # 'list local' returns 2 results
   [[ "$output" =~ .*foobar.* ]]                # "foobar" bundle is in output
 }
 
 @test "Remove bundle from mix" {
-  mixer bundle remove editors
+  mixer $MIXARGS bundle remove editors
 
   [[ $(ls -1q $BATS_TEST_DIRNAME/local-bundles | wc -l) == 2 ]] # Still 2 bundles in local-bundles
 
-  ! mixer bundle list | grep -q editors                         # "editors" no longer in mix
+  ! mixer $MIXARGS bundle list | grep -q editors                # "editors" no longer in mix
 }
 
 @test "Validate a bundle" {
   echo "package" >> $BATS_TEST_DIRNAME/local-bundles/foobar
 
-  mixer bundle validate foobar
+  mixer $MIXARGS bundle validate foobar
 
-  ! mixer bundle validate foobar --strict
+  ! mixer $MIXARGS bundle validate foobar --strict
 }
 
 # vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/bat/tests/02-create-mix-with-upstream-bundles/run.bats
+++ b/bat/tests/02-create-mix-with-upstream-bundles/run.bats
@@ -8,10 +8,10 @@ setup() {
 }
 
 @test "Create mix 10 with real clear bundle" {
-  mixer init --clear-version $CLRVER --mix-version 10
+  mixer $MIXARGS init --clear-version $CLRVER --mix-version 10
   
   rm -f $BATS_TEST_DIRNAME/mixbundles                                # Wipe out default bundles
-  mixer bundle add os-core                                           # Add real os-core from upstream
+  mixer $MIXARGS bundle add os-core                                  # Add real os-core from upstream
   sed -i 's/os-core-update/os-core/' $BATS_TEST_DIRNAME/builder.conf # Patch default builder.conf
   
   mixer-build-bundles > $LOGDIR/build_bundles.log

--- a/mixer/cmd/config.go
+++ b/mixer/cmd/config.go
@@ -37,18 +37,15 @@ environment variables will be expanded`,
 		if config, err = builder.GetConfigPath(config); err != nil {
 			// Print error, but don't print command usage
 			fail(err)
-			return
 		}
 
 		var mc builder.MixConfig
 		if err := mc.LoadConfig(config); err != nil {
 			fail(err)
-			return
 		}
 
 		if err := mc.Print(); err != nil {
 			fail(err)
-			return
 		}
 
 	},
@@ -64,13 +61,11 @@ variables will not be expanded and the values will not be validated`,
 		var err error
 		if config, err = builder.GetConfigPath(config); err != nil {
 			fail(err)
-			return
 		}
 
 		var mc builder.MixConfig
 		if err := mc.Convert(config); err != nil {
 			fail(err)
-			return
 		}
 
 	},

--- a/mixer/cmd/config.go
+++ b/mixer/cmd/config.go
@@ -16,6 +16,8 @@ package cmd
 
 import (
 	"github.com/clearlinux/mixer-tools/builder"
+
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -74,10 +76,40 @@ variables will not be expanded and the values will not be validated`,
 	},
 }
 
+var configSetCmd = &cobra.Command{
+	Use:   "set <property> <value>",
+	Short: "Set a property in the config file to a given value",
+	Long: `This command will parse the provided property in the format 'Section.Property',
+	assign the provided value and update the config file. The command will only validate
+	the existence of the provided property, but will not validate the value provided.`,
+	Args: cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		if !builder.UseNewConfig {
+			fail(errors.New("config set requires `--new-config` flag`"))
+		}
+
+		var err error
+		if config, err = builder.GetConfigPath(config); err != nil {
+			fail(err)
+		}
+
+		var mc builder.MixConfig
+		if err := mc.LoadConfig(config); err != nil {
+			fail(err)
+		}
+
+		if err := mc.SetProperty(config, args[0], args[1]); err != nil {
+			fail(err)
+		}
+
+	},
+}
+
 // List of all config commands
 var configCmds = []*cobra.Command{
 	configValidateCmd,
 	configConvertCmd,
+	configSetCmd,
 }
 
 func init() {


### PR DESCRIPTION
This patchset is focused on getting batcheck to work with --new-config flag.

Other than allowing the flag to be set for every call of mixer command, this change required setting the properties for LOCAL_BUNDLE_DIR and LOCAL_REPO_DIR in a different way for the TOML config. For old config they were simply appended to the end of the file, but for TOML they need to be on the correct section and with the values in TOML format.

To address that, I included in this patch the config set command. This command looks for a given property in a given section and sets that property to whatever value the user provides. There is no validation at this stage. I believe this command also addresses the request made in #270 