### PR TITLE
battest: Add test for format bump

### DIFF
--- a/bat/lib/mixerlib.bash
+++ b/bat/lib/mixerlib.bash
@@ -36,12 +36,28 @@ mixer-versions-update() {
   mixer $MIXARGS versions update --mix-version $1
 }
 
+mixer-upstream-update() {
+  mixer $MIXARGS versions update --upstream-version $1
+}
+
 mixer-build-bundles() {
   sudo -E mixer $MIXARGS build bundles --config $BATS_TEST_DIRNAME/builder.conf
 }
 
 mixer-build-update() {
   sudo -E mixer $MIXARGS build update --config $BATS_TEST_DIRNAME/builder.conf
+}
+
+mixer-build-all() {
+  sudo -E mixer $MIXARGS build all --config $BATS_TEST_DIRNAME/builder.conf
+}
+
+mixer-build-format-bump-new() {
+  sudo -E mixer $MIXARGS build format-bump new --native
+}
+
+mixer-build-format-bump-old() {
+  sudo -E mixer $MIXARGS build format-bump old --native
 }
 
 mixer-add-rpms() {
@@ -74,6 +90,14 @@ download-rpm() {
   pushd $BATS_TEST_DIRNAME/local-rpms
   curl -LO $1
   popd
+}
+
+get-last-format-boundary() {
+  latest=$(curl https://download.clearlinux.org/latest)
+  format=$(curl https://download.clearlinux.org/update/$latest/format)
+  first=$(curl https://download.clearlinux.org/update/version/format$format/first)
+
+  echo $(($first-10))
 }
 
 # vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/bat/tests/06-test-format-bump/run.bats
+++ b/bat/tests/06-test-format-bump/run.bats
@@ -1,14 +1,48 @@
 #!/usr/bin/env bats
 
 # shared test functions
-#load ../../lib/mixerlib
+load ../../lib/mixerlib
 
-#setup() {
-#  global_setup
-#}
+setup() {
+  global_setup
+}
 
-# TODO: fill out once auto format bump implemented
-#@test "Create initial mix 10" {
-#}
+# TODO: This test should run 'mixer build upstream-format' instead
+# once the tooling required to run custom test docker images for
+# is ready.
+@test "Perform upstream format bump on last format boundary" {
+  upstreamver=$(get-last-format-boundary)
+  mixer-init-stripped-down $upstreamver 10
+
+  #Create initial version in the old format
+  mixer-build-all > $LOGDIR/build_all.log
+
+  #Update to new upstream in the new format
+  mixer-upstream-update $(($upstreamver + 10)) > $LOGDIR/upstream_update.log
+
+  #Build +20
+  mixer-build-format-bump-new > $LOGDIR/build_formatbump_new.log
+
+  #Reset upstream for +10 build
+  echo -n "$upstreamver" > upstreamversion
+
+  #Build +10
+  mixer-build-format-bump-old > $LOGDIR/build_formatbump_old.log
+
+  #restore upstrean
+  mv upstreamversion.bump upstreamversion
+
+  #check if LAST_VER is set to +20
+  test $(< update/image/LAST_VER) -eq 30
+
+  #check if +20 previous version is set to +0
+  awk '$1 == "previous:" { exit $2 != 10}' update/www/30/Manifest.MoM
+
+  #check if +10 previous version is set to +0
+  awk '$1 == "previous:" { exit $2 != 10}' update/www/30/Manifest.MoM
+
+  #check if builder.conf has the +20 format
+  test $(sed -n 's/[ ]*FORMAT[ ="]*\([0-9]\+\)[ "]*/\1/p' builder.conf) -eq 2
+}
 
 # vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
This patch adds temporary tests for the format bump feature. A permanent
test will require the generation of custom docker images with an updated
build of mixer. Until this tooling is available, this test provides a
minimum integrity check on the feature.

The added test checks the operation of a format bump on a real format
boundary. In addition, it checks the integrity of 4 key values:
- image/LasT_VER should point to the +20 version
- Previous version in +20 MoM should point to +0
- Previous version in +10 MoM should point to +0
- FORMAT property in builder.conf should have the +20 format

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>