### PR TITLE
Create SERVER_STATE_DIR with uid/gid of parent

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -32,6 +32,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"text/tabwriter"
 	textTemplate "text/template" // "template" conflicts with crypto/x509
 
@@ -1427,6 +1428,22 @@ func (b *Builder) NewDNFConfIfNeeded() error {
 	return nil
 }
 
+// getClosestAncestorOwner returns the owner uid/gid of the closest existing
+// ancestor of the file or dir pointed to by path. There is no fully cross-
+// platform concept of "ownership", so this method only works on *nix systems.
+func getClosestAncestorOwner(path string) (int, int, error) {
+	path = filepath.Dir(path)
+	fi, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return getClosestAncestorOwner(path)
+	} else if err != nil {
+		return 0, 0, err
+	}
+	uid := int(fi.Sys().(*syscall.Stat_t).Uid)
+	gid := int(fi.Sys().(*syscall.Stat_t).Gid)
+	return uid, gid, nil
+}
+
 // BuildBundles will attempt to construct the bundles required by generating a
 // DNF configuration file, then resolving all files for each bundle using dnf
 // resolve and no-op installs. One full chroot is created from this step with
@@ -1447,6 +1464,21 @@ func (b *Builder) BuildBundles(template *x509.Certificate, privkey *rsa.PrivateK
 	timer.Start("BUILD BUNDLES")
 	if err := b.NewDNFConfIfNeeded(); err != nil {
 		return err
+	}
+
+	// If ServerStateDir does not exist, create it with ownership matching its
+	// closest existing ancestor directory
+	if _, err := os.Stat(b.Config.Builder.ServerStateDir); os.IsNotExist(err) {
+		uid, gid, err := getClosestAncestorOwner(b.Config.Builder.ServerStateDir)
+		if err != nil {
+			return err
+		}
+		if err = os.MkdirAll(b.Config.Builder.ServerStateDir, 0755); err != nil {
+			return errors.Wrapf(err, "Failed to create server state dir: %q", b.Config.Builder.ServerStateDir)
+		}
+		if err = os.Chown(b.Config.Builder.ServerStateDir, uid, gid); err != nil {
+			return errors.Wrapf(err, "Failed to set ownership of dir: %q", b.Config.Builder.ServerStateDir)
+		}
 	}
 
 	// If MIXVER already exists, wipe it so it's a fresh build


### PR DESCRIPTION
This patch changes the way `SERVER_STATE_DIR` is created if it does not already exist, in order to facilitate mounting the directory inside the Docker container.

By default, `SERVER_STATE_DIR` in `builder.conf` is set to `PWD + "/update"`, a path that typically does not already exist and is created automaticallly the first time mixer builds bundles. Historically, `mixer build bundles` was run as root; now it is run as root within a Docker container. In either case, this `update` directory ends up owned by root.

For security reasons, mixer will not mount to the container any directory to which the caller does not have read/write permissions. This means that on subsequent calls, mixer refuses to mount the `update` directory it just created, as it is owned by root.

This patch resolves this for most users by creating the `SERVER_STATE_DIR` with the uid/gid of its closest existant ancester. In the default case, this is the uid/gid of the `PWD`. Users with existing mixes will need to manually `chown` the `SERVER_STATE_DIR` to a uid/gid they have read/write permission to.

Signed-off-by: Kevin C. Wells <kevin.c.wells@intel.com>