### PR TITLE
mixin: fix local repo bug

### DIFF
--- a/mixin/package.go
+++ b/mixin/package.go
@@ -110,6 +110,21 @@ func addPackage(pkg string, build bool) (string, error) {
 	b.NumBundleWorkers = runtime.NumCPU()
 	b.NumFullfileWorkers = runtime.NumCPU()
 
+	rpms, err := helpers.ListVisibleFiles(b.Config.Mixer.LocalRPMDir)
+	if err != nil {
+		return "", err
+	}
+
+	if len(rpms) > 0 {
+		// initialize local repo automatically
+		runInitRepo(&cobra.Command{}, []string{})
+
+		err = b.AddRPMList(rpms)
+		if err != nil {
+			return "", err
+		}
+	}
+
 	bundle, err = getPackageRepo(pkg, ver, b.Config.Builder.DNFConf)
 	if err != nil {
 		return "", err
@@ -121,16 +136,6 @@ func addPackage(pkg string, build bool) (string, error) {
 	}
 
 	err = appendToFile(filepath.Join(mixWS, "local-bundles", bundle), fmt.Sprintf("%s\n", pkg))
-	if err != nil {
-		return "", err
-	}
-
-	rpms, err := helpers.ListVisibleFiles(b.Config.Mixer.LocalRPMDir)
-	if err != nil {
-		return "", err
-	}
-
-	err = b.AddRPMList(rpms)
 	if err != nil {
 		return "", err
 	}

--- a/mixin/repo.go
+++ b/mixin/repo.go
@@ -178,10 +178,20 @@ func runInitRepo(cmd *cobra.Command, args []string) {
 		fail(err)
 	}
 
+	// save working directory so we can come back,
+	// this function may be called other than by commandline
+	wd, err := os.Getwd()
+	if err != nil {
+		fail(err)
+	}
+
 	err = os.Chdir(mixWS)
 	if err != nil {
 		fail(err)
 	}
+	defer func() {
+		_ = os.Chdir(wd)
+	}()
 
 	err = b.NewDNFConfIfNeeded()
 	if err != nil {


### PR DESCRIPTION
Fixes #309
Add the local RPMs before checking if they exist via getPackageRepo. If
the .yum-mix.conf does not exist yet initialize this file so the local
repo is configured.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>