### PR TITLE
Don't wipe output dirs on build bundles

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -1397,7 +1397,7 @@ func getClosestAncestorOwner(path string) (int, int, error) {
 // DNF configuration file, then resolving all files for each bundle using dnf
 // resolve and no-op installs. One full chroot is created from this step with
 // the file contents of all bundles.
-func (b *Builder) BuildBundles(template *x509.Certificate, privkey *rsa.PrivateKey, signflag bool) error {
+func (b *Builder) BuildBundles(template *x509.Certificate, privkey *rsa.PrivateKey, signflag, clean bool) error {
 	// Fetch upstream bundle files if needed
 	if err := b.getUpstreamBundles(b.UpstreamVer, true); err != nil {
 		return err
@@ -1430,9 +1430,8 @@ func (b *Builder) BuildBundles(template *x509.Certificate, privkey *rsa.PrivateK
 		}
 	}
 
-	// If MIXVER already exists, wipe it so it's a fresh build
-	if _, err := os.Stat(b.Config.Builder.ServerStateDir + "/image/" + b.MixVer); err == nil {
-		fmt.Printf("Wiping away previous version %s...\n", b.MixVer)
+	if _, err := os.Stat(b.Config.Builder.ServerStateDir + "/image/" + b.MixVer); err == nil && clean {
+		fmt.Printf("* Wiping away previous version %s...\n", b.MixVer)
 		err = os.RemoveAll(b.Config.Builder.ServerStateDir + "/www/" + b.MixVer)
 		if err != nil {
 			return err

--- a/mixin/build.go
+++ b/mixin/build.go
@@ -66,8 +66,9 @@ func buildBundles(b *builder.Builder) error {
 		}
 		template = helpers.CreateCertTemplate()
 	}
-
-	return errors.Wrap(b.BuildBundles(template, privkey, false), "Error building bundles")
+	// Always wipe /image and /www because mixver will only be incremented if the last
+	// build was valid, so the user may end up using bad data if it's not cleaned.
+	return errors.Wrap(b.BuildBundles(template, privkey, false, true), "Error building bundles")
 }
 
 func mergeMoMs(mixWS string, mixVer, lastVer int) error {


### PR DESCRIPTION
By default, build bundles removes image/ver and www/ver, so that builds
of the same number start with a clean slate. There are specific use cases
where this is not desirable, and the statedir already has a version folder
populated/mounted which shouldn't be wiped. This allows mixer to write
the full chroot into an actual mounted file system for example that is
attached to update/image/VER/full.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>

Fixes https://github.com/clearlinux/mixer-tools/issues/376