### PR TITLE
mixin: add --bundle flag for optional bundle name

### DIFF
--- a/docs/mixin.1
+++ b/docs/mixin.1
@@ -61,7 +61,7 @@ Print help text for any \fBmixin\fP subcommand.
 .UNINDENT
 .UNINDENT
 .sp
-\fBpackage add <package\-name> [\-\-build]\fP
+\fBpackage add <package\-name> [\-\-build] [\-\-bundle <name>]\fP
 .INDENT 0.0
 .INDENT 3.5
 Add RPM packages from remote or local repositories for use by mixer\-swupd
@@ -71,6 +71,9 @@ a custom bundle named after the repo from which the package originated.
 .sp
 Adding the optional \fI\-\-build\fP flag will run \fBmixin build\fP after adding the
 package.
+.sp
+Adding the option \fI\-\-bundle <name>\fP flag will add the package to \fIname\fP
+instead of the repo name.
 .UNINDENT
 .UNINDENT
 .sp

--- a/docs/mixin.1.rst
+++ b/docs/mixin.1.rst
@@ -42,7 +42,7 @@ SUBCOMMANDS
 
     Print help text for any ``mixin`` subcommand.
 
-``package add <package-name> [--build]``
+``package add <package-name> [--build] [--bundle <name>]``
 
     Add RPM packages from remote or local repositories for use by mixer-swupd
     integration. This command performs a check to see if the added package
@@ -51,6 +51,9 @@ SUBCOMMANDS
 
     Adding the optional `--build` flag will run ``mixin build`` after adding the
     package.
+
+    Adding the option `--bundle <name>` flag will add the package to `name`
+    instead of the repo name.
 
 ``repo``
 


### PR DESCRIPTION
When adding a package provide an optional --bundle flag so users can set
which bundle their package is added to instead of automatically adding
it to a bundle named after the repo the package came from.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>