### PR TITLE
swupd: export BundleInfo struct

### DIFF
--- a/swupd/bundleinfo.go
+++ b/swupd/bundleinfo.go
@@ -23,7 +23,8 @@ import (
 	"strings"
 )
 
-type bundleInfo struct {
+// BundleInfo describes the JSON object to be read from the *-info files
+type BundleInfo struct {
 	Name           string
 	Filename       string
 	DirectIncludes []string
@@ -41,9 +42,9 @@ func (m *Manifest) getBundleInfo(c config, path string) error {
 			return err
 		}
 
-		m.bundleInfo.Files = make(map[string]bool)
+		m.BundleInfo.Files = make(map[string]bool)
 		for _, f := range m.Files {
-			m.bundleInfo.Files[f.Name] = true
+			m.BundleInfo.Files[f.Name] = true
 		}
 
 		var includes []string
@@ -51,7 +52,7 @@ func (m *Manifest) getBundleInfo(c config, path string) error {
 		if err != nil {
 			return err
 		}
-		m.bundleInfo.DirectIncludes = includes
+		m.BundleInfo.DirectIncludes = includes
 		return nil
 	}
 
@@ -60,7 +61,7 @@ func (m *Manifest) getBundleInfo(c config, path string) error {
 		return err
 	}
 
-	err = json.Unmarshal(biBytes, &m.bundleInfo)
+	err = json.Unmarshal(biBytes, &m.BundleInfo)
 	if err != nil {
 		return err
 	}
@@ -79,7 +80,7 @@ func (m *Manifest) getBundleInfo(c config, path string) error {
 			if !strings.HasPrefix(f, "/") {
 				return fmt.Errorf("invalid extra file %s in %s, must start with '/'", f, extraFilesPath)
 			}
-			m.bundleInfo.Files[f] = true
+			m.BundleInfo.Files[f] = true
 		}
 	}
 
@@ -88,7 +89,7 @@ func (m *Manifest) getBundleInfo(c config, path string) error {
 
 func (m *Manifest) addFilesFromBundleInfo(c config, version uint32) error {
 	chrootDir := filepath.Join(c.imageBase, fmt.Sprint(version), "full")
-	for fpath := range m.bundleInfo.Files {
+	for fpath := range m.BundleInfo.Files {
 		fullPath := filepath.Join(chrootDir, fpath)
 		fi, err := os.Lstat(fullPath)
 		if err != nil {
@@ -126,7 +127,7 @@ func (m *Manifest) readIncludesFromBundleInfo(bundles []*Manifest) error {
 		}
 	}
 
-	for _, bn := range m.bundleInfo.DirectIncludes {
+	for _, bn := range m.BundleInfo.DirectIncludes {
 		// just add this one blindly since it is processed later
 		if bn == IndexBundle {
 			includes = append(includes, &Manifest{Name: IndexBundle})

--- a/swupd/bundleinfo.go
+++ b/swupd/bundleinfo.go
@@ -33,7 +33,9 @@ type BundleInfo struct {
 	Files          map[string]bool
 }
 
-func (m *Manifest) getBundleInfo(c config, path string) error {
+// GetBundleInfo loads the BundleInfo member of m from the bundle-info file at
+// path
+func (m *Manifest) GetBundleInfo(stateDir, path string) error {
 	var err error
 	if _, err = os.Stat(path); os.IsNotExist(err) {
 		basePath := filepath.Dir(path)
@@ -66,7 +68,7 @@ func (m *Manifest) getBundleInfo(c config, path string) error {
 		return err
 	}
 
-	extraFilesPath := filepath.Join(c.stateDir, m.Name+"-extra-files")
+	extraFilesPath := filepath.Join(stateDir, m.Name+"-extra-files")
 	if _, err = os.Stat(extraFilesPath); err == nil {
 		extraFilesBytes, err := ioutil.ReadFile(extraFilesPath)
 		if err != nil {

--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -98,7 +98,7 @@ func initBundles(ui UpdateInfo, c config) ([]*Manifest, error) {
 					useBundleInfo = false
 				}
 
-				err = bundle.getBundleInfo(c, biPath)
+				err = bundle.GetBundleInfo(c.stateDir, biPath)
 				if err != nil {
 					errorChan <- err
 					break

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -386,7 +386,7 @@ func (fs *testFileSystem) write(subpath, content string) {
 }
 
 func (fs *testFileSystem) initBundleInfo(version uint32, bundle string, includes []string) {
-	bi := bundleInfo{
+	bi := BundleInfo{
 		Name:           bundle,
 		DirectIncludes: includes,
 		DirectPackages: make(map[string]bool),
@@ -434,7 +434,7 @@ func (fs *testFileSystem) addToBundleInfo(version uint32, bundle, file string) {
 		fs.t.Fatal(err)
 	}
 
-	var bi bundleInfo
+	var bi BundleInfo
 	err = json.Unmarshal(biBytes, &bi)
 	if err != nil {
 		fs.t.Fatal(err)
@@ -460,7 +460,7 @@ func (fs *testFileSystem) addIncludesToBundleInfo(version uint32, bundle string,
 		fs.t.Fatal(err)
 	}
 
-	var bi bundleInfo
+	var bi BundleInfo
 	err = json.Unmarshal(biBytes, &bi)
 	if err != nil {
 		fs.t.Fatal(err)

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -61,7 +61,7 @@ type Manifest struct {
 	Header       ManifestHeader
 	Files        []*File
 	DeletedFiles []*File
-	bundleInfo   bundleInfo
+	BundleInfo   BundleInfo
 }
 
 // MoM is a manifest that holds references to bundle manifests.


### PR DESCRIPTION
This is useful for other projects trying to use the *-info file.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>