### PR TITLE
mixin: read current version from upstreamversion

### DIFF
--- a/mixin/helpers.go
+++ b/mixin/helpers.go
@@ -30,7 +30,15 @@ import (
 )
 
 func getCurrentVersion() (int, error) {
-	c, err := ioutil.ReadFile("/usr/lib/os-release")
+	// if upstreamversion exists, use that
+	c, err := ioutil.ReadFile(filepath.Join(mixWS, "upstreamversion"))
+	if err == nil {
+		return strconv.Atoi(strings.TrimSpace(string(c)))
+	}
+
+	// if upstreamversion does not exist, this is the first time
+	// the workspace has been set up; read from /usr/lib/os-release
+	c, err = ioutil.ReadFile("/usr/lib/os-release")
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
If the upstreamversion file exists read the current version from there.
Only read from /usr/lib/os-release if the upstreamversion file does not
exist. The os-release file is modified every time a local mix is
migrated to (version * 1000) so reading from that file every time causes
the mix version to multiply by 1000 every mix build.

Fixes #303

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>