### PR TITLE
Do not copy deleted bundles across a minversion

### DIFF
--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -366,6 +366,28 @@ func TestCreateManifestsMinVersion(t *testing.T) {
 	ts.checkNotContains("www/20/Manifest.full", "\t10\t")
 }
 
+func TestCreateManifestsMVDeletes(t *testing.T) {
+	ts := newTestSwupd(t, "minVersionDeletes")
+	defer ts.cleanup()
+
+	ts.Bundles = []string{"test-bundle"}
+	ts.addFile(10, "test-bundle", "/foo", "foo")
+	ts.createManifests(10)
+	ts.checkContains("www/10/Manifest.test-bundle", "10\t/foo\n")
+	ts.checkContains("www/10/Manifest.full", "10\t/foo\n")
+
+	// update and remove /foo
+	ts.createManifests(20)
+	fileDeletedInManifest(t, ts.parseManifest(20, "test-bundle"), 20, "/foo")
+	fileDeletedInManifest(t, ts.parseManifest(20, "full"), 20, "/foo")
+
+	// now create a minversion and make sure the deletes persist
+	ts.MinVersion = 30
+	ts.createManifests(30)
+	fileDeletedInManifest(t, ts.parseManifest(30, "test-bundle"), 30, "/foo")
+	fileDeletedInManifest(t, ts.parseManifest(30, "full"), 30, "/foo")
+}
+
 func TestCreateManifestsPersistDeletes(t *testing.T) {
 	ts := newTestSwupd(t, "persistDeletes")
 	defer ts.cleanup()


### PR DESCRIPTION
If the bundle was not generated anew for the new minversion do not try
to copy a reference to it from the old MoM. This indicates a bundle was
deleted and the old build may be cleaned up.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>


Sooo... OSVs shouldn't be deleting bundles over a minversion if it isn't associated with a format bump, and the failure that causes in mixer can help catch that. but I think that check should live elsewhere, not in mixer, and mixer should still do the right thing by dropping the bundle reference here. Thoughts @tmarcu?