### PR TITLE
swupd: read *-extra-files from persistent location

### DIFF
--- a/swupd/bundleinfo.go
+++ b/swupd/bundleinfo.go
@@ -32,7 +32,7 @@ type bundleInfo struct {
 	Files          map[string]bool
 }
 
-func (m *Manifest) getBundleInfo(path string) error {
+func (m *Manifest) getBundleInfo(c config, path string) error {
 	var err error
 	if _, err = os.Stat(path); os.IsNotExist(err) {
 		basePath := filepath.Dir(path)
@@ -65,7 +65,7 @@ func (m *Manifest) getBundleInfo(path string) error {
 		return err
 	}
 
-	extraFilesPath := filepath.Join(filepath.Dir(path), m.Name+"-extra-files")
+	extraFilesPath := filepath.Join(c.stateDir, m.Name+"-extra-files")
 	if _, err = os.Stat(extraFilesPath); err == nil {
 		extraFilesBytes, err := ioutil.ReadFile(extraFilesPath)
 		if err != nil {

--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -84,7 +84,7 @@ func initBundles(ui UpdateInfo, c config) ([]*Manifest, error) {
 				useBundleInfo = false
 			}
 
-			err = bundle.getBundleInfo(biPath)
+			err = bundle.getBundleInfo(c, biPath)
 			if err != nil {
 				return nil, err
 			}

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -504,7 +504,7 @@ func (fs *testFileSystem) addDir(version uint32, bundle, dir string) {
 
 func (fs *testFileSystem) addExtraFile(version uint32, bundle, file, content string) {
 	fs.t.Helper()
-	path := filepath.Join(fs.Dir, "image", fmt.Sprint(version), bundle+"-extra-files")
+	path := filepath.Join(fs.Dir, bundle+"-extra-files")
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
 		fs.t.Fatal(err)


### PR DESCRIPTION
Instead of reading the bundle-extra-files configuration file from the
bundle directory under /image/<ver> (which does not exist until mixer
build bundles is run) read from the persistent mixer workspace. This
means users no longer have to copy these files into place after building
bundles.

Fixes #241 

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>