### PR TITLE
Ignore possible %ghost files in RPM files.

### DIFF
--- a/swupd/bundleinfo.go
+++ b/swupd/bundleinfo.go
@@ -94,6 +94,10 @@ func (m *Manifest) addFilesFromBundleInfo(c config, version uint32) error {
 	for fpath := range m.BundleInfo.Files {
 		fullPath := filepath.Join(chrootDir, fpath)
 		fi, err := os.Lstat(fullPath)
+		if os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "Warning: Missing file, assuming %%ghost: %s\n", fpath)
+			continue
+		}
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Due to the way that we use repoquery, we are returned files that
may be %ghost files in RPMs. These files may be missing and this
is legal and compliant.

While Clear Linux OS does not use %ghost files in any of the RPMs
created, there is nothing wrong with permitting other vendor RPM
files that may list %ghost files, and mixer should just ignore
these files.

This change does just that: If repoquery returns files that are
not existing in the fullimage, prints a warning and continues with
out dropping the manifest for that bundle.