### PR TITLE
Use New Config as Default

### DIFF
--- a/bat/lib/mixerlib.bash
+++ b/bat/lib/mixerlib.bash
@@ -15,8 +15,8 @@ global_setup() {
 }
 
 localize_builder_conf() {
-  if $(mixer $MIXARGS config set Mixer.LOCAL_RPM_DIR $BATS_TEST_DIRNAME/local-rpms --new-config); then
-    mixer $MIXARGS config set  Mixer.LOCAL_REPO_DIR $BATS_TEST_DIRNAME/local-yum --new-config
+  if $(mixer $MIXARGS config set Mixer.LOCAL_RPM_DIR $BATS_TEST_DIRNAME/local-rpms); then
+    mixer $MIXARGS config set  Mixer.LOCAL_REPO_DIR $BATS_TEST_DIRNAME/local-yum
   else
     echo -e "LOCAL_RPM_DIR=$BATS_TEST_DIRNAME/local-rpms\nLOCAL_REPO_DIR=$BATS_TEST_DIRNAME/local-yum" >> $BATS_TEST_DIRNAME/builder.conf
   fi

--- a/bat/tests/01-bundle-commands/Makefile
+++ b/bat/tests/01-bundle-commands/Makefile
@@ -4,6 +4,6 @@ check:
 	bats ./run.bats
 
 CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
-CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
 clean:
 	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/02-create-mix-with-upstream-bundles/Makefile
+++ b/bat/tests/02-create-mix-with-upstream-bundles/Makefile
@@ -4,6 +4,6 @@ check:
 	bats ./run.bats
 
 CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
-CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
 clean:
 	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/03-create-mix-bump-version-add-remove-bundles/Makefile
+++ b/bat/tests/03-create-mix-bump-version-add-remove-bundles/Makefile
@@ -4,6 +4,6 @@ check:
 	bats ./run.bats
 
 CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
-CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
 clean:
 	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/04-create-mix-with-custom-content/Makefile
+++ b/bat/tests/04-create-mix-with-custom-content/Makefile
@@ -4,6 +4,6 @@ check:
 	bats ./run.bats
 
 CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
-CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
 clean:
 	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/05-create-mix-with-blended-content/Makefile
+++ b/bat/tests/05-create-mix-with-blended-content/Makefile
@@ -4,6 +4,6 @@ check:
 	bats ./run.bats
 
 CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
-CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
 clean:
 	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/06-test-format-bump/Makefile
+++ b/bat/tests/06-test-format-bump/Makefile
@@ -4,6 +4,6 @@ check:
 	bats ./run.bats
 
 CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
-CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
 clean:
 	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/06-test-format-bump/run.bats
+++ b/bat/tests/06-test-format-bump/run.bats
@@ -42,7 +42,7 @@ setup() {
   awk '$1 == "previous:" { exit $2 != 10}' update/www/30/Manifest.MoM
 
   #check if builder.conf has the +20 format
-  test $(sed -n 's/[ ]*FORMAT[ ="]*\([0-9]\+\)[ "]*/\1/p' builder.conf) -eq 2
+  test $(sed -n 's/[ ]*FORMAT[ ="]*\([0-9]\+\)[ "]*/\1/p' mixer.state) -eq 2
 }
 
 # vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -32,7 +32,7 @@ type buildBundlesConfig struct {
 	UpdateBundle string
 	ContentURL   string
 	VersionURL   string
-	// Format is already in b.Config.Swupd.Format.
+	// Format is already in b.State.Mix.Format.
 }
 
 // TODO: Move this to the more general configuration handling.
@@ -494,7 +494,7 @@ func genUpdateBundleSpecialFiles(chrootDir string, cfg *buildBundlesConfig, b *B
 		}
 	}
 
-	return ioutil.WriteFile(filepath.Join(swupdDir, "format"), []byte(b.Config.Swupd.Format), 0644)
+	return ioutil.WriteFile(filepath.Join(swupdDir, "format"), []byte(b.State.Mix.Format), 0644)
 }
 
 func installBundleToFull(packagerCmd []string, buildVersionDir string, bundle *bundle) error {

--- a/builder/format.go
+++ b/builder/format.go
@@ -19,37 +19,18 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 
-	"github.com/clearlinux/mixer-tools/config"
 	"github.com/clearlinux/mixer-tools/helpers"
 	"github.com/pkg/errors"
 )
 
 // UpdateFormatVersion updates the builder.conf file with a new format version
 func (b *Builder) UpdateFormatVersion(version string) error {
-	b.Config.Swupd.Format = version
+	b.State.Mix.Format = version
 
-	if config.UseNewConfig {
-		return b.Config.SaveConfig()
-	}
-
-	builderData, err := ioutil.ReadFile(b.Config.GetConfigFileName())
-	if err != nil {
-		return errors.Wrap(err, "Failed to read builder.conf")
-	}
-
-	var re = regexp.MustCompile(`(FORMAT=)[0-9]+`)
-	newver := []byte("${1}" + b.Config.Swupd.Format)
-	builderData = re.ReplaceAll(builderData, newver)
-
-	if err = ioutil.WriteFile(b.Config.GetConfigFileName(), builderData, 0644); err != nil {
-		return errors.Wrap(err, "Failed to write new builder.conf")
-	}
-
-	return nil
+	return b.State.Save()
 }
 
 // CopyFullGroupsINI copies the initial ini file which has ALL bundle definitions

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ import (
 
 // UseNewConfig controls whether to use the new TOML config format.
 // This is an experimental feature.
-var UseNewConfig = false
+var UseNewConfig = true
 
 // CurrentConfigVersion holds the current version of the config file
 const CurrentConfigVersion = "1.0"
@@ -302,16 +302,13 @@ func (config *MixConfig) Parse() error {
 
 	if found {
 		// Version only exists in New Config, so parse builder.conf as TOML
-		UseNewConfig = true
 		if _, err := toml.DecodeReader(reader, &config); err != nil {
 			return err
 		}
 	} else {
 		// Assume missing version and try to parse as TOML
-		UseNewConfig = true
 		if _, err := toml.DecodeFile(config.filename, &config); err != nil {
 			// Try parsing as INI
-			UseNewConfig = false
 			if err := config.legacyParse(); err != nil {
 				return err
 			}
@@ -322,9 +319,7 @@ func (config *MixConfig) Parse() error {
 }
 
 func (config *MixConfig) legacyParse() error {
-	if UseNewConfig {
-		return errors.Errorf("legacyParse is not compatible with --new-config flag")
-	}
+	UseNewConfig = false
 
 	lines, err := helpers.ReadFileAndSplit(config.filename)
 	if err != nil {

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -217,7 +217,7 @@ var buildFormatNewCmd = &cobra.Command{
 
 		// Set format to format+1 so that the format file inserted into the
 		// update content is the new one
-		newFormat, err := strconv.Atoi(b.Config.Swupd.Format)
+		newFormat, err := strconv.Atoi(b.State.Mix.Format)
 		if err != nil {
 			fail(err)
 		}
@@ -281,7 +281,7 @@ var buildFormatNewCmd = &cobra.Command{
 		}
 
 		// Set the format back to the previous format version before building the +10 update
-		prevFormat, err := strconv.Atoi(b.Config.Swupd.Format)
+		prevFormat, err := strconv.Atoi(b.State.Mix.Format)
 		if err != nil {
 			fail(err)
 		}
@@ -317,7 +317,7 @@ var buildFormatOldCmd = &cobra.Command{
 		// Build the update content for the +10 build
 		params := builder.UpdateParameters{
 			MinVersion:    ver,
-			Format:        b.Config.Swupd.Format,
+			Format:        b.State.Mix.Format,
 			Publish:       !buildFlags.noPublish,
 			SkipSigning:   buildFlags.noSigning,
 			SkipFullfiles: buildFlags.skipFullfiles,
@@ -336,7 +336,7 @@ var buildFormatOldCmd = &cobra.Command{
 			fail(err)
 		}
 		// Restore the new format in builder.conf
-		newFormat, err := strconv.Atoi(b.Config.Swupd.Format)
+		newFormat, err := strconv.Atoi(b.State.Mix.Format)
 		if err != nil {
 			fail(err)
 		}

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -216,7 +216,7 @@ func init() {
 	_ = RootCmd.Flags().MarkDeprecated("new-swupd", "new functionality is now the standard behavior, this flag is obsolete and no longer used")
 
 	// TODO: Remove this once we drop the old config format
-	RootCmd.PersistentFlags().BoolVar(&config.UseNewConfig, "new-config", false, "EXPERIMENTAL: use the new TOML config format")
+	RootCmd.PersistentFlags().BoolVar(&config.UseNewConfig, "new-config", true, "Set this property to false to use the old INI config format. Ignored for all commands but 'init'")
 
 	RootCmd.PersistentFlags().BoolVar(&builder.Native, "native", true, "Run mixer command on native host instead of in a container")
 	RootCmd.PersistentFlags().BoolVar(&builder.Offline, "offline", false, "Skip caching upstream-bundles; work entirely with local-bundles")

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -98,7 +98,7 @@ var RootCmd = &cobra.Command{
 					"Mixer may be incompatible with this format; running natively may fail.")
 			}
 		} else if networkCheck {
-			fmt.Printf("Warning: Using Format=%s from builder.conf for this build.\n", b.Config.Swupd.Format)
+			fmt.Printf("Warning: Using Format=%s from mixer.state for this build.\n", b.State.Mix.Format)
 		}
 
 		// For non-bump build commands, check if building across a format
@@ -182,6 +182,12 @@ var initCmd = &cobra.Command{
 		if err := b.Config.LoadConfig(configFile); err != nil {
 			fail(err)
 		}
+
+		b.State.LoadDefaults()
+		if err := b.State.Save(); err != nil {
+			fail(err)
+		}
+
 		err := b.InitMix(initFlags.clearVer, strconv.Itoa(initFlags.mixver), initFlags.allLocal, initFlags.allUpstream, initFlags.noDefaults, initFlags.upstreamURL, initFlags.git)
 		if err != nil {
 			fail(err)


### PR DESCRIPTION
This patchset adds a couple changes to the config system to allow the TOML config to be used as default. Among this changes are a versioning system and, auto detection of the config format.

This patch also introduces the mixer.state file. Currently it only holds the format variable, which was the last remaining transient variable in builder.conf, but the idea is to concentrate all the other temporary files (e.g. upstreamversion) under this state file.

Note: I'm adding subsections to mixer.state file and I'll update this commit before it is merged. This will also make the batcheck pass (atm It will fail when trying to validate the format).