### PR TITLE
[AFB] Fix docker mount path lookup

### DIFF
--- a/builder/config.go
+++ b/builder/config.go
@@ -42,10 +42,10 @@ type MixConfig struct {
 }
 
 type builderConf struct {
-	Cert           string `required:"true" toml:"CERT"`
-	ServerStateDir string `required:"true" toml:"SERVER_STATE_DIR"`
-	VersionPath    string `required:"true" toml:"VERSIONS_PATH"`
-	DNFConf        string `required:"true" toml:"YUM_CONF"`
+	Cert           string `required:"true" mount:"true" toml:"CERT"`
+	ServerStateDir string `required:"true" mount:"true" toml:"SERVER_STATE_DIR"`
+	VersionPath    string `required:"true" mount:"true" toml:"VERSIONS_PATH"`
+	DNFConf        string `required:"true" mount:"true" toml:"YUM_CONF"`
 }
 
 type swupdConf struct {
@@ -62,9 +62,9 @@ type serverConf struct {
 }
 
 type mixerConf struct {
-	LocalBundleDir string `required:"false" toml:"LOCAL_BUNDLE_DIR"`
-	LocalRepoDir   string `required:"false" toml:"LOCAL_REPO_DIR"`
-	LocalRPMDir    string `required:"false" toml:"LOCAL_RPM_DIR"`
+	LocalBundleDir string `required:"false" mount:"true" toml:"LOCAL_BUNDLE_DIR"`
+	LocalRepoDir   string `required:"false" mount:"true" toml:"LOCAL_REPO_DIR"`
+	LocalRPMDir    string `required:"false" mount:"true" toml:"LOCAL_RPM_DIR"`
 	DockerImgPath  string `required:"false" toml:"DOCKER_IMAGE_PATH"`
 }
 


### PR DESCRIPTION
This patch fixes a bug with the way mixer determined which fields in `builder.conf` were mountable paths.

Previously, mixer treated every field in `[Builder]` and `[Mixer]` as paths on the filesystem (or paths to files whose parent directories needed to be mounted). Introducing the `DOCKER_IMAGE_PATH` field broke this approach.

This patch introduces a new "mount" tag on the config struct fields that indicates whether a config field represents a mountable path. This has several benefits:
1. It allows us to know definitively which fields we should look at.
1. It allows us to look at the entire `builder.conf`, not just the `[Builder]` and `[Mixer]` sections.
1. It removes the restriction that paths in 'builder.conf' be absolute. This absolute check was mostly a sloppy way of checking if a field was in fact a path.

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>