### PR TITLE
Report repo name title not repo key name

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -1778,7 +1778,7 @@ func (b *Builder) ListRepos() error {
 	}
 
 	for _, s := range DNFConf.Sections() {
-		name := s.Key("name").Value()
+		name := s.Name()
 		if name == "" {
 			continue
 		}


### PR DESCRIPTION
List the repo title (which is not upper cased) instead of the key 'name'
in the section body. This is important because repo set-url and repo add
operates on the section title not the key name.

Fixes #316 

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>