### PR TITLE
Manifest error

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -1571,7 +1571,7 @@ func (b *Builder) buildUpdateContent(params UpdateParameters, timer *stopWatch) 
 		return errors.Wrapf(err, "failed to write update metadata files")
 	}
 	timer.Start("CREATE MANIFESTS")
-	mom, err := swupd.CreateManifests(b.MixVerUint32, minVersion, uint(format), b.Config.Builder.ServerStateDir)
+	mom, err := swupd.CreateManifests(b.MixVerUint32, minVersion, uint(format), b.Config.Builder.ServerStateDir, b.NumBundleWorkers)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create update metadata")
 	}

--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"testing"
 )
 
@@ -27,7 +28,7 @@ func TestInitBuildEnv(t *testing.T) {
 }
 
 func TestCreateManifestsBadMinVersion(t *testing.T) {
-	if _, err := CreateManifests(10, 20, 1, "testdir"); err == nil {
+	if _, err := CreateManifests(10, 20, 1, "testdir", runtime.NumCPU()); err == nil {
 		t.Error("No error raised with invalid minVersion (20) for version 10")
 	}
 }

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"testing"
 	"text/template"
 )
@@ -181,7 +182,7 @@ func mustCreateManifestsStandard(t *testing.T, ver uint32, testDir string) *MoM 
 
 func mustCreateManifests(t *testing.T, ver uint32, minVer uint32, format uint, testDir string) *MoM {
 	t.Helper()
-	mom, err := CreateManifests(ver, minVer, format, testDir)
+	mom, err := CreateManifests(ver, minVer, format, testDir, runtime.NumCPU())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -703,7 +704,7 @@ func (ts *testSwupd) createManifests(version uint32) *MoM {
 	osRelease := fmt.Sprintf("VERSION_ID=%d\n", version)
 	ts.addFile(version, "os-core", "/usr/lib/os-release", osRelease)
 
-	mom, err := CreateManifests(version, ts.MinVersion, ts.Format, ts.Dir)
+	mom, err := CreateManifests(version, ts.MinVersion, ts.Format, ts.Dir, runtime.NumCPU())
 	if err != nil {
 		ts.t.Fatalf("error creating manifests for version %d: %s", version, err)
 	}
@@ -724,7 +725,7 @@ func (ts *testSwupd) createManifestsFromChroots(version uint32) *MoM {
 	osRelease := fmt.Sprintf("VERSION_ID=%d\n", version)
 	ts.write(filepath.Join("image", fmt.Sprint(version), "os-core", "usr/lib/os-release"), osRelease)
 
-	mom, err := CreateManifests(version, ts.MinVersion, ts.Format, ts.Dir)
+	mom, err := CreateManifests(version, ts.MinVersion, ts.Format, ts.Dir, runtime.NumCPU())
 	if err != nil {
 		ts.t.Fatalf("error creating manifests for version %d: %s", version, err)
 	}


### PR DESCRIPTION
This patch fix the error handling issue in manifest creation and change it so the number of worker threads matches the one defined by --bundle-workers option. See commit message for detailed description on the issue.