### PR TITLE
swupd: persist deletes over minversions, but not format bumps

### DIFF
--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -234,7 +234,7 @@ func processBundles(ui UpdateInfo, c config) ([]*Manifest, error) {
 		}
 		changedIncludes := includesChanged(bundle, oldM)
 		oldM.sortFilesName()
-		changedFiles, added, deleted := bundle.linkPeersAndChange(oldM, c, ui.minVersion)
+		changedFiles, added, deleted := bundle.linkPeersAndChange(oldM, ui.minVersion)
 		// if nothing changed, skip
 		if changedFiles == 0 && added == 0 && deleted == 0 && !changedIncludes {
 			continue

--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -388,6 +388,30 @@ func TestCreateManifestsMVDeletes(t *testing.T) {
 	fileDeletedInManifest(t, ts.parseManifest(30, "full"), 30, "/foo")
 }
 
+func TestCreateManifestsFormatDeletes(t *testing.T) {
+	ts := newTestSwupd(t, "formatDeletes")
+	defer ts.cleanup()
+
+	ts.Bundles = []string{"test-bundle"}
+	ts.addFile(10, "test-bundle", "/foo", "foo")
+	ts.createManifests(10)
+	ts.checkContains("www/10/Manifest.test-bundle", "10\t/foo\n")
+	ts.checkContains("www/10/Manifest.full", "10\t/foo\n")
+
+	// update and remove /foo
+	ts.createManifests(20)
+	fileDeletedInManifest(t, ts.parseManifest(20, "test-bundle"), 20, "/foo")
+	fileDeletedInManifest(t, ts.parseManifest(20, "full"), 20, "/foo")
+
+	// now create a minversion and format bump
+	ts.Format = 2
+	ts.MinVersion = 30
+	ts.createManifests(30)
+
+	fileNotInManifest(t, ts.parseManifest(30, "test-bundle"), "/foo")
+	fileNotInManifest(t, ts.parseManifest(30, "full"), "/foo")
+}
+
 func TestCreateManifestsPersistDeletes(t *testing.T) {
 	ts := newTestSwupd(t, "persistDeletes")
 	defer ts.cleanup()

--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -366,6 +366,28 @@ func TestCreateManifestsMinVersion(t *testing.T) {
 	ts.checkNotContains("www/20/Manifest.full", "\t10\t")
 }
 
+func TestCreateManifestsMVDeletes(t *testing.T) {
+	ts := newTestSwupd(t, "minVersionDeletes")
+	defer ts.cleanup()
+
+	ts.Bundles = []string{"test-bundle"}
+	ts.addFile(10, "test-bundle", "/foo", "foo")
+	ts.createManifests(10)
+	ts.checkContains("www/10/Manifest.test-bundle", "10\t/foo\n")
+	ts.checkContains("www/10/Manifest.full", "10\t/foo\n")
+
+	// update and remove /foo
+	ts.createManifests(20)
+	fileDeletedInManifest(t, ts.parseManifest(20, "test-bundle"), 20, "/foo")
+	fileDeletedInManifest(t, ts.parseManifest(20, "full"), 20, "/foo")
+
+	// now create a minversion and make sure the deletes persist
+	ts.MinVersion = 30
+	ts.createManifests(30)
+	fileDeletedInManifest(t, ts.parseManifest(30, "test-bundle"), 30, "/foo")
+	fileDeletedInManifest(t, ts.parseManifest(30, "full"), 30, "/foo")
+}
+
 func TestCreateManifestsPersistDeletes(t *testing.T) {
 	ts := newTestSwupd(t, "persistDeletes")
 	defer ts.cleanup()

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -373,7 +373,7 @@ func (m *Manifest) sortFilesVersionName() {
 //
 // An important note is that deletes must persist over minversions but not over
 // format bumps.
-func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, c config, minVersion uint32) (int, int, int) {
+func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, minVersion uint32) (int, int, int) {
 	// set previous version to oldManifest version
 	m.Header.Previous = oldManifest.Header.Version
 
@@ -426,7 +426,7 @@ func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, c config, minVersio
 			// in the new manifest, it was deleted or is an old deleted/ghosted
 			// file
 			if !of.Present() {
-				if of.Status == StatusDeleted {
+				if of.Status == StatusDeleted && m.Header.Format == oldManifest.Header.Format {
 					// copy over old deleted files
 					// append as-is
 					if of.Version < minVersion {
@@ -867,7 +867,7 @@ func writeIndexManifest(c *config, ui *UpdateInfo, bundles []*Manifest) (*Manife
 	}
 	oldM.sortFilesName()
 	// linkPeersAndChange will update file versions correctly
-	_, _, _ = idxMan.linkPeersAndChange(oldM, *c, ui.minVersion)
+	_, _, _ = idxMan.linkPeersAndChange(oldM, ui.minVersion)
 	// now add any new files to the full manifest
 	for _, idxF := range idxMan.Files {
 		i := sort.Search(len(newFull.Files), func(i int) bool {

--- a/swupd/manifest_test.go
+++ b/swupd/manifest_test.go
@@ -401,7 +401,7 @@ func TestLinkPeersAndChange(t *testing.T) {
 	// by name.
 	mNew.sortFilesName()
 	mOld.sortFilesName()
-	changed, added, deleted := mNew.linkPeersAndChange(&mOld, config{}, 0)
+	changed, added, deleted := mNew.linkPeersAndChange(&mOld, 0)
 	if changed != 2 {
 		t.Errorf("%v files detected as changed when 2 was expected", changed)
 	}


### PR DESCRIPTION
Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>

See #374 