### PR TITLE
swupd: remove old file heuristics

### DIFF
--- a/swupd/heuristics.go
+++ b/swupd/heuristics.go
@@ -58,34 +58,12 @@ func (f *File) setStateFromPathname() {
 
 	// TODO: make this list configurable
 	// these are paths that are not shipped directories
-	extraStatePaths := []string{
+	stateDirs := []string{
 		"/usr/src/",
-	}
-
-	// TODO: make this list configurable
-	// these are commonly added directories for user customization
-	// ideally this never triggers if package builds are clean
-	otherStatePaths := []string{
-		"/acct",
-		"/cache",
-		"/data",
 		"/lost+found",
-		"/mnt/asec",
-		"/mnt/obb",
-		"/mnt/shell/emulated",
-		"/mnt/swupd",
-		"/oem",
-		"/system/rt/audio",
-		"/system/rt/gfx",
-		"/system/rt/media",
-		"/system/rt/wifi",
-		"/system/etc/firmware/virtual",
 	}
 
-	// these are treated the same, they are only kept apart for bookkeeping
-	finalStatePaths := append(otherStatePaths, extraStatePaths...)
-
-	for _, path := range finalStatePaths {
+	for _, path := range stateDirs {
 		if strings.HasPrefix(f.Name, path) {
 			f.Modifier = ModifierState
 			return
@@ -99,8 +77,6 @@ func (f *File) setBootFromPathname() {
 		"/boot/",
 		"/usr/lib/modules/",
 		"/usr/lib/kernel/",
-		"/usr/lib/gummiboot",
-		"/usr/bin/gummiboot",
 	}
 
 	for _, path := range bootPaths {

--- a/swupd/heuristics_test.go
+++ b/swupd/heuristics_test.go
@@ -63,13 +63,8 @@ func TestSetStateFromPathname(t *testing.T) {
 		file     File
 		expected ModifierFlag
 	}{
-		{File{Name: "/acct/a"}, ModifierState},
-		{File{Name: "/cache/a"}, ModifierState},
-		{File{Name: "/data/a"}, ModifierState},
 		{File{Name: "/lost+found/a"}, ModifierState},
-		{File{Name: "/mnt/asec/a"}, ModifierState},
 		{File{Name: "/a"}, ModifierUnset},
-		{File{Name: "/acct"}, ModifierState},
 		{File{Name: "/other"}, ModifierUnset},
 		{File{Name: "/usr/src/foo"}, ModifierState},
 	}
@@ -93,9 +88,6 @@ func TestSetBootFromPathname(t *testing.T) {
 		{File{Name: "/boot/EFI"}, ModifierBoot},
 		{File{Name: "/usr/lib/modules/module"}, ModifierBoot},
 		{File{Name: "/usr/lib/kernel/file"}, ModifierBoot},
-		{File{Name: "/usr/lib/gummiboot/foo"}, ModifierBoot},
-		{File{Name: "/usr/bin/gummiboot/bar"}, ModifierBoot},
-		{File{Name: "/usr/gummiboot/bar"}, ModifierUnset},
 		{File{Name: "/usr/kernel/bar"}, ModifierUnset},
 	}
 
@@ -119,7 +111,6 @@ func TestSetModifierFromPathname(t *testing.T) {
 		{File{Name: "/usr/src/debug"}, ModifierUnset},
 		{File{Name: "/dev/foo"}, ModifierState},
 		{File{Name: "/usr/src/file"}, ModifierState},
-		{File{Name: "/acct/file"}, ModifierState},
 		{File{Name: "/boot/EFI"}, ModifierBoot},
 		{File{Name: "/randomfile"}, ModifierUnset},
 	}
@@ -141,7 +132,6 @@ func TestApplyHeuristics(t *testing.T) {
 		"/usr/src/debug": ModifierUnset,
 		"/dev/foo":       ModifierState,
 		"/usr/src/file":  ModifierState,
-		"/acct/file":     ModifierState,
 		"/boot/EFI":      ModifierBoot,
 		"/randomfile":    ModifierUnset,
 	}


### PR DESCRIPTION
Remove unused heuristics intended to set flags on manifest file records.

Fixes #345

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>