### PR TITLE
Using ldflags for mixer version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ include Makefile.bats
 
 .NOTPARALLEL:
 
+VERSION=5.1.0
 GO_PACKAGE_PREFIX := github.com/clearlinux/mixer-tools
 
 .PHONY: gopath
@@ -36,7 +37,7 @@ endif
 
 
 build: gopath
-	go install ${GO_PACKAGE_PREFIX}/mixer
+	go install -ldflags="-X ${GO_PACKAGE_PREFIX}/builder.Version=${VERSION}" ${GO_PACKAGE_PREFIX}/mixer
 	go install ${GO_PACKAGE_PREFIX}/mixin
 	go install ${GO_PACKAGE_PREFIX}/swupd-extract
 	go install ${GO_PACKAGE_PREFIX}/swupd-inspector
@@ -99,12 +100,7 @@ release:
 		echo "Release needs to be used from a git repository"; \
 		exit 1; \
 	fi
-	@VERSION=$$(grep -e 'const Version' builder/builder.go | cut -d '"' -f 2) ; \
-	if [ -z "$$VERSION" ]; then \
-		echo "Couldn't extract version number from the source code"; \
-		exit 1; \
-	fi; \
-	git archive --format=tar.gz --verbose -o mixer-tools-$$VERSION.tar.gz HEAD --prefix=mixer-tools-$$VERSION/
+	git archive --format=tar.gz --verbose -o mixer-tools-${VERSION}.tar.gz HEAD --prefix=mixer-tools-${VERSION}/
 
 MANPAGES = \
 	docs/mixer.1 \

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -44,8 +44,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Version of Mixer. Also used by the Makefile for releases.
-const Version = "5.1.0"
+// Version of Mixer. This is provided by ldflags in Makefile during compilation
+var Version = ""
 
 // Native controls whether mixer runs the command on the native machine or in a
 // container.


### PR DESCRIPTION
This change moves the setting of mixer version string from source code
to a variable defined during compilation. This approach is preferable
because:

1- builder.go does not need to change just to change version.
2- simplifies logic in Makefile, no need to retrieve value from source.