### PR TITLE
bundles: write bundle info to tracking file

### DIFF
--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -520,7 +520,7 @@ func installBundleToFull(packagerCmd []string, buildVersionDir string, bundle *b
 		return err
 	}
 
-	return ioutil.WriteFile(filepath.Join(bundleDir, bundle.Name), nil, 0644)
+	return writeBundleInfoPretty(bundle, filepath.Join(bundleDir, bundle.Name))
 }
 
 func clearDNFCache(packagerCmd []string) error {
@@ -584,6 +584,15 @@ func buildFullChroot(cfg *buildBundlesConfig, b *Builder, set *bundleSet, packag
 	}
 
 	return nil
+}
+
+func writeBundleInfoPretty(bundle *bundle, path string) error {
+	b, err := json.MarshalIndent(*bundle, "", "	")
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(path, b, 0644)
 }
 
 func writeBundleInfo(bundle *bundle, path string) error {


### PR DESCRIPTION
Fixes #333
Write the bundle information JSON to the bundle tracking file under
/usr/share/clear/bundles/<bundle-name> for future use by a swupd-client
bundle-info command. Write it in a human-readable format for now until
the bundle-info command is usable by writing indents with
json.MarshalIndent.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>