### PR TITLE
Notify user about bundle changes after format bump

### DIFF
--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -163,6 +163,8 @@ var buildUpstreamFormatCmd = &cobra.Command{
 				fail(err)
 			}
 		}
+		fmt.Println(`NOTE: upstream bundle definitions may have changed,
+please review any upstream bundles included in your mix.`)
 	},
 }
 
@@ -232,8 +234,6 @@ var buildFormatNewCmd = &cobra.Command{
 		if err = b.CopyFullGroupsINI(); err != nil {
 			fail(err)
 		}
-		// Fill this in w/Update bundle definitions
-		// if err := UpdateBudlesForFormatBump(); err != nil {...}
 
 		// Build the +20 (first build in new format) bundles
 		if err = buildBundles(b, buildFlags.noSigning); err != nil {


### PR DESCRIPTION
During a format bump, the upstream version for a mix is updated, which may
introduce changes to the upstream bundles. Any changes to included (and
un-edited) bundles will be propagated to the mix, so warn the user to take
changes into consideration.
Local bundle definitions will override upstream ones, so even if upstream
bundles change, they will not change the locally defined versions for a mix.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>