### PR TITLE
swupd: fix manifest creation

### DIFF
--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -168,7 +168,7 @@ func processBundles(ui UpdateInfo, c config) ([]*Manifest, error) {
 		if err != nil {
 			return nil, err
 		}
-		changedIncludes := compareIncludes(bundle, oldM)
+		changedIncludes := includesChanged(bundle, oldM)
 		oldM.sortFilesName()
 		changedFiles, added, deleted := bundle.linkPeersAndChange(oldM, c, ui.minVersion)
 		// if nothing changed, skip

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -555,8 +554,18 @@ func linkDeltaPeersForPack(c *config, oldManifest, newManifest *Manifest) error 
 	return nil
 }
 
-func compareIncludes(m1 *Manifest, m2 *Manifest) bool {
-	return reflect.DeepEqual(m1.Header.Includes, m2.Header.Includes)
+func includesChanged(m1 *Manifest, m2 *Manifest) bool {
+	if len(m1.Header.Includes) != len(m2.Header.Includes) {
+		return true
+	}
+
+	for i := 0; i < len(m1.Header.Includes); i++ {
+		if m1.Header.Includes[i].Name != m2.Header.Includes[i].Name {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (m *Manifest) hasUnsupportedTypeChanges() bool {


### PR DESCRIPTION
The compareIncludes() function indicates if two include lists are the
same. On the other hand, the changedIncludes variable indicates if the
list has changed, so it is always the opposite of what is returned by
compareIncludes()nd it must be swapped on assignment.

Also, the comparison using DeepEqual cannot be used to compare the list.
We only care if the include list is still the same, not if the properties
of that include have changes. This problem was never triggered since the\
result of this call was being misused.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>