### PR TITLE
os-core-update-index: add bundle metadata files

### DIFF
--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -520,7 +520,18 @@ func installBundleToFull(packagerCmd []string, buildVersionDir string, bundle *b
 		return err
 	}
 
-	return ioutil.WriteFile(filepath.Join(bundleDir, bundle.Name), nil, 0644)
+	err = ioutil.WriteFile(filepath.Join(bundleDir, bundle.Name), nil, 0644)
+	if err != nil {
+		return nil
+	}
+
+	metaPath := filepath.Join(baseDir, "usr/share/clear/allbundles")
+	err = os.MkdirAll(metaPath, 0755)
+	if err != nil {
+		return err
+	}
+
+	return writeBundleInfoPretty(bundle, filepath.Join(metaPath, bundle.Name))
 }
 
 func clearDNFCache(packagerCmd []string) error {
@@ -584,6 +595,15 @@ func buildFullChroot(cfg *buildBundlesConfig, b *Builder, set *bundleSet, packag
 	}
 
 	return nil
+}
+
+func writeBundleInfoPretty(bundle *bundle, path string) error {
+	b, err := json.MarshalIndent(*bundle, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(path, b, 0644)
 }
 
 func writeBundleInfo(bundle *bundle, path string) error {

--- a/swupd/bundleinfo.go
+++ b/swupd/bundleinfo.go
@@ -36,7 +36,7 @@ func (m *Manifest) getBundleInfo(path string) error {
 	var err error
 	if _, err = os.Stat(path); os.IsNotExist(err) {
 		basePath := filepath.Dir(path)
-		err = m.addFilesFromChroot(filepath.Join(filepath.Dir(path), m.Name))
+		err = m.addFilesFromChroot(filepath.Join(filepath.Dir(path), m.Name), "")
 		if err != nil {
 			return err
 		}
@@ -95,7 +95,7 @@ func (m *Manifest) addFilesFromBundleInfo(c config, version uint32) error {
 			return err
 		}
 
-		err = m.createFileRecord(chrootDir, fpath, fi)
+		err = m.createFileRecord(chrootDir, fpath, "", fi)
 		if err != nil {
 			if strings.Contains(err.Error(), "hash calculation error") {
 				return err

--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -73,7 +73,7 @@ func initBundles(ui UpdateInfo, c config) ([]*Manifest, error) {
 			// by reading the files directly from the full chroot.
 			// No bundle-info file exists for full.
 			chroot := filepath.Join(c.imageBase, fmt.Sprint(ui.version), "full")
-			err = bundle.addFilesFromChroot(chroot)
+			err = bundle.addFilesFromChroot(chroot, "")
 		} else {
 			biPath := filepath.Join(c.imageBase, fmt.Sprint(ui.version), bundle.Name+"-info")
 			useBundleInfo := true

--- a/swupd/filesystem_test.go
+++ b/swupd/filesystem_test.go
@@ -28,7 +28,7 @@ func TestCreateFileFromPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = m.createFileRecord("", path, fi)
+	err = m.createFileRecord("", path, "", fi)
 	if err != nil {
 		t.Error(err)
 	}
@@ -44,7 +44,7 @@ func TestCreateFileFromPath(t *testing.T) {
 func TestAddFilesFromChroot(t *testing.T) {
 	rootPath := "testdata/testbundle"
 	m := Manifest{}
-	if err := m.addFilesFromChroot(rootPath); err != nil {
+	if err := m.addFilesFromChroot(rootPath, ""); err != nil {
 		t.Error(err)
 	}
 
@@ -56,7 +56,7 @@ func TestAddFilesFromChroot(t *testing.T) {
 func TestAddFilesFromChrootNotExist(t *testing.T) {
 	rootPath := "testdata/nowhere"
 	m := Manifest{}
-	if err := m.addFilesFromChroot(rootPath); err == nil {
+	if err := m.addFilesFromChroot(rootPath, ""); err == nil {
 		t.Errorf("addFilesFromChroot did not fail on missing root")
 	}
 }

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -882,6 +882,8 @@ func writeIndexManifest(c *config, ui *UpdateInfo, bundles []*Manifest) (*Manife
 		newFull.Files = append(newFull.Files, idxF)
 	}
 
+	// done processing, sort by version before writing
+	idxMan.sortFilesVersionName()
 	manOutput := filepath.Join(c.outputDir, fmt.Sprint(ui.version), "Manifest."+indexBundle)
 	if err := idxMan.WriteManifestFile(manOutput); err != nil {
 		return nil, err


### PR DESCRIPTION
Add bundle information files under /usr/share/clear/allbundles to allow
clients to perform future bundle-info operations. Write with 'pretty'
indented JSON so it is grep-able and human-readable in the mean-time.
Users will have to install the os-core-update-index bundle to get this
functionality.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>