### PR TITLE
Parallel delta creation

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -2000,7 +2000,9 @@ func createDeltaPacks(fromMoM *swupd.Manifest, toMoM *swupd.Manifest, printRepor
 				fmt.Printf("  Creating delta pack for bundle %q from %d to %d\n", b.Name, b.FromVersion, b.ToVersion)
 				info, err := swupd.CreatePack(b.Name, b.FromVersion, b.ToVersion, outputDir, bundleDir, numWorkers)
 				if err != nil {
-					// set some error
+					fmt.Fprintf(os.Stderr, "ERROR: Pack %q from %d to %d FAILED to be created: %s\n", b.Name, b.FromVersion, b.ToVersion, err)
+					// Do not exit on errors, we have logging for all other failures and deltas are optional
+					continue
 				}
 
 				if len(info.Warnings) > 0 {

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -1950,13 +1950,13 @@ func (b *Builder) BuildDeltaPacksPreviousVersions(prev, to uint32, printReport b
 	return nil
 }
 
-func createDeltaPacks(from *swupd.Manifest, to *swupd.Manifest, printReport bool, outputDir, bundleDir string, numWorkers int) error {
+func createDeltaPacks(fromMoM *swupd.Manifest, toMoM *swupd.Manifest, printReport bool, outputDir, bundleDir string, numWorkers int) error {
 	timer := &stopWatch{w: os.Stdout}
 	defer timer.WriteSummary(os.Stdout)
 	timer.Start("CREATE DELTA PACKS")
 
-	fmt.Printf("Creating delta packs from %d to %d\n", from.Header.Version, to.Header.Version)
-	bundlesToPack, err := swupd.FindBundlesToPack(from, to)
+	fmt.Printf("Creating delta packs from %d to %d\n", fromMoM.Header.Version, toMoM.Header.Version)
+	bundlesToPack, err := swupd.FindBundlesToPack(fromMoM, toMoM)
 	if err != nil {
 		return err
 	}

--- a/swupd/delta.go
+++ b/swupd/delta.go
@@ -32,11 +32,11 @@ type Delta struct {
 	to    *File
 }
 
-// CreateDeltas creates all delta files between the previous and current version of the
+// CreateDeltasForManifest creates all delta files between the previous and current version of the
 // supplied manifest. Returns a list of deltas (which contains information about
 // individual delta errors). Returns error (and no deltas) if it can't assemble the delta
 // list. If number of workers is zero or less, 1 worker is used.
-func CreateDeltas(manifest, statedir string, from, to uint32, numWorkers int) ([]Delta, error) {
+func CreateDeltasForManifest(manifest, statedir string, from, to uint32, numWorkers int) ([]Delta, error) {
 	var c config
 
 	c, err := getConfig(statedir)

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -238,7 +238,7 @@ func checkManifestMatches(t *testing.T, testDir, ver, name string, res ...*regex
 
 func mustCreateAllDeltas(t *testing.T, manifest, statedir string, from, to uint32) {
 	t.Helper()
-	deltas, err := CreateDeltas(manifest, statedir, from, to, 0)
+	deltas, err := CreateDeltasForManifest(manifest, statedir, from, to, 0)
 	if err != nil {
 		t.Fatalf("couldn't create deltas for %s: %s", manifest, err)
 	}
@@ -256,7 +256,7 @@ func mustCreateAllDeltas(t *testing.T, manifest, statedir string, from, to uint3
 
 func tryCreateAllDeltas(t *testing.T, manifest, statedir string, from, to uint32) {
 	t.Helper()
-	_, err := CreateDeltas(manifest, statedir, from, to, 0)
+	_, err := CreateDeltasForManifest(manifest, statedir, from, to, 0)
 	if err != nil {
 		t.Fatalf("couldn't create deltas for %s: %s", manifest, err)
 	}

--- a/swupd/packs.go
+++ b/swupd/packs.go
@@ -79,6 +79,10 @@ func (state PackState) String() string {
 // version to the next. This allows better concurrency and the pack creation
 // code can just worry about adding pre-existing files to packs.
 func CreateAllDeltas(outputDir string, fromVersion, toVersion, numWorkers int) error {
+	// Don't try to make deltas for zero packs
+	if fromVersion == 0 {
+		return nil
+	}
 	fromFile := filepath.Join(outputDir, strconv.Itoa(fromVersion), "Manifest.full")
 	toFile := filepath.Join(outputDir, strconv.Itoa(toVersion), "Manifest.full")
 

--- a/swupd/packs_test.go
+++ b/swupd/packs_test.go
@@ -513,7 +513,12 @@ func mustValidateZeroPack(t *testing.T, manifestPath, packPath string) {
 
 func mustCreatePack(t *testing.T, name string, fromVersion, toVersion uint32, outputDir, chrootDir string) *PackInfo {
 	t.Helper()
-	info, err := CreatePack(name, fromVersion, toVersion, outputDir, chrootDir, 0)
+	err := CreateAllDeltas(outputDir, int(fromVersion), int(toVersion), 0)
+	if err != nil {
+		t.Fatalf("error creating pack for bundle %s: %s", name, err)
+	}
+	var info *PackInfo
+	info, err = CreatePack(name, fromVersion, toVersion, outputDir, chrootDir, 0)
 	if err != nil {
 		t.Fatalf("error creating pack for bundle %s: %s", name, err)
 	}


### PR DESCRIPTION
~This needs to pass make check, opening PR for early review of this new - albeit naive - first pass at re-implementing and parallelizing our delta pack creation.~

In my testing, building delta packs back from 22460 -> 22530 took about 60 minutes with the original code.
With this patch the time is reduced to 5m30s, but there is 1 missing delta and thus 1 added fullfile:
/usr/share/vim/vim81/lang/menu_ja.euc-jp.vim