### PR TITLE
No default bundles

### DIFF
--- a/bat/lib/mixerlib.bash
+++ b/bat/lib/mixerlib.bash
@@ -26,8 +26,7 @@ localize_builder_conf() {
 # builder.conf to use os-core for the "update bundle", strips os-core to just
 # the filesystem, and adds only os-core to the mix
 mixer-init-stripped-down() {
-  touch $BATS_TEST_DIRNAME/mixbundles
-  mixer $MIXARGS init --clear-version $1 --mix-version $2
+  mixer $MIXARGS init --clear-version $1 --mix-version $2 --no-default-bundles
   sed -i 's/os-core-update/os-core/' $BATS_TEST_DIRNAME/builder.conf
   echo "filesystem" > $LOCAL_BUNDLE_DIR/os-core
   mixer $MIXARGS bundle add os-core

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -194,7 +194,7 @@ mix-bundles/`
 
 // InitMix will initialise a new swupd-client consumable "mix" with the given
 // based Clear Linux version and specified mix version.
-func (b *Builder) InitMix(upstreamVer string, mixVer string, allLocal bool, allUpstream bool, upstreamURL string, git bool) error {
+func (b *Builder) InitMix(upstreamVer string, mixVer string, allLocal bool, allUpstream bool, noDefaults bool, upstreamURL string, git bool) error {
 	// Set up local dirs
 	if err := b.initDirs(); err != nil {
 		return err
@@ -253,12 +253,12 @@ func (b *Builder) InitMix(upstreamVer string, mixVer string, allLocal bool, allU
 	}
 
 	// Initialize the Mix Bundles List
-	if _, err := os.Stat(filepath.Join(b.Config.Builder.VersionPath, b.MixBundlesFile)); os.IsNotExist(err) {
-		// Add default bundles (or all)
-		defaultBundles := []string{"os-core", "os-core-update", "bootloader", "kernel-native"}
-		if err := b.AddBundles(defaultBundles, allLocal, allUpstream, false); err != nil {
-			return err
-		}
+	var bundles []string
+	if !noDefaults {
+		bundles = []string{"os-core", "os-core-update", "bootloader", "kernel-native"}
+	}
+	if err := b.AddBundles(bundles, allLocal, allUpstream, false); err != nil {
+		return err
 	}
 
 	// Get upstream bundles

--- a/docs/mixer.init.1
+++ b/docs/mixer.init.1
@@ -75,6 +75,10 @@ Create and configure local RPM directories.
 .sp
 Supply the mix version to build (default is 10)
 .IP \(bu 2
+\fB\-\-no\-default\-bundles\fP
+.sp
+Skip adding default bundles to the mix
+.IP \(bu 2
 \fB\-\-upstream\-url {url}\fP
 .sp
 Supply an upstream URL to use for mixing (default is

--- a/docs/mixer.init.1.rst
+++ b/docs/mixer.init.1.rst
@@ -60,6 +60,10 @@ more details), the following options are recognized.
 
    Supply the mix version to build (default is 10)
 
+-  ``--no-default-bundles``
+
+   Skip adding default bundles to the mix
+
 -  ``--upstream-url {url}``
 
    Supply an upstream URL to use for mixing (default is

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -87,6 +87,7 @@ var rootCmdFlags = struct {
 type initCmdFlags struct {
 	allLocal    bool
 	allUpstream bool
+	noDefaults  bool
 	clearVer    string
 	mixver      int
 	localRPMs   bool
@@ -119,7 +120,7 @@ var initCmd = &cobra.Command{
 		if err := b.LoadBuilderConf(config); err != nil {
 			fail(err)
 		}
-		err := b.InitMix(initFlags.clearVer, strconv.Itoa(initFlags.mixver), initFlags.allLocal, initFlags.allUpstream, initFlags.upstreamURL, initFlags.git)
+		err := b.InitMix(initFlags.clearVer, strconv.Itoa(initFlags.mixver), initFlags.allLocal, initFlags.allUpstream, initFlags.noDefaults, initFlags.upstreamURL, initFlags.git)
 		if err != nil {
 			fail(err)
 		}
@@ -157,6 +158,7 @@ func init() {
 
 	initCmd.Flags().BoolVar(&initFlags.allLocal, "all-local", false, "Initialize mix with all local bundles automatically included")
 	initCmd.Flags().BoolVar(&initFlags.allUpstream, "all-upstream", false, "Initialize mix with all upstream bundles automatically included")
+	initCmd.Flags().BoolVar(&initFlags.noDefaults, "no-default-bundles", false, "Skip adding default bundles to the mix")
 	initCmd.Flags().StringVar(&initFlags.clearVer, "clear-version", "latest", "Supply the Clear version to compose the mix from")
 	initCmd.Flags().StringVar(&initFlags.clearVer, "upstream-version", "latest", "Alias to --clear-version")
 	initCmd.Flags().IntVar(&initFlags.mixver, "mix-version", 10, "Supply the Mix version to build")

--- a/mixin/helpers.go
+++ b/mixin/helpers.go
@@ -113,11 +113,6 @@ func setUpMixDir(upstreamVer, mixVer int) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filepath.Join(mixWS, "mixbundles"),
-		[]byte("os-core"), 0644)
-	if err != nil {
-		return err
-	}
 	err = ioutil.WriteFile(filepath.Join(mixWS, "upstreamurl"),
 		[]byte("https://download.clearlinux.org"), 0644)
 	if err != nil {

--- a/mixin/package.go
+++ b/mixin/package.go
@@ -107,6 +107,10 @@ func addPackage(pkg string, build bool) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	err = b.AddBundles([]string{"os-core"}, false, false, false)
+	if err != nil {
+		return "", err
+	}
 	b.NumBundleWorkers = runtime.NumCPU()
 	b.NumFullfileWorkers = runtime.NumCPU()
 

--- a/mixin/package.go
+++ b/mixin/package.go
@@ -103,7 +103,7 @@ func addPackage(pkg string, build bool) (string, error) {
 		return "", err
 	}
 	err = b.InitMix(fmt.Sprintf("%d", ver), fmt.Sprintf("%d", mixVer),
-		false, false, "https://download.clearlinux.org", false)
+		false, false, true, "https://download.clearlinux.org", false)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixes #300. This has been asked for by numerous people. Even our own BATS tests were using the hack.

Note: Updated the `mixin` call `b.InitMix` to pass `true` for this variable, so it still ends up with only the `os-core` bundle.

---------------

Previously `mixer init` would add four default bundles to your `mixbundles` list, unless it already existed. This resulted in confusing behavior. Some users resorted to creating an empty `mixbundles` list before running 'mixer init' in order to avoid these bundles. Others had a `mixbundles` list already, but expected the bundles to be added anyway. 

This patch changes the behavior to **always** add the four default bundles, even if the `mixbundles` list already exists, unless a new `--no-default-bundles` flag is passed. This does not affect the behavior of `--all-local` or `--all-upstream`.