### PR TITLE
Report TOML config name for missing config values.

### DIFF
--- a/builder/config.go
+++ b/builder/config.go
@@ -314,7 +314,13 @@ func (config *MixConfig) validate() error {
 			tag, ok := sectionT.Field(j).Tag.Lookup("required")
 
 			if ok && tag == "true" && sectionV.Field(j).String() == "" {
-				return errors.Errorf("Missing required field in config file: %s", sectionT.Field(j).Name)
+				name, ok := sectionT.Field(j).Tag.Lookup("toml")
+				if !ok || name == "" {
+					// Default back to variable name if no TOML tag is defined
+					name = sectionT.Field(j).Name
+				}
+
+				return errors.Errorf("Missing required field in config file: %s", name)
 			}
 		}
 	}


### PR DESCRIPTION
Noticed this while testing the new config value I added for containerized mixer. @rchiossi just fixed a similar bug (using variable name instead of toml name during config setting) in his #290.

-------------------------

Previously, when a "required" config value was missing, the config
object's variable name was reported, rather than the name actually used
in the `builder.conf` file itself.

This resulted in the following output, for example:
`ERROR: Missing required field in config file: ServerStateDir`
rather than
`ERROR: Missing required field in config file: SERVER_STATE_DIR`

This patch falls back to the variable name if a config field does not
have a "toml" name defined.

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>