### PR TITLE
config: Add missing default value for docker

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -112,6 +112,7 @@ func (config *MixConfig) LoadDefaultsForPath(localrpms bool, path string) {
 
 	// [Mixer]
 	config.Mixer.LocalBundleDir = filepath.Join(path, "local-bundles")
+	config.Mixer.DockerImgPath = "clearlinux/mixer"
 
 	if localrpms {
 		config.Mixer.LocalRPMDir = filepath.Join(path, "local-rpms")


### PR DESCRIPTION
The default value for DOCKER_IMAGE_PATH was only set for the old INI
config. As a result, TOML configs would have an empty path that would
generate an invalid docker command to be issued.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>