### PR TITLE
Remove LD_PRELOAD

### DIFF
--- a/mixer/main.go
+++ b/mixer/main.go
@@ -15,16 +15,9 @@
 package main
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/clearlinux/mixer-tools/mixer/cmd"
 )
 
 func main() {
-	if err := os.Setenv("LD_PRELOAD", "/usr/lib64/nosync/nosync.so"); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to load nosync.so, mixing may take longer\n")
-	}
-
 	cmd.Execute()
 }


### PR DESCRIPTION
The new dnf release *in Clear* now does this by default, so we do not have to load
the nosync library anymore.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>