### PR TITLE
bundles: Fix race condition on map.Range

### DIFF
--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -352,26 +352,17 @@ func resolvePackages(numWorkers int, set bundleSet, packagerCmd []string, emptyD
 	bundleCh := make(chan *bundle)
 	// bundleRepoPkgs is a map of bundles -> map of repos -> list of packages
 	var bundleRepoPkgs sync.Map
-	// Prepopulate the top-level map so that its size is not changed by the
-	// worker goroutines.
-	for bundle := range set {
-		bundleRepoPkgs.Store(bundle, make(repoPkgMap))
-	}
 
 	packageWorker := func() {
 		for bundle := range bundleCh {
 			fmt.Printf("processing %s\n", bundle.Name)
-			packageNames := make(map[string]bool)
-			for k := range bundle.AllPackages {
-				packageNames[k] = true
-			}
 			queryString := merge(
 				packagerCmd,
 				"--installroot="+emptyDir,
 				"--assumeno",
 				"install",
 			)
-			for p := range packageNames {
+			for p := range bundle.AllPackages {
 				queryString = append(queryString, p)
 			}
 			// ignore error from the --assumeno install. It is an error every time because

--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -383,16 +383,15 @@ func resolvePackages(numWorkers int, set bundleSet, packagerCmd []string, emptyD
 
 			// TODO: parseNoopInstall may fail, so consider a way to stop the processing
 			// once we find that failure. See how errorCh works in fullfiles.go.
-			bundleRepoPkgs.Store(bundle.Name, parseNoopInstall(outBuf.String()))
-
-			bundleRepoPkgs.Range(func(key, val interface{}) bool {
-				for _, r := range val.(repoPkgMap) {
-					for _, p := range r {
-						bundle.AllPackages[p] = true
-					}
+			rpm := parseNoopInstall(outBuf.String())
+			for _, pkgs := range rpm {
+				// Add packages to bundle's AllPackages
+				for _, pkg := range pkgs {
+					bundle.AllPackages[pkg] = true
 				}
-				return true
-			})
+			}
+
+			bundleRepoPkgs.Store(bundle.Name, rpm)
 
 			fmt.Printf("... done with %s\n", bundle.Name)
 		}


### PR DESCRIPTION
When ranging over the syncmap to add packages to a bundle we were
mistakenly ranging over the entire set of bundles and adding all bundle
packages to the same bundle (nondeterministically, since we were doing
concurrent writes to a syncmap). In reality we just need to range over
the repoPkgMap itself and not load it from the syncmap at all. Do this
operation before even storing it.

BONUS COMMIT :fireworks: 
bundles: remove unneeded map assignment dance

We were assigning a map to a map to assign it to a string slice. Instead
just assign the map keys to the string slice directly.