### PR TITLE
cmd: Fix double config parsing

### DIFF
--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -65,9 +65,14 @@ var RootCmd = &cobra.Command{
 			}
 		}
 
-		// Init needs to be handled differently because there is no config yet
-		if cmdContains(cmd, "init") {
-			return checkCmdDeps(cmd)
+		// Commands that don't require the config to be pre-parsed must be
+		// handled differently because there might be no config yet or they
+		// will parse it on their own
+		noParseConfigCmds := []string{"init", "config"}
+		for _, ignoreCmd := range noParseConfigCmds {
+			if cmdContains(cmd, ignoreCmd) {
+				return checkCmdDeps(cmd)
+			}
 		}
 
 		b, err := builder.NewFromConfig(configFile)


### PR DESCRIPTION
When running any 'mixer config' sub-command, the config will be parsed
in the command itself, so there is no need to pre-parse them in the pre
execution. Those commands also don't rely on network nor cause any
format conflict, so it is safe to skip all the remaining checks like it
is done for the 'init' command.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>