### PR TITLE
Remove source RPMs before creating the repo

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -1838,6 +1838,13 @@ func (b *Builder) AddRPMList(rpms []string) error {
 		if _, err := os.Stat(repoPath); err == nil {
 			continue
 		}
+		// Remove source RPMs because they should not be added to mixes
+		if strings.HasSuffix(rpm, ".src.rpm") {
+			fmt.Printf("Removing %s because source RPMs are not supported in mixes.\n", rpm)
+			if err := os.RemoveAll(filepath.Join(b.Config.Mixer.LocalRPMDir, rpm)); err != nil {
+				return errors.Wrapf(err, "Failed to remove %s, your mix will not generate properly with source RPMs included.", rpm)
+			}
+		}
 		fmt.Printf("Hardlinking %s to repodir\n", rpm)
 		if err := os.Link(localPath, repoPath); err != nil {
 			// Fallback to copying the file if hardlink fails.


### PR DESCRIPTION
Mixer will not work with source RPMs added and crash looking for files
that will not actually be provided. This patch removes them as it parses
the RPM list so only valid, usable RPMs get added to the repo.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>