### PR TITLE
builder: No default bundles for offline init

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -278,6 +278,13 @@ func (b *Builder) InitMix(upstreamVer string, mixVer string, allLocal bool, allU
 		return errors.Wrapf(err, "Couldn't parse upstream version")
 	}
 
+	// When running in offline mode, there is no upstream to get the default bundles from,
+	// so the mix must be created without the default bundles.
+	if Offline && !noDefaults {
+		fmt.Println("Running in offline mode. Forcing --no-default-bundles")
+		noDefaults = true
+	}
+
 	// Initialize the Mix Bundles List
 	var bundles []string
 	if !noDefaults {


### PR DESCRIPTION
When running 'mixer init' with the --offline flag, there is no upstream
to fetch the default bundles from, so the mix should be initialized
without the default bundles.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>