### PR TITLE
Format Bump general fixes

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -60,9 +60,6 @@ var Offline = false
 type Builder struct {
 	Config config.MixConfig
 
-	BuildScript string
-	BuildConf   string
-
 	MixVer            string
 	MixVerFile        string
 	MixBundlesFile    string
@@ -91,7 +88,6 @@ var upstreamPackages = make(map[string]bool)
 // default values.
 func New() *Builder {
 	return &Builder{
-		BuildScript:       "bundle-chroot-builder.py",
 		UpstreamURLFile:   "upstreamurl",
 		UpstreamVerFile:   "upstreamversion",
 		MixBundlesFile:    "mixbundles",

--- a/builder/docker.go
+++ b/builder/docker.go
@@ -143,6 +143,11 @@ func (b *Builder) getDockerMounts() ([]string, error) {
 	rc := reflect.ValueOf(b.Config)
 
 	for i := 0; i < rc.NumField(); i++ {
+		/* ignore unexported fields */
+		if !rc.Field(i).CanSet() {
+			continue
+		}
+
 		err := addConfigFieldPaths(rc.Field(i), &mounts)
 		if err != nil {
 			return nil, err

--- a/builder/format.go
+++ b/builder/format.go
@@ -33,7 +33,7 @@ func (b *Builder) UpdateFormatVersion(version string) error {
 	b.Config.Swupd.Format = version
 
 	if config.UseNewConfig {
-		return b.Config.SetProperty("Swupd.FORMAT", version)
+		return b.Config.SaveConfig()
 	}
 
 	builderData, err := ioutil.ReadFile(b.BuildConf)

--- a/builder/format.go
+++ b/builder/format.go
@@ -36,7 +36,7 @@ func (b *Builder) UpdateFormatVersion(version string) error {
 		return b.Config.SaveConfig()
 	}
 
-	builderData, err := ioutil.ReadFile(b.BuildConf)
+	builderData, err := ioutil.ReadFile(b.Config.GetConfigFileName())
 	if err != nil {
 		return errors.Wrap(err, "Failed to read builder.conf")
 	}
@@ -45,7 +45,7 @@ func (b *Builder) UpdateFormatVersion(version string) error {
 	newver := []byte("${1}" + b.Config.Swupd.Format)
 	builderData = re.ReplaceAll(builderData, newver)
 
-	if err = ioutil.WriteFile(b.BuildConf, builderData, 0644); err != nil {
+	if err = ioutil.WriteFile(b.Config.GetConfigFileName(), builderData, 0644); err != nil {
 		return errors.Wrap(err, "Failed to write new builder.conf")
 	}
 

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -191,8 +191,6 @@ var buildFormatBumpCmd = &cobra.Command{
 	},
 }
 
-// buildOldFormatCmd is used to build the final version in the current format (the +10)
-// and ready the mix state for the new (+20) version to be built by a (possibly) newer mixer
 var buildFormatNewCmd = &cobra.Command{
 	Use:   "new",
 	Short: "Build the +20 version in the new format for the format bump",

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -285,6 +285,10 @@ var buildFormatNewCmd = &cobra.Command{
 		if err = b.UpdateMixVer(prevVersion); err != nil {
 			fail(err)
 		}
+		// Since we build +10 out of order, restore LAST_VER to the previous version
+		if err := ioutil.WriteFile(filepath.Join(b.Config.Builder.ServerStateDir, "image/LAST_VER"), []byte(strconv.Itoa(ver-20)), 0644); err != nil {
+			fail(err)
+		}
 	},
 }
 

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -319,6 +319,15 @@ var buildFormatOldCmd = &cobra.Command{
 		if err := ioutil.WriteFile(filepath.Join(b.Config.Builder.ServerStateDir, "image/LAST_VER"), []byte(strconv.Itoa(ver+10)), 0644); err != nil {
 			fail(err)
 		}
+		// Restore the new format in builder.conf
+		newFormat, err := strconv.Atoi(b.Config.Swupd.Format)
+		if err != nil {
+			fail(err)
+		}
+		newFormat++
+		if err = b.UpdateFormatVersion(strconv.Itoa(newFormat)); err != nil {
+			fail(err)
+		}
 	},
 }
 

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -156,6 +156,8 @@ var buildUpstreamFormatCmd = &cobra.Command{
 			if err = b.UnstageMixFromBump(); err != nil {
 				fail(err)
 			}
+			b.UpstreamVerUint32 += 10
+			b.UpstreamVer = strconv.FormatUint(uint64(b.UpstreamVerUint32), 10)
 			bumpNeeded, err = b.CheckBumpNeeded(silent)
 			if err != nil {
 				fail(err)


### PR DESCRIPTION
This patch address a bunch of different issues I stumbled upon while trying to test the new format bump feature. This patch makes the feature functional again since it is broken on master.

The first two patches are just minor cleanups. The last 5 fix 5 different crashes.