### PR TITLE
Remove hardlink dependency check

### DIFF
--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -569,7 +569,6 @@ func init() {
 		"dnf",
 	}
 	externalDeps[buildUpdateCmd] = []string{
-		"hardlink",
 		"openssl",
 		"xz",
 	}

--- a/mixer/cmd/rpms.go
+++ b/mixer/cmd/rpms.go
@@ -40,7 +40,6 @@ func init() {
 
 	externalDeps[addRPMCmd] = []string{
 		"createrepo_c",
-		"hardlink",
 	}
 }
 


### PR DESCRIPTION
Mixer does not use the hardlink binary anymore, so these dependency checks can be removed.