### PR TITLE
Fix global --offline usage

### DIFF
--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -110,6 +110,14 @@ var RootCmd = &cobra.Command{
 		// If so: inform, stage, and exit.
 		// If not: run command in container and cancel pre-run
 		if !cmdContains(cmd, "format-bump") && !cmdContains(cmd, "upstream-format") && cmdContains(cmd, "build") {
+			// --offline=true AND --native=false, try to see if container exists
+			if builder.Offline && !builder.Native {
+				fmt.Println("Warning: Unable to determine upstream format in --offline mode, build may fail if building across format boundaries.")
+				if err := b.RunCommandInContainer(reconstructCommand(cmd, args)); err != nil {
+					fail(err)
+				}
+				return nil
+			}
 			if bumpNeeded, err := b.CheckBumpNeeded(false); err != nil {
 				return err
 			} else if bumpNeeded {


### PR DESCRIPTION
When --offline is passed, any command executed should not reach over the
network. This introduces a tricky scenario when it is passed to a build
command with --native=false (default), because the command in the
container will be run with --offline, but the native mixer binary will
reach over the network to pull/update docker containers before executing
in them. This patch also makes that process offline only, attempting to
use a cached docker image so that it can run offline fully, but exits if
none exist.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>