### PR TITLE
build: add skip-fullfiles and skip-packs option

### DIFF
--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -32,12 +32,14 @@ import (
 )
 
 type buildCmdFlags struct {
-	format     string
-	increment  bool
-	minVersion int
-	noSigning  bool
-	noPublish  bool
-	template   string
+	format        string
+	increment     bool
+	minVersion    int
+	noSigning     bool
+	noPublish     bool
+	template      string
+	skipFullfiles bool
+	skipPacks     bool
 
 	numFullfileWorkers int
 	numDeltaWorkers    int
@@ -245,10 +247,12 @@ var buildFormatNewCmd = &cobra.Command{
 
 		// Build the +20 update so we don't have to switch tooling in between
 		params := builder.UpdateParameters{
-			MinVersion:  ver,
-			Format:      strconv.Itoa(newFormat),
-			Publish:     !buildFlags.noPublish,
-			SkipSigning: buildFlags.noSigning,
+			MinVersion:    ver,
+			Format:        strconv.Itoa(newFormat),
+			Publish:       !buildFlags.noPublish,
+			SkipSigning:   buildFlags.noSigning,
+			SkipFullfiles: buildFlags.skipFullfiles,
+			SkipPacks:     buildFlags.skipPacks,
 		}
 		err = b.BuildUpdate(params)
 		if err != nil {
@@ -308,10 +312,12 @@ var buildFormatOldCmd = &cobra.Command{
 		}
 		// Build the update content for the +10 build
 		params := builder.UpdateParameters{
-			MinVersion:  ver,
-			Format:      b.Config.Swupd.Format,
-			Publish:     !buildFlags.noPublish,
-			SkipSigning: buildFlags.noSigning,
+			MinVersion:    ver,
+			Format:        b.Config.Swupd.Format,
+			Publish:       !buildFlags.noPublish,
+			SkipSigning:   buildFlags.noSigning,
+			SkipFullfiles: buildFlags.skipFullfiles,
+			SkipPacks:     buildFlags.skipPacks,
 		}
 		err = b.BuildUpdate(params)
 		if err != nil {
@@ -339,10 +345,12 @@ var buildUpdateCmd = &cobra.Command{
 		}
 		setWorkers(b)
 		params := builder.UpdateParameters{
-			MinVersion:  buildFlags.minVersion,
-			Format:      buildFlags.format,
-			Publish:     !buildFlags.noPublish,
-			SkipSigning: buildFlags.noSigning,
+			MinVersion:    buildFlags.minVersion,
+			Format:        buildFlags.format,
+			Publish:       !buildFlags.noPublish,
+			SkipSigning:   buildFlags.noSigning,
+			SkipFullfiles: buildFlags.skipFullfiles,
+			SkipPacks:     buildFlags.skipPacks,
 		}
 		err = b.BuildUpdate(params)
 		if err != nil {
@@ -383,10 +391,12 @@ var buildAllCmd = &cobra.Command{
 			failf("Couldn't build bundles: %s", err)
 		}
 		params := builder.UpdateParameters{
-			MinVersion:  buildFlags.minVersion,
-			Format:      buildFlags.format,
-			Publish:     !buildFlags.noPublish,
-			SkipSigning: buildFlags.noSigning,
+			MinVersion:    buildFlags.minVersion,
+			Format:        buildFlags.format,
+			Publish:       !buildFlags.noPublish,
+			SkipSigning:   buildFlags.noSigning,
+			SkipFullfiles: buildFlags.skipFullfiles,
+			SkipPacks:     buildFlags.skipPacks,
 		}
 		err = b.BuildUpdate(params)
 		if err != nil {
@@ -484,6 +494,9 @@ func setUpdateFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&buildFlags.minVersion, "min-version", 0, "Supply minversion to build update with")
 	cmd.Flags().BoolVar(&buildFlags.noSigning, "no-signing", false, "Do not generate a certificate and do not sign the Manifest.MoM")
 	cmd.Flags().BoolVar(&buildFlags.noPublish, "no-publish", false, "Do not update the latest version after update")
+	cmd.Flags().BoolVar(&buildFlags.skipFullfiles, "skip-fullfiles", false, "Do not generate fullfiles")
+	cmd.Flags().BoolVar(&buildFlags.skipPacks, "skip-packs", false, "Do not generate zero packs")
+
 	var unusedStringFlag string
 	cmd.Flags().StringVar(&unusedStringFlag, "prefix", "", "Supply prefix for where the swupd binaries live")
 	_ = cmd.Flags().MarkHidden("prefix")

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -36,9 +36,7 @@ type buildCmdFlags struct {
 	increment  bool
 	minVersion int
 	noSigning  bool
-	prefix     string
 	noPublish  bool
-	keepChroot bool
 	template   string
 
 	numFullfileWorkers int
@@ -485,9 +483,15 @@ func setUpdateFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&buildFlags.increment, "increment", false, "Automatically increment the mixversion post build")
 	cmd.Flags().IntVar(&buildFlags.minVersion, "min-version", 0, "Supply minversion to build update with")
 	cmd.Flags().BoolVar(&buildFlags.noSigning, "no-signing", false, "Do not generate a certificate and do not sign the Manifest.MoM")
-	cmd.Flags().StringVar(&buildFlags.prefix, "prefix", "", "Supply prefix for where the swupd binaries live")
 	cmd.Flags().BoolVar(&buildFlags.noPublish, "no-publish", false, "Do not update the latest version after update")
-	cmd.Flags().BoolVar(&buildFlags.keepChroot, "keep-chroots", false, "Keep individual chroots created and not just consolidated 'full'")
+	var unusedStringFlag string
+	cmd.Flags().StringVar(&unusedStringFlag, "prefix", "", "Supply prefix for where the swupd binaries live")
+	_ = cmd.Flags().MarkHidden("prefix")
+	_ = cmd.Flags().MarkDeprecated("prefix", "This flag is ignored by the update builder")
+	var unusedBoolFlag bool
+	cmd.Flags().BoolVar(&unusedBoolFlag, "keep-chroots", false, "Keep individual chroots created and not just consolidated 'full'")
+	_ = cmd.Flags().MarkHidden("keep-chroots")
+	_ = cmd.Flags().MarkDeprecated("keep-chroots", "This flag is ignored by the update builder")
 }
 
 var buildCmds = []*cobra.Command{

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -246,7 +246,13 @@ var buildFormatNewCmd = &cobra.Command{
 		}
 
 		// Build the +20 update so we don't have to switch tooling in between
-		err = b.BuildUpdate(buildFlags.prefix, ver, strconv.Itoa(newFormat), buildFlags.noSigning, !buildFlags.noPublish, buildFlags.keepChroot)
+		params := builder.UpdateParameters{
+			MinVersion:  ver,
+			Format:      strconv.Itoa(newFormat),
+			Publish:     !buildFlags.noPublish,
+			SkipSigning: buildFlags.noSigning,
+		}
+		err = b.BuildUpdate(params)
 		if err != nil {
 			failf("Couldn't build update: %s", err)
 		}
@@ -303,7 +309,13 @@ var buildFormatOldCmd = &cobra.Command{
 			fail(err)
 		}
 		// Build the update content for the +10 build
-		err = b.BuildUpdate(buildFlags.prefix, ver, b.Config.Swupd.Format, buildFlags.noSigning, !buildFlags.noPublish, buildFlags.keepChroot)
+		params := builder.UpdateParameters{
+			MinVersion:  ver,
+			Format:      b.Config.Swupd.Format,
+			Publish:     !buildFlags.noPublish,
+			SkipSigning: buildFlags.noSigning,
+		}
+		err = b.BuildUpdate(params)
 		if err != nil {
 			failf("Couldn't build update: %s", err)
 		}
@@ -328,7 +340,13 @@ var buildUpdateCmd = &cobra.Command{
 			fail(err)
 		}
 		setWorkers(b)
-		err = b.BuildUpdate(buildFlags.prefix, buildFlags.minVersion, buildFlags.format, buildFlags.noSigning, !buildFlags.noPublish, buildFlags.keepChroot)
+		params := builder.UpdateParameters{
+			MinVersion:  buildFlags.minVersion,
+			Format:      buildFlags.format,
+			Publish:     !buildFlags.noPublish,
+			SkipSigning: buildFlags.noSigning,
+		}
+		err = b.BuildUpdate(params)
 		if err != nil {
 			failf("Couldn't build update: %s", err)
 		}
@@ -366,7 +384,13 @@ var buildAllCmd = &cobra.Command{
 		if err != nil {
 			failf("Couldn't build bundles: %s", err)
 		}
-		err = b.BuildUpdate(buildFlags.prefix, buildFlags.minVersion, buildFlags.format, buildFlags.noSigning, !buildFlags.noPublish, buildFlags.keepChroot)
+		params := builder.UpdateParameters{
+			MinVersion:  buildFlags.minVersion,
+			Format:      buildFlags.format,
+			Publish:     !buildFlags.noPublish,
+			SkipSigning: buildFlags.noSigning,
+		}
+		err = b.BuildUpdate(params)
 		if err != nil {
 			failf("Couldn't build update: %s", err)
 		}

--- a/mixin/build.go
+++ b/mixin/build.go
@@ -161,7 +161,7 @@ func buildMix(prepNeeded bool) error {
 		_ = os.Remove(mixFlagFile)
 		return err
 	}
-	err = b.BuildUpdate("", 0, "", false, true, false)
+	err = b.BuildUpdate(builder.UpdateParameters{Publish: true})
 	if err != nil {
 		_ = os.Remove(mixFlagFile)
 		return err


### PR DESCRIPTION
This patch adds the --skip-fullfiles options for the 'build' subcommand
of mixer. This command will prevent fullfiles from being generated
during 'build update'. Likewise, the --skip-packs option prevents zero
packs form being generated.

This PR addresses issue #352 