### PR TITLE
bundles: Enforce UTF-8 when running dnf

### DIFF
--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -203,7 +203,7 @@ func resolveFilesForBundle(bundle *bundle, repoPkgs repoPkgMap, packagerCmd []st
 		for _, p := range pkgs {
 			queryString = append(queryString, p)
 		}
-		outBuf, err := helpers.RunCommandOutput(queryString[0], queryString[1:]...)
+		outBuf, err := helpers.RunCommandOutputEnv(queryString[0], queryString[1:], []string{"LC_ALL=en_US.UTF-8"})
 		if err != nil {
 			return err
 		}
@@ -370,7 +370,7 @@ func resolvePackages(numWorkers int, set bundleSet, packagerCmd []string, emptyD
 			// status. This exit status is 1, which is the same as any other dnf install
 			// error. Fortunately if this is a different error than we expect, it should
 			// fail in the actual install to the full chroot.
-			outBuf, _ := helpers.RunCommandOutput(queryString[0], queryString[1:]...)
+			outBuf, _ := helpers.RunCommandOutputEnv(queryString[0], queryString[1:], []string{"LC_ALL=en_US.UTF-8"})
 
 			// TODO: parseNoopInstall may fail, so consider a way to stop the processing
 			// once we find that failure. See how errorCh works in fullfiles.go.
@@ -409,7 +409,8 @@ func installFilesystem(packagerCmd []string, chrootDir string) error {
 		"install",
 		"filesystem",
 	)
-	return helpers.RunCommandSilent(installArgs[0], installArgs[1:]...)
+	_, err := helpers.RunCommandOutputEnv(installArgs[0], installArgs[1:], []string{"LC_ALL=en_US.UTF-8"})
+	return err
 }
 
 func createClearDir(chrootDir, version string) error {
@@ -508,7 +509,7 @@ func installBundleToFull(packagerCmd []string, buildVersionDir string, bundle *b
 		for p := range bundle.AllPackages {
 			args = append(args, p)
 		}
-		err = helpers.RunCommandSilent(args[0], args[1:]...)
+		_, err = helpers.RunCommandOutputEnv(args[0], args[1:], []string{"LC_ALL=en_US.UTF-8"})
 		if err != nil {
 			return err
 		}
@@ -536,7 +537,8 @@ func installBundleToFull(packagerCmd []string, buildVersionDir string, bundle *b
 
 func clearDNFCache(packagerCmd []string) error {
 	args := merge(packagerCmd, "clean", "all")
-	return helpers.RunCommandSilent(args[0], args[1:]...)
+	_, err := helpers.RunCommandOutputEnv(args[0], args[1:], []string{"LC_ALL=en_US.UTF-8"})
+	return err
 }
 
 func rmDNFStatePaths(fullDir string) {
@@ -809,6 +811,7 @@ func createVersionsFile(baseDir string, packagerCmd []string) error {
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf
+	cmd.Env = append(os.Environ(), "LC_ALL=en_US.UTF-8")
 	err := cmd.Run()
 	if err != nil {
 		msg := fmt.Sprintf("couldn't list packages: %s\nCOMMAND LINE: %s", err, args)

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -308,11 +308,19 @@ func RunCommandTimeout(timeout int, cmdname string, args ...string) error {
 // memory. If the command succeeds returns that output, if it fails, return err that
 // contains both the out and err streams from the execution.
 func RunCommandOutput(cmdname string, args ...string) (*bytes.Buffer, error) {
+	return RunCommandOutputEnv(cmdname, args, []string{})
+}
+
+// RunCommandOutputEnv executes the command with arguments and environment and stores
+// its output in memory. If the command succeeds returns that output, if it fails,
+// return err that contains both the out and err streams from the execution.
+func RunCommandOutputEnv(cmdname string, args []string, envs []string) (*bytes.Buffer, error) {
 	cmd := exec.Command(cmdname, args...)
 	var outBuf bytes.Buffer
 	var errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf
+	cmd.Env = append(os.Environ(), envs...)
 	err := cmd.Run()
 
 	if err != nil {

--- a/mixin/helpers.go
+++ b/mixin/helpers.go
@@ -163,6 +163,6 @@ func getPackageRepo(pkg string, ver int, configFile string) (string, error) {
 	// ignore error here because passing --assumeno to dnf install always
 	// results in an error due to the aborted install. Instead rely on the
 	// error to come from parseHeaderNoopInstall
-	outBuf, _ := helpers.RunCommandOutput(packagerCmd[0], packagerCmd[1:]...)
+	outBuf, _ := helpers.RunCommandOutputEnv(packagerCmd[0], packagerCmd[1:], []string{"LC_ALL=en_US.UTF-8"})
 	return parseHeaderNoopInstall(pkg, outBuf.String())
 }


### PR DESCRIPTION
In some situations dnf may try to combine files from different
encodings. If the command is not running is a UTF-8 locale, this
combination will be missing a new line, causing and error.

An example of this occurrence is the command `dnf repoquery --quiet -l
systemd ca-certs-static ...` which combines a file list from systemd and
ca-certs-static

This patch enforces UTF-8 locale on every dnf execution.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>