### PR TITLE
state: Better default values for FORMAT

### DIFF
--- a/bat/tests/06-test-format-bump/run.bats
+++ b/bat/tests/06-test-format-bump/run.bats
@@ -17,6 +17,9 @@ setup() {
   #Create initial version in the old format
   mixer-build-all > $LOGDIR/build_all.log
 
+  #Save initial format
+  format=$(sed -n 's/[ ]*FORMAT[ ="]*\([0-9]\+\)[ "]*/\1/p' mixer.state)
+
   #Update to new upstream in the new format
   mixer-upstream-update $(($upstreamver + 10)) > $LOGDIR/upstream_update.log
 
@@ -42,7 +45,7 @@ setup() {
   awk '$1 == "previous:" { exit $2 != 10}' update/www/30/Manifest.MoM
 
   #check if builder.conf has the +20 format
-  test $(sed -n 's/[ ]*FORMAT[ ="]*\([0-9]\+\)[ "]*/\1/p' mixer.state) -eq 2
+  test $(sed -n 's/[ ]*FORMAT[ ="]*\([0-9]\+\)[ "]*/\1/p' mixer.state) -eq $(($format + 1))
 }
 
 # vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
Instead of always using '1' as the default FORMAT value, check first if
the value was available in a legacy config. If not, try using the system
format instead. If both fail, fallback to the hardcoded value as it was
previously done.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>