### PR TITLE
swupd: make slim packs across minversions

### DIFF
--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -887,6 +887,31 @@ func writeIndexManifest(c *config, ui *UpdateInfo, bundles []*Manifest) (*Manife
 	return idxMan, nil
 }
 
+func fileContentInManifest(f *File, m *Manifest) bool {
+	if m == nil {
+		return false
+	}
+	for i := range m.Files {
+		if f.Name != m.Files[i].Name {
+			continue
+		}
+		if f.Hash != m.Files[i].Hash {
+			continue
+		}
+		if f.Type != m.Files[i].Type {
+			continue
+		}
+		if f.Status != m.Files[i].Status {
+			continue
+		}
+		if f.Modifier != m.Files[i].Modifier {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 // this is a hack to allow users to update using swupd-client v3.15.3 which performs a
 // check on contentsize with a maximum a couple of orders off the intended maximum.
 // Remove this code (and the caller) when a format bump has occurred in Clear.

--- a/swupd/packs.go
+++ b/swupd/packs.go
@@ -238,7 +238,7 @@ func WritePack(w io.Writer, fromManifest, toManifest *Manifest, outputDir, chroo
 		entry := &info.Entries[i]
 		entry.File = f
 
-		if f.Version <= fromVersion {
+		if f.Version <= fromVersion || fileContentInManifest(f, fromManifest) {
 			entry.Reason = "already in from manifest"
 			continue
 		}


### PR DESCRIPTION
Add an additional fileContentInManifest check to pack creation to
exclude full files that are represented in the from manifest even if the
version changed in the to manifest. This allows mixer to exclude
unchanged files from delta packs over minversion bumps.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>

Before patch, delta packs over a min-version bump (only three files changed):
```
Using 12 workers
=> CREATE DELTA PACKS
Creating delta packs from 10 to 20
  Creating delta pack for bundle "bootloader" from 10 to 20
  Creating delta pack for bundle "os-core" from 10 to 20
  Creating delta pack for bundle "os-core-update-index" from 10 to 20
  Creating delta pack for bundle "os-core-update" from 10 to 20
  Creating delta pack for bundle "kernel-native" from 10 to 20
    Fullfiles in pack: 7
    Deltas in pack: 0
    Fullfiles in pack: 35
    Deltas in pack: 0
    Fullfiles in pack: 475
    Deltas in pack: 0
    Fullfiles in pack: 2552
    Deltas in pack: 1
    Fullfiles in pack: 2520
    Deltas in pack: 0

TIMINGS
  CREATE DELTA PACKS 12.498s
TOTAL: 12.498s
```

After patch, delta packs over a min-version bump, only three files changed:
```
Using 12 workers
=> CREATE DELTA PACKS
Creating delta packs from 10 to 20
  Creating delta pack for bundle "bootloader" from 10 to 20
  Creating delta pack for bundle "kernel-native" from 10 to 20
  Creating delta pack for bundle "os-core" from 10 to 20
  Creating delta pack for bundle "os-core-update-index" from 10 to 20
  Creating delta pack for bundle "os-core-update" from 10 to 20
    Fullfiles in pack: 0
    Deltas in pack: 0
    Fullfiles in pack: 0
    Deltas in pack: 0
    Fullfiles in pack: 0
    Deltas in pack: 0
    Fullfiles in pack: 0
    Deltas in pack: 0
    Fullfiles in pack: 2
    Deltas in pack: 1

TIMINGS
  CREATE DELTA PACKS 16ms
TOTAL: 16ms
```