### PR TITLE
Set timeout on bsdiff delta creation

### DIFF
--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -787,9 +787,7 @@ src=%s
 // there are no file collisions in the build.
 func createOsPackagesFile(buildVersionDir string) error {
 	fullChroot := filepath.Join(buildVersionDir, "full")
-	packages, err := helpers.RunCommandOutput(
-		"rpm", "--root="+fullChroot, "-qa", "--queryformat", "%{NAME}\t%{SOURCERPM}\n",
-	)
+	packages, err := helpers.RunCommandOutput("rpm", "--root="+fullChroot, "-qa", "--queryformat", "%{NAME}\t%{SOURCERPM}\n")
 	if err != nil {
 		return err
 	}

--- a/swupd/delta.go
+++ b/swupd/delta.go
@@ -142,7 +142,13 @@ func createDelta(c *config, delta *Delta) error {
 	oldPath := filepath.Join(c.imageBase, fmt.Sprint(delta.from.Version), "full", delta.from.Name)
 	newPath := filepath.Join(c.imageBase, fmt.Sprint(delta.to.Version), "full", delta.to.Name)
 
-	if err := helpers.RunCommandSilent("bsdiff", oldPath, newPath, delta.Path); err != nil {
+	// Set timeout to 1 minute (60 seconds) for bsdiff
+	// The majority of all delta creations take significantly less than 1 minute
+	// to run, which signifies that bsdiff is working on a delta that may be very
+	// large, or very difficult to diff. In all the cases where bsdiff took
+	// multiple minutes to finish, the delta ended up not being used because it
+	// was larger than the compressed fullfile. This attempts to skip those cases.
+	if err := helpers.RunCommandTimeout(60, "bsdiff", oldPath, newPath, delta.Path); err != nil {
 		_ = os.Remove(delta.Path)
 		if exitErr, ok := errors.Cause(err).(*exec.ExitError); ok {
 			// bsdiff returns 1 that stands for "FULLDL", i.e. it decided that


### PR DESCRIPTION
Set timeout to 1 minute for bsdiff. The majority of all delta creations
take significantly less than 1 minute to run, which signifies that bsdiff
is working on a delta that may be very large, or very difficult to diff. In
all the cases where bsdiff took multiple minutes to finish, the delta ended
up not being used because it was larger than the compressed fullfile. This
attempts to skip those cases and improve delta creation time.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>