### PR TITLE
swupd-inspector: initial import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,16 @@ endif
 build: gopath
 	go install ${GO_PACKAGE_PREFIX}/mixer
 	go install ${GO_PACKAGE_PREFIX}/mixin
+	go install ${GO_PACKAGE_PREFIX}/swupd-extract
+	go install ${GO_PACKAGE_PREFIX}/swupd-inspector
 	go install ${GO_PACKAGE_PREFIX}/mixer-completion
 
 install: gopath
 	test -d $(DESTDIR)/usr/bin || install -D -d -m 00755 $(DESTDIR)/usr/bin;
 	install -m 00755 $(GOPATH)/bin/mixer $(DESTDIR)/usr/bin/.
 	install -m 00755 $(GOPATH)/bin/mixin $(DESTDIR)/usr/bin/.
+	install -m 00755 $(GOPATH)/bin/swupd-extract $(DESTDIR)/usr/bin/.
+	install -m 00755 $(GOPATH)/bin/swupd-inspector $(DESTDIR)/usr/bin/.
 	$(GOPATH)/bin/mixer-completion bash --path $(DESTDIR)/usr/share/bash-completion/completions/mixer
 	$(GOPATH)/bin/mixer-completion zsh --path $(DESTDIR)/usr/share/zsh/site-functions/_mixer
 	test -d $(DESTDIR)/usr/share/man/man1 || install -D -d -m 00755 $(DESTDIR)/usr/share/man/man1

--- a/swupd-inspector/cat.go
+++ b/swupd-inspector/cat.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/clearlinux/mixer-tools/internal/client"
+	"github.com/clearlinux/mixer-tools/swupd"
+)
+
+// TODO: Support reading text files.
+
+func runCat(cacheDir string, args []string) {
+	if len(args) != 2 {
+		usage()
+		os.Exit(2)
+	}
+
+	base, version := parseURL(args[0])
+	stateDir := filepath.Join(cacheDir, convertContentBaseToDirname(base))
+	state, err := client.NewState(stateDir, base)
+	if err != nil {
+		log.Fatalf("ERROR: %s", err)
+	}
+
+	mom, err := state.GetMoM(version)
+	if err != nil {
+		log.Fatalf("ERROR: %s", err)
+	}
+
+	arg := args[1]
+	switch {
+	case arg == "Manifest.MoM", arg == "Manifest.full":
+		path, err := state.GetFile(version, arg)
+		if err != nil {
+			log.Fatalf("ERROR: %s", err)
+		}
+		err = copyFileToStdout(path)
+		if err != nil {
+			log.Fatalf("ERROR: %s", err)
+		}
+
+	case strings.HasPrefix(arg, "Manifest."):
+		// Look at MoM first to find the version of the bundle.
+		name := arg[9:]
+		var found *swupd.File
+		for _, f := range mom.Files {
+			if f.Name == name {
+				found = f
+				break
+			}
+		}
+		if found == nil {
+			log.Fatalf("ERROR: Manifest.MoM for version %s doesn't have a bundle named %s", version, name)
+		}
+		path, err := state.GetFile(fmt.Sprint(found.Version), arg)
+		if err != nil {
+			log.Fatalf("ERROR: %s", err)
+		}
+		err = copyFileToStdout(path)
+		if err != nil {
+			log.Fatalf("ERROR: %s", err)
+		}
+
+	default:
+		log.Fatalf("Second argument to 'cat' must be a Manifest name")
+	}
+}
+
+func copyFileToStdout(src string) error {
+	srcF, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = srcF.Close()
+	}()
+	_, err = io.Copy(os.Stdout, srcF)
+	return err
+}

--- a/swupd-inspector/cat.go
+++ b/swupd-inspector/cat.go
@@ -14,13 +14,8 @@ import (
 
 // TODO: Support reading text files.
 
-func runCat(cacheDir string, args []string) {
-	if len(args) != 2 {
-		usage()
-		os.Exit(2)
-	}
-
-	base, version := parseURL(args[0])
+func runCat(cacheDir, url, arg string) {
+	base, version := parseURL(url)
 	stateDir := filepath.Join(cacheDir, convertContentBaseToDirname(base))
 	state, err := client.NewState(stateDir, base)
 	if err != nil {
@@ -32,7 +27,6 @@ func runCat(cacheDir string, args []string) {
 		log.Fatalf("ERROR: %s", err)
 	}
 
-	arg := args[1]
 	switch {
 	case arg == "Manifest.MoM", arg == "Manifest.full":
 		path, err := state.GetFile(version, arg)

--- a/swupd-inspector/clean.go
+++ b/swupd-inspector/clean.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+func runClean(cacheDir string, args []string) {
+	fis, err := ioutil.ReadDir(cacheDir)
+	if err != nil {
+		log.Fatalf("ERROR: %s", err)
+	}
+
+	for _, fi := range fis {
+		if !fi.IsDir() {
+			log.Printf("Skipping unknown file %s/%s", cacheDir, fi.Name())
+			continue
+		}
+		stateDir := filepath.Join(cacheDir, fi.Name())
+		_, err = os.Stat(filepath.Join(stateDir, "content"))
+		if err != nil {
+			log.Printf("Skipping unrecognized directory %s", stateDir)
+			continue
+		}
+		log.Printf("Deleting directory %s", stateDir)
+		err = os.RemoveAll(stateDir)
+		if err != nil {
+			log.Fatalf("ERROR: %s", err)
+		}
+	}
+}

--- a/swupd-inspector/clean.go
+++ b/swupd-inspector/clean.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 )
 
-func runClean(cacheDir string, args []string) {
+func runClean(cacheDir string) {
 	fis, err := ioutil.ReadDir(cacheDir)
 	if err != nil {
 		log.Fatalf("ERROR: %s", err)

--- a/swupd-inspector/diff.go
+++ b/swupd-inspector/diff.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"path/filepath"
+	"sort"
+
+	"github.com/clearlinux/mixer-tools/internal/client"
+	"github.com/clearlinux/mixer-tools/swupd"
+)
+
+// TODO: MoM signature verification.
+
+// Terminal colors.
+var (
+	RED   = "\x1b[31m"
+	GREEN = "\x1b[32m"
+	RESET = "\x1b[0m"
+)
+
+func runDiff(cacheDir string, args []string) {
+	var (
+		noColor bool
+		strict  bool
+	)
+
+	flagSet := flag.NewFlagSet("diff", flag.ExitOnError)
+	flagSet.BoolVar(&noColor, "no-color", false, "use no colors")
+	flagSet.BoolVar(&strict, "strict", false, "also compare version numbers")
+	flagSet.Usage = usage
+	err := flagSet.Parse(args)
+	if err != nil {
+		log.Fatalf("ERROR: %s", err)
+	}
+
+	if len(flagSet.Args()) != 2 {
+		usage()
+		return
+	}
+
+	if noColor {
+		RED = ""
+		GREEN = ""
+		RESET = ""
+	}
+
+	baseA, versionA := parseURL(flagSet.Arg(0))
+	baseB, versionB := parseURL(flagSet.Arg(1))
+
+	var stateA, stateB *client.State
+	stateDirA := filepath.Join(cacheDir, convertContentBaseToDirname(baseA))
+	stateA, err = client.NewState(stateDirA, baseA)
+	if err != nil {
+		log.Fatalf("ERROR: %s", err)
+	}
+
+	stateDirB := filepath.Join(cacheDir, convertContentBaseToDirname(baseB))
+	if stateDirB == stateDirA {
+		if baseB == baseA {
+			stateB = stateA
+		} else {
+			// This should be a rare case, if we hit this we should improve
+			// our normalization function.
+			stateDirB = stateDirB + "_other"
+			stateB, err = client.NewState(stateDirB, baseB)
+			if err != nil {
+				log.Fatalf("ERROR: %s", err)
+			}
+		}
+	} else {
+		stateB, err = client.NewState(stateDirB, baseB)
+		if err != nil {
+			log.Fatalf("ERROR: %s", err)
+		}
+	}
+
+	momA, err := stateA.GetMoM(versionA)
+	if err != nil {
+		log.Fatalf("ERROR: %s", err)
+	}
+	momB, err := stateB.GetMoM(versionB)
+	if err != nil {
+		log.Fatalf("ERROR: %s", err)
+	}
+
+	fmt.Printf(`=== Differences from A to B
+
+  A Base:            %s
+  A Version:         %s
+  A State directory: %s
+
+  B Base:            %s
+  B Version:         %s
+  B State directory: %s
+
+`, baseA, versionA, stateDirA, baseB, versionB, stateDirB)
+
+	sortFiles(momA)
+	sortFiles(momB)
+
+	fmt.Println("=== Manifest.MoM")
+
+	type bundlePair struct {
+		Name string
+		A, B *swupd.File
+	}
+	var bundles []*bundlePair
+
+	// TODO: Check all them are manifests...
+
+	walkFiles(momA.Files, momB.Files, func(a, b *swupd.File) {
+		switch {
+		case a == nil:
+			fmt.Printf("%s+%s%s %s%s\n", GREEN, b.Type, b.Status, b.Name, RESET)
+		case b == nil:
+			fmt.Printf("%s-%s%s %s%s\n", RED, a.Type, a.Status, a.Name, RESET)
+		default:
+			if a.Type != b.Type || a.Status != b.Status {
+				fmt.Printf("%s-%s%s %s%s\n", RED, a.Type, a.Status, a.Name, RESET)
+				fmt.Printf("%s+%s%s %s%s\n", RED, a.Type, a.Status, a.Name, RESET)
+			} else {
+				fmt.Printf(" %s%s %s", a.Type, a.Status, a.Name)
+				if strict && a.Version != b.Version {
+					fmt.Printf(" (VERSION: %s-%d%s / %s+%d%s)", RED, a.Version, RESET, GREEN, b.Version, RESET)
+				}
+				if a.Hash != b.Hash {
+					pair := &bundlePair{
+						Name: a.Name,
+						A:    a,
+						B:    b,
+					}
+					bundles = append(bundles, pair)
+					fmt.Printf(" (HASH: %s-%s%s / %s+%s%s)", RED, a.Hash.String()[:7], RESET, GREEN, b.Hash.String()[:7], RESET)
+				}
+				fmt.Println()
+			}
+		}
+	})
+	fmt.Println()
+
+	flags := func(f *swupd.File) string {
+		result, err := f.GetFlagString()
+		if err != nil {
+			result = "...."
+		}
+		return result[:3]
+	}
+
+	for _, pair := range bundles {
+		mA, err := stateA.GetBundleManifest(fmt.Sprint(pair.A.Version), pair.Name, "")
+		if err != nil {
+			log.Fatalf("ERROR: %s", err)
+		}
+
+		mB, err := stateB.GetBundleManifest(fmt.Sprint(pair.B.Version), pair.Name, "")
+		if err != nil {
+			log.Fatalf("ERROR: %s", err)
+		}
+
+		fmt.Printf("=== Manifest.%s A=%d B=%d\n", pair.Name, mA.Header.Version, mB.Header.Version)
+
+		var extraIncludesA, extraIncludesB []string
+		{
+			includesA := map[string]bool{}
+			for _, inc := range mA.Header.Includes {
+				includesA[inc.Name] = true
+			}
+			includesB := map[string]bool{}
+			for _, inc := range mB.Header.Includes {
+				includesB[inc.Name] = true
+			}
+			for name := range includesA {
+				if !includesB[name] {
+					extraIncludesA = append(extraIncludesA, name)
+				}
+			}
+			for name := range includesB {
+				if !includesA[name] {
+					extraIncludesB = append(extraIncludesB, name)
+				}
+			}
+		}
+
+		if mA.Header.FileCount != mB.Header.FileCount {
+			fmt.Printf("%s-filecount: %d%s\n", RED, mA.Header.FileCount, RESET)
+			fmt.Printf("%s+filecount: %d%s\n", GREEN, mB.Header.FileCount, RESET)
+		}
+		// TODO: Compare ContentSize?
+
+		for _, name := range extraIncludesA {
+			fmt.Printf("%s-includes: %s%s\n", RED, name, RESET)
+		}
+		for _, name := range extraIncludesB {
+			fmt.Printf("%s+includes: %s%s\n", GREEN, name, RESET)
+		}
+
+		// TODO: Move sort files to walker?
+		sortFiles(mA)
+		sortFiles(mB)
+		walkFiles(mA.Files, mB.Files, func(a, b *swupd.File) {
+			switch {
+			case a == nil:
+				fmt.Printf("%s+%s %s%s\n", GREEN, flags(b), b.Name, RESET)
+			case b == nil:
+				fmt.Printf("%s-%s %s%s\n", RED, flags(a), a.Name, RESET)
+			default:
+				if flags(a) != flags(b) {
+					fmt.Printf("%s-%s %s%s\n", RED, flags(a), a.Name, RESET)
+					fmt.Printf("%s+%s %s%s\n", GREEN, flags(b), b.Name, RESET)
+				} else if a.Rename != b.Rename || a.Hash != b.Hash || (strict && a.Version != b.Version) {
+					fmt.Printf(" %s %s", flags(a), a.Name)
+					if strict && a.Version != b.Version {
+						fmt.Printf(" (VERSION: %s-%d%s / %s+%d%s)", RED, a.Version, RESET, GREEN, b.Version, RESET)
+					}
+					if a.Rename != b.Rename {
+						fmt.Printf(" (RENAME: %s-%d%s / %s+%d%s)", RED, a.Rename, RESET, GREEN, b.Rename, RESET)
+					}
+					if a.Hash != b.Hash {
+						fmt.Printf(" (HASH: %s-%s%s / %s+%s%s)", RED, a.Hash.String()[:7], RESET, GREEN, b.Hash.String()[:7], RESET)
+					}
+					fmt.Println()
+				}
+			}
+		})
+		fmt.Println()
+	}
+
+	// TODO: Print number of mismatches, new files in B and missing files in A.
+}
+
+func walkFiles(filesA, filesB []*swupd.File, fn func(a, b *swupd.File)) {
+	indexA := 0
+	indexB := 0
+	for indexA < len(filesA) && indexB < len(filesB) {
+		fileA := filesA[indexA]
+		fileB := filesB[indexB]
+		switch {
+		case fileA.Name < fileB.Name:
+			indexA++
+			fn(fileA, nil)
+		case fileA.Name > fileB.Name:
+			indexB++
+			fn(nil, fileB)
+		case fileA.Name == fileB.Name:
+			indexA++
+			indexB++
+			fn(fileA, fileB)
+		}
+	}
+	for indexA < len(filesA) {
+		fileA := filesA[indexA]
+		indexA++
+		fn(fileA, nil)
+	}
+	for indexB < len(filesB) {
+		fileB := filesB[indexB]
+		indexB++
+		fn(nil, fileB)
+	}
+}
+
+func sortFiles(m *swupd.Manifest) {
+	sort.Slice(m.Files, func(i, j int) bool {
+		return m.Files[i].Name < m.Files[j].Name
+	})
+}

--- a/swupd-inspector/get.go
+++ b/swupd-inspector/get.go
@@ -12,13 +12,8 @@ import (
 	"github.com/clearlinux/mixer-tools/swupd"
 )
 
-func runGet(cacheDir string, args []string) {
-	if len(args) != 2 {
-		usage()
-		os.Exit(2)
-	}
-
-	base, version := parseURL(args[0])
+func runGet(cacheDir, url, arg string) {
+	base, version := parseURL(url)
 	stateDir := filepath.Join(cacheDir, convertContentBaseToDirname(base))
 	state, err := client.NewState(stateDir, base)
 	if err != nil {
@@ -30,7 +25,6 @@ func runGet(cacheDir string, args []string) {
 		log.Fatalf("ERROR: %s", err)
 	}
 
-	arg := args[1]
 	switch {
 
 	case arg == "Manifest.MoM", arg == "Manifest.full":

--- a/swupd-inspector/get.go
+++ b/swupd-inspector/get.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/clearlinux/mixer-tools/internal/client"
+	"github.com/clearlinux/mixer-tools/swupd"
+)
+
+func runGet(cacheDir string, args []string) {
+	if len(args) != 2 {
+		usage()
+		os.Exit(2)
+	}
+
+	base, version := parseURL(args[0])
+	stateDir := filepath.Join(cacheDir, convertContentBaseToDirname(base))
+	state, err := client.NewState(stateDir, base)
+	if err != nil {
+		log.Fatalf("ERROR: %s", err)
+	}
+
+	mom, err := state.GetMoM(version)
+	if err != nil {
+		log.Fatalf("ERROR: %s", err)
+	}
+
+	arg := args[1]
+	switch {
+
+	case arg == "Manifest.MoM", arg == "Manifest.full":
+		path, err := state.GetFile(version, arg)
+		if err != nil {
+			log.Fatalf("ERROR: %s", err)
+		}
+		err = cp(path, arg)
+		if err != nil {
+			log.Fatalf("ERROR: %s", err)
+		}
+
+	case strings.HasPrefix(arg, "Manifest."):
+		// Look at MoM first to find the version of the bundle.
+		name := arg[9:]
+		var found *swupd.File
+		for _, f := range mom.Files {
+			if f.Name == name {
+				found = f
+				break
+			}
+		}
+		if found == nil {
+			log.Fatalf("ERROR: Manifest.MoM for version %s doesn't have a bundle named %s", version, name)
+		}
+		path, err := state.GetFile(fmt.Sprint(found.Version), arg)
+		if err != nil {
+			log.Fatalf("ERROR: %s", err)
+		}
+		err = cp(path, arg)
+		if err != nil {
+			log.Fatalf("ERROR: %s", err)
+		}
+
+	case len(arg) > 0 && arg[0] == '/':
+		var found *swupd.File
+		err := visitAllFiles(state, mom, func(bundle, file *swupd.File) bool {
+			if file.Name == arg {
+				found = file
+				return true
+			}
+			return false
+		})
+		if err != nil {
+			log.Fatalf("ERROR: %s", err)
+		}
+		if found == nil {
+			log.Fatalf("ERROR: file %s not found in version %s", arg, version)
+		}
+		log.Printf("%s => %s", arg, found.Hash)
+		err = downloadFullfile(state, found)
+		if err != nil {
+			log.Fatalf("ERROR: %s", err)
+		}
+
+	case len(arg) == len(swupd.AllZeroHash):
+		// TODO: Support shortened hashes.
+		var found *swupd.File
+		err := visitAllFiles(state, mom, func(bundle, file *swupd.File) bool {
+			if file.Hash.String() == arg {
+				found = file
+				return true
+			}
+			return false
+		})
+		if err != nil {
+			log.Fatalf("ERROR: %s", err)
+		}
+		if found == nil {
+			log.Fatalf("ERROR: file with hash %s not found in version %s", arg, version)
+		}
+		err = downloadFullfile(state, found)
+		if err != nil {
+			log.Fatalf("ERROR: %s", err)
+		}
+
+	default:
+		log.Fatalf("Second argument to 'get' must be an absolute path, a hash or be a Manifest name")
+	}
+}
+
+func visitAllFiles(state *client.State, mom *swupd.Manifest, visitFunc func(bundle, file *swupd.File) bool) error {
+	var stop bool
+	for _, bundleF := range mom.Files {
+		bundle, err := state.GetBundleManifest(fmt.Sprint(bundleF.Version), bundleF.Name, "")
+		if err != nil {
+			return err
+		}
+		for _, f := range bundle.Files {
+			if visitFunc(bundleF, f) {
+				stop = true
+				break
+			}
+		}
+		if stop {
+			break
+		}
+	}
+	return nil
+}
+
+func downloadFullfile(state *client.State, file *swupd.File) error {
+	fullfile := file.Hash.String() + ".tar"
+	f, err := state.GetFile(fmt.Sprint(file.Version), "files", fullfile)
+	if err != nil {
+		return err
+	}
+	return cp(f, fullfile)
+}
+
+func cp(src, dst string) error {
+	srcF, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = srcF.Close()
+	}()
+
+	dstF, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = dstF.Close()
+	}()
+
+	_, err = io.Copy(dstF, srcF)
+	return err
+}

--- a/swupd-inspector/log.go
+++ b/swupd-inspector/log.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"os"
 	"path/filepath"
 
 	"github.com/clearlinux/mixer-tools/internal/client"
@@ -12,21 +11,15 @@ import (
 
 // TODO: Consider a --unique flag that would not print consecutive versions that have the same hash.
 
-func runLog(cacheDir string, args []string) {
-	if len(args) != 2 {
-		usage()
-		os.Exit(2)
-	}
-
-	base, version := parseURL(args[0])
+func runLog(cacheDir, url, filename string) {
+	base, version := parseURL(url)
 	stateDir := filepath.Join(cacheDir, convertContentBaseToDirname(base))
 	state, err := client.NewState(stateDir, base)
 	if err != nil {
 		log.Fatalf("ERROR: %s", err)
 	}
 
-	arg := args[1]
-	if arg == "" || arg[0] != '/' {
+	if filename == "" || filename[0] != '/' {
 		// TODO: Support Manifest.* files too, but showing the diff of the files?
 		log.Fatalf("Second argument to 'log' must be an absolute path")
 	}
@@ -44,7 +37,7 @@ func runLog(cacheDir string, args []string) {
 		var found *swupd.File
 
 		visit := func(bundle, file *swupd.File) bool {
-			if file.Name == arg && file.Present() {
+			if file.Name == filename && file.Present() {
 				found = file
 				lastBundle = bundle.Name
 				return true
@@ -95,7 +88,7 @@ func runLog(cacheDir string, args []string) {
 	}
 
 	if lastBundle == "" {
-		log.Fatalf("ERROR: file %s not found in version %s", arg, version)
+		log.Fatalf("ERROR: file %s not found in version %s", filename, version)
 	}
 
 }

--- a/swupd-inspector/log.go
+++ b/swupd-inspector/log.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/clearlinux/mixer-tools/internal/client"
+	"github.com/clearlinux/mixer-tools/swupd"
+)
+
+// TODO: Consider a --unique flag that would not print consecutive versions that have the same hash.
+
+func runLog(cacheDir string, args []string) {
+	if len(args) != 2 {
+		usage()
+		os.Exit(2)
+	}
+
+	base, version := parseURL(args[0])
+	stateDir := filepath.Join(cacheDir, convertContentBaseToDirname(base))
+	state, err := client.NewState(stateDir, base)
+	if err != nil {
+		log.Fatalf("ERROR: %s", err)
+	}
+
+	arg := args[1]
+	if arg == "" || arg[0] != '/' {
+		// TODO: Support Manifest.* files too, but showing the diff of the files?
+		log.Fatalf("Second argument to 'log' must be an absolute path")
+	}
+
+	var lastVersion uint32
+	lastBundle := ""
+
+	for version != "0" {
+		mom, err := state.GetMoM(version)
+		if err != nil {
+			// TODO: check for the "aborted" file in the version directory?
+			log.Fatalf("ERROR: %s", err)
+		}
+
+		var found *swupd.File
+
+		visit := func(bundle, file *swupd.File) bool {
+			if file.Name == arg && file.Present() {
+				found = file
+				lastBundle = bundle.Name
+				return true
+			}
+			return false
+		}
+
+		// Look first in the bundle that had the file before, since it is more likely to
+		// have the file again. This reduces the amount of manifest files downloaded.
+		if lastBundle != "" {
+			var bundleF *swupd.File
+			for _, b := range mom.Files {
+				if b.Name == lastBundle {
+					bundleF = b
+				}
+			}
+
+			if bundleF != nil {
+				err = visitFilesInBundle(state, bundleF, visit)
+				if err != nil {
+					log.Fatalf("ERROR: %s", err)
+				}
+			}
+		}
+
+		if found == nil {
+			err = visitAllFiles(state, mom, visit)
+			if err != nil {
+				log.Fatalf("ERROR: %s", err)
+			}
+		}
+
+		if found == nil {
+			break
+		}
+		if lastVersion != found.Version {
+			fmt.Printf("%s/%d/files/%s.tar\n", base, found.Version, found.Hash)
+			lastVersion = found.Version
+		}
+
+		// Look at the immediate previous OS version, unless we already know the file is
+		// from an earlier version, so we can skip to it.
+		v := mom.Header.Previous
+		if v > found.Version {
+			v = found.Version
+		}
+		version = fmt.Sprint(v)
+	}
+
+	if lastBundle == "" {
+		log.Fatalf("ERROR: file %s not found in version %s", arg, version)
+	}
+
+}
+
+func visitFilesInBundle(state *client.State, bundleFile *swupd.File, visitFunc func(bundle, file *swupd.File) bool) error {
+	bundle, err := state.GetBundleManifest(fmt.Sprint(bundleFile.Version), bundleFile.Name, "")
+	if err != nil {
+		return err
+	}
+	for _, f := range bundle.Files {
+		if visitFunc(bundleFile, f) {
+			break
+		}
+	}
+	return nil
+}

--- a/swupd-inspector/main.go
+++ b/swupd-inspector/main.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"bufio"
-	"fmt"
 	"log"
 	"os"
 	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 // TODO: Flag to set cacheDir.
@@ -17,57 +18,8 @@ import (
 
 // TODO: Take into account deleted files, right now 'get' fails trying to download 0000...0.tar.
 
-func usage() {
-	fmt.Printf(`swupd-inspector analyzes swupd content
-
-Commands:
-
-    cat URL Manifest.NAME
-        Print the contents of the given Manifest.
-
-    get URL Manifest.NAME
-        Download the contents of the given Manifest.
-
-    get URL FILENAME
-        Search for the FILENAME and download the corresponding fullfile.
-        The FILENAME must be an absolute path.
-
-    get URL HASH
-        Download the fullfile corresponding to the hash.
-
-    diff [--strict] [--no-color] URL1 URL2
-        Compare two versions of swupd content. The filenames and flags
-        will be compared, recursing to the bundles. Use --strict to
-        also compare the version numbers of the files. Use --no-color
-        to not emit escape codes in the output.
-
-    log URL FILENAME
-        Show FILENAME version and its previous versions.
-
-    clean
-        Clean up any cached content.
-
-The program will cache everything downloaded, and can keep content from
-different sources. The cache directory is $HOME/.cache/swupd-inspector.
-
-The URLs must refer to a specific version like
-https://download.clearlinux.org/update/20520. Absolute local paths can
-also be used instead of URLs.
-
-It is possible to refer to content by aliases. The alias 'clear' works
-by default, so clear/20520 refer to the same as the URL above. Other
-aliases can be defined in $HOME/.config/swupd-inspector/aliases in the
-format ALIAS=URL per line.
-`)
-}
-
 func main() {
 	log.SetFlags(0)
-
-	if len(os.Args) < 2 {
-		usage()
-		os.Exit(2)
-	}
 
 	user, err := user.Current()
 	if err != nil {
@@ -83,26 +35,99 @@ func main() {
 		log.Fatalf("couldn't create cache directory: %s", err)
 	}
 
-	cmd := os.Args[1]
-	args := os.Args[2:]
-	switch cmd {
-	case "help", "-h", "--help":
-		usage()
-		os.Exit(0)
-	case "diff":
-		runDiff(cacheDir, args)
-	case "get":
-		runGet(cacheDir, args)
-	case "cat":
-		runCat(cacheDir, args)
-	case "log":
-		runLog(cacheDir, args)
-	case "clean":
-		runClean(cacheDir, args)
-	default:
-		usage()
-		os.Exit(2)
+	rootCmd := &cobra.Command{
+		Use:   "swupd-inspector",
+		Short: "Inspect and download swupd content",
+		Long: `Inspect and download swupd content
+
+The program will cache everything downloaded, and can keep content from
+different sources. The cache directory is $HOME/.cache/swupd-inspector.
+
+The URLs must refer to a specific version like
+https://download.clearlinux.org/update/20520. Absolute local paths can
+also be used instead of URLs.
+
+It is possible to refer to content by aliases. The alias 'clear' works
+by default, so clear/20520 refer to the same as the URL above. Other
+aliases can be defined in $HOME/.config/swupd-inspector/aliases in the
+format ALIAS=URL per line.
+`,
 	}
+
+	diffFlags := &diffFlags{}
+	diffCmd := &cobra.Command{
+		Use:   "diff [flags] URL1 URL2",
+		Short: "Compare two versions of swupd content",
+		Long: `Compare two versions of swupd content.
+
+The filenames and flags will be compared, recursing to the
+bundles. Use --strict to also compare the version numbers of the
+files. Use --no-color to not emit escape codes in the output.
+`,
+		Args: cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			runDiff(cacheDir, diffFlags, args[0], args[1])
+		},
+	}
+	diffCmd.Flags().BoolVar(&diffFlags.noColor, "no-color", false, "disable colored output")
+	diffCmd.Flags().BoolVar(&diffFlags.strict, "strict", false, "compare version numbers of files")
+	rootCmd.AddCommand(diffCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get [flags] URL (FILENAME|HASH|Manifest.NAME)",
+		Short: "Download content from a swupd repository",
+		Long: `Download content from a swupd repository.
+
+Different types of content can be downloaded:
+
+  swupd-inspector get URL Manifest.NAME
+      Download the contents of the given Manifest.
+
+  swupd-inspector get URL FILENAME
+      Search for the FILENAME and download the corresponding fullfile.
+      The FILENAME must be an absolute path.
+
+  swupd-inspector get URL HASH
+      Download the fullfile corresponding to the hash.
+`,
+		Args: cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			runGet(cacheDir, args[0], args[1])
+		},
+	}
+	rootCmd.AddCommand(getCmd)
+
+	cleanCmd := &cobra.Command{
+		Use:   "clean",
+		Short: "Clean up any cached content",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runClean(cacheDir)
+		},
+	}
+	rootCmd.AddCommand(cleanCmd)
+
+	catCmd := &cobra.Command{
+		Use:   "cat [flags] URL Manifest.NAME",
+		Short: "Print the contents of a Manifest",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			runCat(cacheDir, args[0], args[1])
+		},
+	}
+	rootCmd.AddCommand(catCmd)
+
+	logCmd := &cobra.Command{
+		Use:   "log [flags] URL FILENAME",
+		Short: "Print FILENAME version and all previous versions",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			runLog(cacheDir, args[0], args[1])
+		},
+	}
+	rootCmd.AddCommand(logCmd)
+
+	_ = rootCmd.Execute()
 }
 
 var aliases = map[string]string{

--- a/swupd-inspector/main.go
+++ b/swupd-inspector/main.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// TODO: Flag to set cacheDir.
+
+// TODO: Use XDG_* environment variables instead of ~/.config and ~/.cache by default.
+
+// TODO: Take into account deleted files, right now 'get' fails trying to download 0000...0.tar.
+
+func usage() {
+	fmt.Printf(`swupd-inspector analyzes swupd content
+
+Commands:
+
+    cat URL Manifest.NAME
+        Print the contents of the given Manifest.
+
+    get URL Manifest.NAME
+        Download the contents of the given Manifest.
+
+    get URL FILENAME
+        Search for the FILENAME and download the corresponding fullfile.
+        The FILENAME must be an absolute path.
+
+    get URL HASH
+        Download the fullfile corresponding to the hash.
+
+    diff [--strict] [--no-color] URL1 URL2
+        Compare two versions of swupd content. The filenames and flags
+        will be compared, recursing to the bundles. Use --strict to
+        also compare the version numbers of the files. Use --no-color
+        to not emit escape codes in the output.
+
+    log URL FILENAME
+        Show FILENAME version and its previous versions.
+
+    clean
+        Clean up any cached content.
+
+The program will cache everything downloaded, and can keep content from
+different sources. The cache directory is $HOME/.cache/swupd-inspector.
+
+The URLs must refer to a specific version like
+https://download.clearlinux.org/update/20520. Absolute local paths can
+also be used instead of URLs.
+
+It is possible to refer to content by aliases. The alias 'clear' works
+by default, so clear/20520 refer to the same as the URL above. Other
+aliases can be defined in $HOME/.config/swupd-inspector/aliases in the
+format ALIAS=URL per line.
+`)
+}
+
+func main() {
+	log.SetFlags(0)
+
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+
+	user, err := user.Current()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	applyUserAliases(filepath.Join(user.HomeDir, ".config/swupd-inspector/aliases"))
+
+	// TODO: Use os.UserCacheDir instead of user.HomeDir+".cache".
+	cacheDir := filepath.Join(user.HomeDir, ".cache", "swupd-inspector")
+	err = os.MkdirAll(cacheDir, 0755)
+	if err != nil {
+		log.Fatalf("couldn't create cache directory: %s", err)
+	}
+
+	cmd := os.Args[1]
+	args := os.Args[2:]
+	switch cmd {
+	case "help", "-h", "--help":
+		usage()
+		os.Exit(0)
+	case "diff":
+		runDiff(cacheDir, args)
+	case "get":
+		runGet(cacheDir, args)
+	case "cat":
+		runCat(cacheDir, args)
+	case "log":
+		runLog(cacheDir, args)
+	case "clean":
+		runClean(cacheDir, args)
+	default:
+		usage()
+		os.Exit(2)
+	}
+}
+
+var aliases = map[string]string{
+	"clear": "https://cdn.download.clearlinux.org/update",
+}
+
+func applyUserAliases(path string) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
+		log.Fatalf("ERROR: %s", err)
+	}
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		text := strings.TrimSpace(scanner.Text())
+		if len(text) == 0 {
+			continue
+		}
+		if text[0] == '#' {
+			continue
+		}
+		sep := strings.Index(text, "=")
+		if sep != -1 {
+			alias := text[:sep]
+			url := text[sep+1:]
+			if strings.HasPrefix(alias, "/") {
+				log.Printf("Rejecting alias %q that starts with /", alias)
+				continue
+			}
+			if alias == "clear" {
+				// TODO: Should we just let the user do this?
+				log.Printf("Ignoring redefinition of 'clear' in %s", path)
+				continue
+			}
+			if url == "" {
+				log.Printf("Rejecting alias %q because URL is empty", alias)
+				continue
+			}
+			aliases[alias] = url
+		}
+	}
+
+	err = scanner.Err()
+	if err != nil {
+		log.Fatalf("ERROR: %s", scanner.Err())
+	}
+}
+
+func parseURL(s string) (base string, version string) {
+	if s == "" {
+		log.Fatalf("ERROR: couldn't parse empty URL")
+	}
+
+	for alias, aliasBase := range aliases {
+		if strings.HasPrefix(s, alias+"/") {
+			s = aliasBase + s[len(alias):]
+			break
+		}
+	}
+
+	switch {
+	case strings.HasPrefix(s, "/"):
+		s = filepath.Clean(s)
+	case strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://"):
+		// Eat the extra slashes in the end.
+		for len(s) > 0 && s[len(s)-1] == '/' {
+			s = s[:len(s)-1]
+		}
+	default:
+		log.Fatalf("ERROR: Invalid URL: %s", s)
+	}
+
+	sep := strings.LastIndex(s, "/")
+	if sep == -1 {
+		log.Fatalf("Invalid URL for content: %s", s)
+	}
+	base = s[:sep]
+	version = s[sep+1:]
+
+	parsed, err := strconv.ParseUint(version, 10, 32)
+	if err != nil {
+		log.Fatalf("Error parsing version in URL %s: %s", s, err)
+	}
+	if parsed == 0 {
+		log.Fatalf("Invalid version 0 in URL %s", s)
+	}
+
+	return base, version
+}
+
+func convertContentBaseToDirname(content string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			return r
+		default:
+			return '_'
+		}
+	}, content)
+}


### PR DESCRIPTION
swupd-inspector contains various commands that help read data of a
swupd repository: download the fullfile for a specific file, see the
Manifest for a specific version, see the differences between two
versions.

The 'diff' subcommand was one of the tools used to evaluate whether
the new swupd implementation was generating correct results compared
with the existing clear implementation.

The clientState struct is almost the same as the one used in
swupd-extract, and given the two use cases, a potential candidate to
move over to swupd package (or at least to an internal package so we
can use without being API). I'm postponing this to when we make
further updates to either of the programs.

Like swupd-extract, it does have a shortcut to handle the main Clear
Linux repository

    // Shows the content of Manifest.vim at a specific OS version
    $ swupd-inspector cat clear/22460 Manifest.vim

    // Download a fullfile for a given file
    $ swupd-inspector get clear/22460 /usr/bin/vim

    // Show the differences between two versions
    $ swupd-inspector diff clear/22450 clear/22460

    // List the different versions of a file since a given OS version
    $ swupd-inspector log clear/22450 /usr/bin/vim

In those examples, "clear/..." could be replace for a URL of a
repository (plus version) of a mix. The downloaded metadata is cached
based on the URL, allowing further queries to be cached, even when
querying mixes.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>