### PR TITLE
Compress Manifest.full as well

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -1555,6 +1555,15 @@ func (b *Builder) buildUpdateContent(timer *stopWatch, mixVersion uint32, minVer
 			return err
 		}
 	}
+
+	// Now tar the full manifest, since it doesn't show up in the MoM
+	fmt.Println("  full")
+	f := filepath.Join(thisVersionDir, "Manifest.full")
+	err = createCompressedArchive(f+".tar", f)
+	if err != nil {
+		return err
+	}
+
 	// TODO: Create manifest tars for Manifest.MoM and the mom.UpdatedBundles.
 	timer.Stop()
 


### PR DESCRIPTION
The client needs to download the Manifest.full for mixer-integration to
work and expects a tar to exist.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>

pls merge and release :(