### PR TITLE
[Bugfix] Use config property name in battest

### DIFF
--- a/bat/lib/mixerlib.bash
+++ b/bat/lib/mixerlib.bash
@@ -15,8 +15,8 @@ global_setup() {
 }
 
 localize_builder_conf() {
-  if $(mixer $MIXARGS config set Mixer.LocalRPMDir $BATS_TEST_DIRNAME/local-rpms); then
-    mixer $MIXARGS config set  Mixer.LocalRepoDir $BATS_TEST_DIRNAME/local-yum
+  if $(mixer $MIXARGS config set Mixer.LOCAL_RPM_DIR $BATS_TEST_DIRNAME/local-rpms); then
+    mixer $MIXARGS config set  Mixer.LOCAL_REPO_DIR $BATS_TEST_DIRNAME/local-yum
   else
     echo -e "LOCAL_RPM_DIR=$BATS_TEST_DIRNAME/local-rpms\nLOCAL_REPO_DIR=$BATS_TEST_DIRNAME/local-yum" >> $BATS_TEST_DIRNAME/builder.conf
   fi


### PR DESCRIPTION
The name used in battests for config set were using the name used in the code for the properties instead of the name found in the config file causing the test to fail.

I forgot to change this after the rework on `config set` to use the name in toml tag.
