### PR TITLE
Fix bug for user who don't have upstreamurl file

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -172,6 +172,9 @@ func (b *Builder) buildUpstreamURL(subpath string) (string, error) {
 // joined with the passed subpath. It will trim leading and trailing whitespace
 // from the result.
 func (b *Builder) DownloadFileFromUpstreamAsString(subpath string) (string, error) {
+	if b.UpstreamURL == "" {
+		return b.Config.Swupd.Format, nil
+	}
 	url, err := b.buildUpstreamURL(subpath)
 	if err != nil {
 		return "", err

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -76,7 +76,7 @@ var RootCmd = &cobra.Command{
 		}
 
 		// If running natively, check for format missmatch and warn
-		if builder.Native {
+		if builder.Native && b.UpstreamURL != "" {
 			hostFormat, upstreamFormat, err := b.GetHostAndUpstreamFormats()
 			if err != nil {
 				fail(err)
@@ -88,6 +88,8 @@ var RootCmd = &cobra.Command{
 				fmt.Println("Warning: The host format and mix upstream format do not match.",
 					"Mixer may be incompatible with this format; running natively may fail.")
 			}
+		} else {
+			fmt.Printf("Warning: Using Format=%s from builder.conf for this build.\n", b.Config.Swupd.Format)
 		}
 
 		// For non-bump build commands, check if building across a format


### PR DESCRIPTION
This is the case for when an OSV *is upstream* and does not have a set
upstreamurl. There is nothing to download and figure out the format range
for since they set the bounds manually, so don't crash on this error unless
it is running in a container non-natively.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>