### PR TITLE
lint: Fix lint errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ lint: gopath
 	--enable=unused \
 	--enable=vetshadow \
 	--enable=errcheck \
+	--exclude=golang/src \
 	./...
 
 clean:

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -61,9 +61,9 @@ func CreateCertTemplate() *x509.Certificate {
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().AddDate(1, 0, 0),
 		BasicConstraintsValid: true,
-		IsCA:        false, // This could be true since we are self signed, but set false for correctness
-		KeyUsage:    x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature | x509.KeyUsageCRLSign,
-		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		IsCA:                  false, // This could be true since we are self signed, but set false for correctness
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature | x509.KeyUsageCRLSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
 	}
 
 	return &template

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -543,7 +543,7 @@ func linkDeltaPeersForPack(c *config, oldManifest, newManifest *Manifest) error 
 			newPath := filepath.Join(c.imageBase, fmt.Sprint(nf.Version), "full", nf.Name)
 			fi, err := os.Stat(newPath)
 			if err != nil {
-				return errors.Wrapf(err, "error accessing %s to decide whether it can have a delta or not")
+				return errors.Wrapf(err, "error accessing %s to decide whether it can have a delta or not", newPath)
 			}
 			if fi.Size() < minimumSizeToMakeDeltaInBytes {
 				continue


### PR DESCRIPTION
These errors are reported by the current version of gometalinter. Aside
from the errors in mixer code, it is also reporting errors in the
standard golang libraries, so golang/src path was excluded from the lint
errors in the Makefile.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>