### PR TITLE
config-unify part1: Base changes

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -35,6 +35,7 @@ import (
 	"text/tabwriter"
 	textTemplate "text/template" // "template" conflicts with crypto/x509
 
+	"github.com/clearlinux/mixer-tools/config"
 	"github.com/clearlinux/mixer-tools/helpers"
 	"github.com/clearlinux/mixer-tools/swupd"
 	"github.com/go-ini/ini"
@@ -51,7 +52,7 @@ var Offline = false
 // A Builder contains all configurable fields required to perform a full mix
 // operation, and is used to encapsulate life time data.
 type Builder struct {
-	Config MixConfig
+	Config config.MixConfig
 
 	BuildScript string
 	BuildConf   string
@@ -109,20 +110,6 @@ func NewFromConfig(conf string) (*Builder, error) {
 		return nil, err
 	}
 	return b, nil
-}
-
-// GetConfigPath returns the default config path if the provided path is empty
-func GetConfigPath(path string) (string, error) {
-	if path != "" {
-		return path, nil
-	}
-
-	pwd, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(pwd, "builder.conf"), nil
 }
 
 // initDirs creates the directories mixer uses
@@ -292,7 +279,7 @@ func (b *Builder) InitMix(upstreamVer string, mixVer string, allLocal bool, allU
 // the local builder.conf file.
 func (b *Builder) LoadBuilderConf(builderconf string) error {
 	var err error
-	b.BuildConf, err = GetConfigPath(builderconf)
+	b.BuildConf, err = config.GetConfigPath(builderconf)
 	if err != nil {
 		return err
 	}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -2003,18 +2003,18 @@ func createDeltaPacks(from *swupd.Manifest, to *swupd.Manifest, printReport bool
 	sort.Strings(orderedBundles)
 
 	for _, name := range orderedBundles {
-		b := bundlesToPack[name]
-		packPath := filepath.Join(outputDir, fmt.Sprint(b.ToVersion), swupd.GetPackFilename(b.Name, b.FromVersion))
+		bp := bundlesToPack[name]
+		packPath := filepath.Join(outputDir, fmt.Sprint(bp.ToVersion), swupd.GetPackFilename(bp.Name, bp.FromVersion))
 		_, err = os.Lstat(packPath)
 		if err == nil {
-			fmt.Printf("  Delta pack already exists for %s from %d to %d\n", b.Name, b.FromVersion, b.ToVersion)
+			fmt.Printf("  Delta pack already exists for %s from %d to %d\n", bp.Name, bp.FromVersion, bp.ToVersion)
 			continue
 		}
 		if !os.IsNotExist(err) {
 			return errors.Wrapf(err, "couldn't access existing pack file %s", packPath)
 		}
-		fmt.Printf("  Creating delta pack for bundle %q from %d to %d\n", b.Name, b.FromVersion, b.ToVersion)
-		info, err := swupd.CreatePack(b.Name, b.FromVersion, b.ToVersion, outputDir, bundleDir, numWorkers)
+		fmt.Printf("  Creating delta pack for bundle %q from %d to %d\n", bp.Name, bp.FromVersion, bp.ToVersion)
+		info, err := swupd.CreatePack(bp.Name, bp.FromVersion, bp.ToVersion, outputDir, bundleDir, numWorkers)
 		if err != nil {
 			return err
 		}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -100,7 +100,7 @@ func New() *Builder {
 // NewFromConfig creates a new Builder with the given Configuration.
 func NewFromConfig(conf string) (*Builder, error) {
 	b := New()
-	if err := b.Config.LoadDefaults(); err != nil {
+	if err := b.Config.LoadDefaults(false); err != nil {
 		return nil, err
 	}
 	if err := b.LoadBuilderConf(conf); err != nil {

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -55,7 +55,6 @@ type Builder struct {
 	Config config.MixConfig
 
 	BuildScript string
-	BuildConf   string
 
 	MixVer            string
 	MixVerFile        string
@@ -103,7 +102,7 @@ func NewFromConfig(conf string) (*Builder, error) {
 	if err := b.Config.LoadDefaults(false); err != nil {
 		return nil, err
 	}
-	if err := b.LoadBuilderConf(conf); err != nil {
+	if err := b.Config.LoadConfig(conf); err != nil {
 		return nil, err
 	}
 	if err := b.ReadVersions(); err != nil {
@@ -272,19 +271,6 @@ func (b *Builder) InitMix(upstreamVer string, mixVer string, allLocal bool, allU
 	}
 
 	return nil
-}
-
-// LoadBuilderConf will read the builder configuration from the command line if
-// it was provided, otherwise it will fall back to reading the configuration from
-// the local builder.conf file.
-func (b *Builder) LoadBuilderConf(builderconf string) error {
-	var err error
-	b.BuildConf, err = config.GetConfigPath(builderconf)
-	if err != nil {
-		return err
-	}
-
-	return b.Config.LoadConfig(b.BuildConf)
 }
 
 // ReadVersions will initialise the mix versions (mix and clearlinux) from

--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -625,7 +625,7 @@ func (b *Builder) buildBundles(set bundleSet) error {
 	// TODO: Do not touch config code that is in flux at the moment, reparsing it here to grab
 	// information that previously Mixer didn't care about. Move that to the configuration part
 	// of Mixer.
-	cfg, err := readBuildBundlesConfig(b.BuildConf)
+	cfg, err := readBuildBundlesConfig(b.Config.GetConfigFileName())
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package builder
+package config
 
 import (
 	"bytes"
@@ -390,4 +390,18 @@ func (config *MixConfig) Print() error {
 	fmt.Println(sb.String())
 
 	return nil
+}
+
+// GetConfigPath returns the default config path if the provided path is empty
+func GetConfigPath(path string) (string, error) {
+	if path != "" {
+		return path, nil
+	}
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(pwd, "builder.conf"), nil
 }

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -97,7 +97,7 @@ var buildBundlesCmd = &cobra.Command{
 	Short:   "Build the bundles for your mix",
 	Long:    `Build the bundles for your mix`,
 	Run: func(cmd *cobra.Command, args []string) {
-		b, err := builder.NewFromConfig(config)
+		b, err := builder.NewFromConfig(configFile)
 		if err != nil {
 			fail(err)
 		}
@@ -114,7 +114,7 @@ var buildUpdateCmd = &cobra.Command{
 	Short: "Build the update content for your mix",
 	Long:  `Build the update content for your mix`,
 	Run: func(cmd *cobra.Command, args []string) {
-		b, err := builder.NewFromConfig(config)
+		b, err := builder.NewFromConfig(configFile)
 		if err != nil {
 			fail(err)
 		}
@@ -137,7 +137,7 @@ var buildAllCmd = &cobra.Command{
 	Short: "Build all content for mix with default options",
 	Long:  `Build all content for mix with default options`,
 	Run: func(cmd *cobra.Command, args []string) {
-		b, err := builder.NewFromConfig(config)
+		b, err := builder.NewFromConfig(configFile)
 		if err != nil {
 			fail(err)
 		}
@@ -169,7 +169,7 @@ var buildImageCmd = &cobra.Command{
 	Short: "Build an image from the mix content",
 	Long:  `Build an image from the mix content`,
 	Run: func(cmd *cobra.Command, args []string) {
-		b, err := builder.NewFromConfig(config)
+		b, err := builder.NewFromConfig(configFile)
 		if err != nil {
 			fail(err)
 		}
@@ -223,7 +223,7 @@ func runBuildDeltaPacks(cmd *cobra.Command, args []string) error {
 		return errors.Errorf("either --from or --previous-versions must be set, but not both")
 	}
 
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}
@@ -260,7 +260,7 @@ var buildCmds = []*cobra.Command{
 func init() {
 	for _, cmd := range buildCmds {
 		buildCmd.AddCommand(cmd)
-		cmd.Flags().StringVarP(&config, "config", "c", "", "Builder config to use")
+		cmd.Flags().StringVarP(&configFile, "config", "c", "", "Builder config to use")
 	}
 
 	buildCmd.PersistentFlags().IntVar(&buildFlags.numFullfileWorkers, "fullfile-workers", 0, "Number of parallel workers when creating fullfiles, 0 means number of CPUs")

--- a/mixer/cmd/bundles.go
+++ b/mixer/cmd/bundles.go
@@ -50,7 +50,7 @@ resultant list is written back out in sorted order.`,
 			}
 		}
 
-		b, err := builder.NewFromConfig(config)
+		b, err := builder.NewFromConfig(configFile)
 		if err != nil {
 			fail(err)
 		}
@@ -92,7 +92,7 @@ and now reference the original upstream version. If the bundle was custom, and
 no upstream alternative exists, a warning will be returned.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		b, err := builder.NewFromConfig(config)
+		b, err := builder.NewFromConfig(configFile)
 		if err != nil {
 			fail(err)
 		}
@@ -125,7 +125,7 @@ var bundleListCmd = &cobra.Command{
 			return errors.New("bundle list takes at most one argument")
 		}
 
-		b, err := builder.NewFromConfig(config)
+		b, err := builder.NewFromConfig(configFile)
 		if err != nil {
 			fail(err)
 		}
@@ -186,7 +186,7 @@ bundles are added after all bundles are edited, and thus will not be added if
 any errors are encountered earlier on.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		b, err := builder.NewFromConfig(config)
+		b, err := builder.NewFromConfig(configFile)
 		if err != nil {
 			fail(err)
 		}
@@ -227,7 +227,7 @@ Passing '--all-local' will run validation on all bundles in local-bundles.`,
 			return errors.New("bundle validate requires at least 1 argument if --all-local is not passed")
 		}
 
-		b, err := builder.NewFromConfig(config)
+		b, err := builder.NewFromConfig(configFile)
 		if err != nil {
 			fail(err)
 		}
@@ -264,7 +264,7 @@ var bundlesCmds = []*cobra.Command{
 func init() {
 	for _, cmd := range bundlesCmds {
 		bundleCmd.AddCommand(cmd)
-		cmd.Flags().StringVarP(&config, "config", "c", "", "Builder config to use")
+		cmd.Flags().StringVarP(&configFile, "config", "c", "", "Builder config to use")
 	}
 
 	RootCmd.AddCommand(bundleCmd)

--- a/mixer/cmd/config.go
+++ b/mixer/cmd/config.go
@@ -15,8 +15,7 @@
 package cmd
 
 import (
-	"github.com/clearlinux/mixer-tools/builder"
-
+	"github.com/clearlinux/mixer-tools/config"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -34,12 +33,12 @@ var configValidateCmd = &cobra.Command{
 environment variables will be expanded`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
-		if configFile, err = builder.GetConfigPath(configFile); err != nil {
+		if configFile, err = config.GetConfigPath(configFile); err != nil {
 			// Print error, but don't print command usage
 			fail(err)
 		}
 
-		var mc builder.MixConfig
+		var mc config.MixConfig
 		if err := mc.LoadConfig(configFile); err != nil {
 			fail(err)
 		}
@@ -59,11 +58,11 @@ a backup file of the old config and will replace it with the converted one. Envi
 variables will not be expanded and the values will not be validated`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
-		if configFile, err = builder.GetConfigPath(configFile); err != nil {
+		if configFile, err = config.GetConfigPath(configFile); err != nil {
 			fail(err)
 		}
 
-		var mc builder.MixConfig
+		var mc config.MixConfig
 		if err := mc.Convert(configFile); err != nil {
 			fail(err)
 		}
@@ -79,16 +78,16 @@ var configSetCmd = &cobra.Command{
 	the existence of the provided property, but will not validate the value provided.`,
 	Args: cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		if !builder.UseNewConfig {
+		if !config.UseNewConfig {
 			fail(errors.New("config set requires `--new-config` flag`"))
 		}
 
 		var err error
-		if configFile, err = builder.GetConfigPath(configFile); err != nil {
+		if configFile, err = config.GetConfigPath(configFile); err != nil {
 			fail(err)
 		}
 
-		var mc builder.MixConfig
+		var mc config.MixConfig
 		if err := mc.LoadConfig(configFile); err != nil {
 			fail(err)
 		}

--- a/mixer/cmd/config.go
+++ b/mixer/cmd/config.go
@@ -32,12 +32,6 @@ var configValidateCmd = &cobra.Command{
 	Long: `Parse a builder config file and display its properties. Properties containing
 environment variables will be expanded`,
 	Run: func(cmd *cobra.Command, args []string) {
-		var err error
-		if configFile, err = config.GetConfigPath(configFile); err != nil {
-			// Print error, but don't print command usage
-			fail(err)
-		}
-
 		var mc config.MixConfig
 		if err := mc.LoadConfig(configFile); err != nil {
 			fail(err)
@@ -57,11 +51,6 @@ var configConvertCmd = &cobra.Command{
 a backup file of the old config and will replace it with the converted one. Environment
 variables will not be expanded and the values will not be validated`,
 	Run: func(cmd *cobra.Command, args []string) {
-		var err error
-		if configFile, err = config.GetConfigPath(configFile); err != nil {
-			fail(err)
-		}
-
 		var mc config.MixConfig
 		if err := mc.Convert(configFile); err != nil {
 			fail(err)
@@ -81,18 +70,12 @@ var configSetCmd = &cobra.Command{
 		if !config.UseNewConfig {
 			fail(errors.New("config set requires `--new-config` flag`"))
 		}
-
-		var err error
-		if configFile, err = config.GetConfigPath(configFile); err != nil {
-			fail(err)
-		}
-
 		var mc config.MixConfig
 		if err := mc.LoadConfig(configFile); err != nil {
 			fail(err)
 		}
 
-		if err := mc.SetProperty(configFile, args[0], args[1]); err != nil {
+		if err := mc.SetProperty(args[0], args[1]); err != nil {
 			fail(err)
 		}
 

--- a/mixer/cmd/config.go
+++ b/mixer/cmd/config.go
@@ -34,13 +34,13 @@ var configValidateCmd = &cobra.Command{
 environment variables will be expanded`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
-		if config, err = builder.GetConfigPath(config); err != nil {
+		if configFile, err = builder.GetConfigPath(configFile); err != nil {
 			// Print error, but don't print command usage
 			fail(err)
 		}
 
 		var mc builder.MixConfig
-		if err := mc.LoadConfig(config); err != nil {
+		if err := mc.LoadConfig(configFile); err != nil {
 			fail(err)
 		}
 
@@ -59,12 +59,12 @@ a backup file of the old config and will replace it with the converted one. Envi
 variables will not be expanded and the values will not be validated`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
-		if config, err = builder.GetConfigPath(config); err != nil {
+		if configFile, err = builder.GetConfigPath(configFile); err != nil {
 			fail(err)
 		}
 
 		var mc builder.MixConfig
-		if err := mc.Convert(config); err != nil {
+		if err := mc.Convert(configFile); err != nil {
 			fail(err)
 		}
 
@@ -84,16 +84,16 @@ var configSetCmd = &cobra.Command{
 		}
 
 		var err error
-		if config, err = builder.GetConfigPath(config); err != nil {
+		if configFile, err = builder.GetConfigPath(configFile); err != nil {
 			fail(err)
 		}
 
 		var mc builder.MixConfig
-		if err := mc.LoadConfig(config); err != nil {
+		if err := mc.LoadConfig(configFile); err != nil {
 			fail(err)
 		}
 
-		if err := mc.SetProperty(config, args[0], args[1]); err != nil {
+		if err := mc.SetProperty(configFile, args[0], args[1]); err != nil {
 			fail(err)
 		}
 
@@ -110,7 +110,7 @@ var configCmds = []*cobra.Command{
 func init() {
 	for _, cmd := range configCmds {
 		configCmd.AddCommand(cmd)
-		cmd.Flags().StringVarP(&config, "config", "c", "", "Builder config to use")
+		cmd.Flags().StringVarP(&configFile, "config", "c", "", "Builder config to use")
 	}
 
 	RootCmd.AddCommand(configCmd)

--- a/mixer/cmd/repos.go
+++ b/mixer/cmd/repos.go
@@ -75,7 +75,7 @@ var repoCmds = []*cobra.Command{
 func init() {
 	for _, cmd := range repoCmds {
 		repoCmd.AddCommand(cmd)
-		cmd.Flags().StringVarP(&config, "config", "c", "", "Builder config to use")
+		cmd.Flags().StringVarP(&configFile, "config", "c", "", "Builder config to use")
 	}
 
 	RootCmd.AddCommand(repoCmd)
@@ -85,7 +85,7 @@ func runAddRepo(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
 		fail(errors.New("add requires exactly two arguments: <repo-name> <repo-url>"))
 	}
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}
@@ -101,7 +101,7 @@ func runRemoveRepo(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		fail(errors.New("remove requires exactly one argument: <name>"))
 	}
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}
@@ -114,7 +114,7 @@ func runRemoveRepo(cmd *cobra.Command, args []string) {
 }
 
 func runListRepos(cmd *cobra.Command, args []string) {
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}
@@ -126,7 +126,7 @@ func runListRepos(cmd *cobra.Command, args []string) {
 }
 
 func runInitRepo(cmd *cobra.Command, args []string) {
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}
@@ -142,7 +142,7 @@ func runSetURLRepo(cmd *cobra.Command, args []string) {
 		fail(errors.New("set-url requires exactly two arguments: <name> <url>"))
 	}
 
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -29,7 +29,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var config string
+var configFile string
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
@@ -110,13 +110,13 @@ var initCmd = &cobra.Command{
 		}
 
 		b := builder.New()
-		if config == "" {
+		if configFile == "" {
 			// Create default config if necessary
 			if err := b.Config.CreateDefaultConfig(initFlags.localRPMs); err != nil {
 				fail(err)
 			}
 		}
-		if err := b.LoadBuilderConf(config); err != nil {
+		if err := b.LoadBuilderConf(configFile); err != nil {
 			fail(err)
 		}
 		err := b.InitMix(initFlags.clearVer, strconv.Itoa(initFlags.mixver), initFlags.allLocal, initFlags.allUpstream, initFlags.upstreamURL, initFlags.git)
@@ -161,7 +161,7 @@ func init() {
 	initCmd.Flags().StringVar(&initFlags.clearVer, "upstream-version", "latest", "Alias to --clear-version")
 	initCmd.Flags().IntVar(&initFlags.mixver, "mix-version", 10, "Supply the Mix version to build")
 	initCmd.Flags().BoolVar(&initFlags.localRPMs, "local-rpms", false, "Create and configure local RPMs directories")
-	initCmd.Flags().StringVar(&config, "config", "", "Supply a specific builder.conf to use for mixing")
+	initCmd.Flags().StringVar(&configFile, "config", "", "Supply a specific builder.conf to use for mixing")
 	initCmd.Flags().StringVar(&initFlags.upstreamURL, "upstream-url", "https://download.clearlinux.org", "Supply an upstream URL to use for mixing")
 	initCmd.Flags().BoolVar(&initFlags.git, "git", false, "Track mixer's internal work dir with git")
 

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/clearlinux/mixer-tools/builder"
+	"github.com/clearlinux/mixer-tools/config"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -147,7 +148,7 @@ func init() {
 	_ = RootCmd.Flags().MarkDeprecated("new-swupd", "new functionality is now the standard behavior, this flag is obsolete and no longer used")
 
 	// TODO: Remove this once we drop the old config format
-	RootCmd.PersistentFlags().BoolVar(&builder.UseNewConfig, "new-config", false, "EXPERIMENTAL: use the new TOML config format")
+	RootCmd.PersistentFlags().BoolVar(&config.UseNewConfig, "new-config", false, "EXPERIMENTAL: use the new TOML config format")
 
 	RootCmd.PersistentFlags().BoolVar(&builder.Offline, "offline", false, "Skip caching upstream-bundles; work entirely with local-bundles")
 

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -117,7 +117,8 @@ var initCmd = &cobra.Command{
 				fail(err)
 			}
 		}
-		if err := b.LoadBuilderConf(configFile); err != nil {
+
+		if err := b.Config.LoadConfig(configFile); err != nil {
 			fail(err)
 		}
 		err := b.InitMix(initFlags.clearVer, strconv.Itoa(initFlags.mixver), initFlags.allLocal, initFlags.allUpstream, initFlags.upstreamURL, initFlags.git)

--- a/mixer/cmd/rpms.go
+++ b/mixer/cmd/rpms.go
@@ -35,7 +35,7 @@ var rpmCmds = []*cobra.Command{
 func init() {
 	for _, cmd := range rpmCmds {
 		RootCmd.AddCommand(cmd)
-		cmd.Flags().StringVarP(&config, "config", "c", "", "Builder config to use")
+		cmd.Flags().StringVarP(&configFile, "config", "c", "", "Builder config to use")
 	}
 
 	externalDeps[addRPMCmd] = []string{
@@ -45,7 +45,7 @@ func init() {
 }
 
 func runAddRPM(cmd *cobra.Command, args []string) {
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}

--- a/mixer/cmd/versions.go
+++ b/mixer/cmd/versions.go
@@ -63,7 +63,7 @@ func init() {
 	versionsCmd.AddCommand(versionsUpdateCmd)
 	RootCmd.AddCommand(versionsCmd)
 
-	versionsUpdateCmd.Flags().StringVarP(&config, "config", "c", "", "Builder config to use")
+	versionsUpdateCmd.Flags().StringVarP(&configFile, "config", "c", "", "Builder config to use")
 	versionsUpdateCmd.Flags().Uint32Var(&versionsUpdateFlags.mixVersion, "mix-version", 0, "Set a specific mix version")
 	versionsUpdateCmd.Flags().StringVar(&versionsUpdateFlags.upstreamVersion, "upstream-version", "", "Next upstream version (either version number or 'latest')")
 	versionsUpdateCmd.Flags().StringVar(&versionsUpdateFlags.upstreamVersion, "clear-version", "", "Alias to --upstream-version")
@@ -71,7 +71,7 @@ func init() {
 }
 
 func runVersions(cmd *cobra.Command, args []string) {
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}
@@ -82,7 +82,7 @@ func runVersions(cmd *cobra.Command, args []string) {
 }
 
 func runVersionsUpdate(cmd *cobra.Command, args []string) {
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}

--- a/mixin/helpers.go
+++ b/mixin/helpers.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/clearlinux/mixer-tools/config"
 	"github.com/clearlinux/mixer-tools/helpers"
 	"github.com/clearlinux/mixer-tools/swupd"
 
@@ -103,9 +104,13 @@ func setUpMixDir(upstreamVer, mixVer int) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filepath.Join(mixWS, "builder.conf"),
-		[]byte(builderConf), 0644)
-	if err != nil {
+	config.UseNewConfig = true
+	var c config.MixConfig
+	c.LoadDefaultsForPath(true, "/usr/share/mix")
+	c.Swupd.Bundle = "os-core"
+	c.Swupd.ContentURL = "file:///usr/share/mix/update/www"
+	c.Swupd.VersionURL = "file:///usr/share/mix/update/www"
+	if err = c.SaveConfig(filepath.Join(mixWS, "builder.conf")); err != nil {
 		return err
 	}
 	err = ioutil.WriteFile(filepath.Join(mixWS, "mixversion"),
@@ -151,10 +156,10 @@ func parseHeaderNoopInstall(pkg, installOut string) (string, error) {
 	return "", errors.New("unable to find repo for package")
 }
 
-func getPackageRepo(pkg string, ver int, config string) (string, error) {
+func getPackageRepo(pkg string, ver int, configFile string) (string, error) {
 	packagerCmd := []string{
 		"dnf",
-		"--config=" + config,
+		"--config=" + configFile,
 		fmt.Sprintf("--releasever=%d", ver),
 		"install",
 		"--assumeno",

--- a/mixin/helpers.go
+++ b/mixin/helpers.go
@@ -110,7 +110,7 @@ func setUpMixDir(upstreamVer, mixVer int) error {
 	c.Swupd.Bundle = "os-core"
 	c.Swupd.ContentURL = "file:///usr/share/mix/update/www"
 	c.Swupd.VersionURL = "file:///usr/share/mix/update/www"
-	if err = c.SaveConfig(filepath.Join(mixWS, "builder.conf")); err != nil {
+	if err = c.SaveConfig(); err != nil {
 		return err
 	}
 	err = ioutil.WriteFile(filepath.Join(mixWS, "mixversion"),

--- a/mixin/main.go
+++ b/mixin/main.go
@@ -15,26 +15,7 @@
 package main
 
 var mixWS = "/usr/share/mix"
-var config = "/usr/share/mix/builder.conf"
-
-const builderConf = `[Mixer]
-LOCAL_BUNDLE_DIR = /usr/share/mix/local-bundles
-
-[Builder]
-SERVER_STATE_DIR = /usr/share/mix/update
-BUNDLE_DIR = /usr/share/mix/local-bundles
-YUM_CONF = /usr/share/mix/.yum-mix.conf
-CERT = /usr/share/mix/Swupd_Root.pem
-VERSIONS_PATH =/usr/share/mix
-LOCAL_RPM_DIR = /usr/share/mix/local-rpms
-LOCAL_REPO_DIR = /usr/share/mix/local
-
-[swupd]
-BUNDLE=os-core
-CONTENTURL=file:///usr/share/mix/update/www
-VERSIONURL=file:///usr/share/mix/update/www
-FORMAT=1
-`
+var configFile = "/usr/share/mix/builder.conf"
 
 func main() {
 	Execute()

--- a/mixin/package.go
+++ b/mixin/package.go
@@ -63,7 +63,7 @@ var packageAddFlags packageAddCmdFlags
 func init() {
 	for _, cmd := range packageCmds {
 		packageCmd.AddCommand(cmd)
-		cmd.Flags().StringVarP(&config, "config", "c", "/usr/share/mix/builder.conf", "Builder config to use")
+		cmd.Flags().StringVarP(&configFile, "config", "c", "/usr/share/mix/builder.conf", "Builder config to use")
 	}
 
 	addPackageCmd.Flags().BoolVar(&packageAddFlags.build, "build", false, "Build mix update after adding package to bundle")

--- a/mixin/repo.go
+++ b/mixin/repo.go
@@ -97,7 +97,7 @@ func repoPrep() error {
 func init() {
 	for _, cmd := range repoCmds {
 		repoCmd.AddCommand(cmd)
-		cmd.Flags().StringVarP(&config, "config", "c", "/usr/share/mix/builder.conf", "Builder config to use")
+		cmd.Flags().StringVarP(&configFile, "config", "c", "/usr/share/mix/builder.conf", "Builder config to use")
 	}
 
 	RootCmd.AddCommand(repoCmd)
@@ -108,7 +108,7 @@ func runAddRepo(cmd *cobra.Command, args []string) {
 	if err != nil {
 		fail(err)
 	}
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}
@@ -130,7 +130,7 @@ func runRemoveRepo(cmd *cobra.Command, args []string) {
 	if err != nil {
 		fail(err)
 	}
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}
@@ -152,7 +152,7 @@ func runListRepos(cmd *cobra.Command, args []string) {
 	if err != nil {
 		fail(err)
 	}
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}
@@ -173,7 +173,7 @@ func runInitRepo(cmd *cobra.Command, args []string) {
 	if err != nil {
 		fail(err)
 	}
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}
@@ -205,7 +205,7 @@ func runSetURLRepo(cmd *cobra.Command, args []string) {
 		fail(err)
 	}
 
-	b, err := builder.NewFromConfig(config)
+	b, err := builder.NewFromConfig(configFile)
 	if err != nil {
 		fail(err)
 	}


### PR DESCRIPTION
This PR is the first part of the config unification patch and includes all the pre-work required to remove the extra config files. With those changes in, the remaining patches can be sent as independent PRs as each one only deals with removing one specific config file (e.g. server.ini). This also is the part that requires the most work rebasing, so once they are in, working on further revisions for the rest should be much easier.