### PR TITLE
mixin: Enable new config for all executions

### DIFF
--- a/mixin/helpers.go
+++ b/mixin/helpers.go
@@ -104,7 +104,6 @@ func setUpMixDir(upstreamVer, mixVer int) error {
 	if err != nil {
 		return err
 	}
-	config.UseNewConfig = true
 	var c config.MixConfig
 	c.LoadDefaultsForPath(true, "/usr/share/mix")
 	c.Swupd.Bundle = "os-core"

--- a/mixin/root_cmd.go
+++ b/mixin/root_cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/clearlinux/mixer-tools/config"
 	"github.com/spf13/cobra"
 )
 
@@ -35,6 +36,7 @@ var RootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	config.UseNewConfig = true
 	if err := RootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
This patch fixes a bug where new config option was not enabled when
reading the config file. Instead of enabling it for every place config
is used, new config is now always enabled when the program executed.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>