### PR TITLE
bundles: Remove redundant parsing of config file.

### DIFF
--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -16,71 +16,8 @@ import (
 	"time"
 
 	"github.com/clearlinux/mixer-tools/helpers"
-	"github.com/go-ini/ini"
 	"github.com/pkg/errors"
 )
-
-// TODO: Move this to the more general configuration handling.
-type buildBundlesConfig struct {
-	// [Server] section.
-	HasServerSection bool
-	DebugInfoBanned  string
-	DebugInfoLib     string
-	DebugInfoSrc     string
-
-	// [swupd] section.
-	UpdateBundle string
-	ContentURL   string
-	VersionURL   string
-	// Format is already in b.State.Mix.Format.
-}
-
-// TODO: Move this to the more general configuration handling.
-func readBuildBundlesConfig(path string) (*buildBundlesConfig, error) {
-	iniFile, err := ini.InsensitiveLoad(path)
-	if err != nil {
-		return nil, err
-	}
-
-	cfg := &buildBundlesConfig{}
-
-	// TODO: Validate early the fields we read.
-	server, err := iniFile.GetSection("Server")
-	if err == nil {
-		cfg.HasServerSection = true
-		cfg.DebugInfoBanned = server.Key("debuginfo_banned").Value()
-		cfg.DebugInfoLib = server.Key("debuginfo_lib").Value()
-		cfg.DebugInfoSrc = server.Key("debuginfo_src").Value()
-	}
-
-	swupd, err := iniFile.GetSection("swupd")
-	if err != nil {
-		return nil, fmt.Errorf("error in configuration file %s: %s", path, err)
-	}
-
-	getKey := func(section *ini.Section, name string) (string, error) {
-		key, kerr := section.GetKey(name)
-		if kerr != nil {
-			return "", fmt.Errorf("error in configuration file %s: %s", path, kerr)
-		}
-		return key.Value(), nil
-	}
-
-	cfg.UpdateBundle, err = getKey(swupd, "BUNDLE")
-	if err != nil {
-		return nil, err
-	}
-	cfg.ContentURL, err = getKey(swupd, "CONTENTURL")
-	if err != nil {
-		return nil, err
-	}
-	cfg.VersionURL, err = getKey(swupd, "VERSIONURL")
-	if err != nil {
-		return nil, err
-	}
-
-	return cfg, nil
-}
 
 var bannedPaths = [...]string{
 	"/var/lib/",
@@ -467,16 +404,16 @@ func buildOsCore(packagerCmd []string, chrootDir, version string) error {
 	return nil
 }
 
-func genUpdateBundleSpecialFiles(chrootDir string, cfg *buildBundlesConfig, b *Builder) error {
+func genUpdateBundleSpecialFiles(chrootDir string, b *Builder) error {
 	swupdDir := filepath.Join(chrootDir, "usr/share/defaults/swupd")
 	if err := os.MkdirAll(swupdDir, 0755); err != nil {
 		return err
 	}
-	cURLBytes := []byte(cfg.ContentURL)
+	cURLBytes := []byte(b.Config.Swupd.ContentURL)
 	if err := ioutil.WriteFile(filepath.Join(swupdDir, "contenturl"), cURLBytes, 0644); err != nil {
 		return err
 	}
-	vURLBytes := []byte(cfg.VersionURL)
+	vURLBytes := []byte(b.Config.Swupd.VersionURL)
 	if err := ioutil.WriteFile(filepath.Join(swupdDir, "versionurl"), vURLBytes, 0644); err != nil {
 		return err
 	}
@@ -563,7 +500,7 @@ func rmDNFStatePaths(fullDir string) {
 	}
 }
 
-func buildFullChroot(cfg *buildBundlesConfig, b *Builder, set *bundleSet, packagerCmd []string, buildVersionDir, version string) error {
+func buildFullChroot(b *Builder, set *bundleSet, packagerCmd []string, buildVersionDir, version string) error {
 	fmt.Println("Cleaning DNF cache before full install")
 	if err := clearDNFCache(packagerCmd); err != nil {
 		return err
@@ -588,9 +525,9 @@ func buildFullChroot(cfg *buildBundlesConfig, b *Builder, set *bundleSet, packag
 		}
 
 		// special handling for update bundle
-		if bundle.Name == cfg.UpdateBundle {
+		if bundle.Name == b.Config.Swupd.Bundle {
 			fmt.Printf("... Adding swupd default values to %s bundle\n", bundle.Name)
-			if err := genUpdateBundleSpecialFiles(fullDir, cfg, b); err != nil {
+			if err := genUpdateBundleSpecialFiles(fullDir, b); err != nil {
 				return err
 			}
 		}
@@ -644,16 +581,9 @@ func (b *Builder) buildBundles(set bundleSet) error {
 		return err
 	}
 
-	// TODO: Do not touch config code that is in flux at the moment, reparsing it here to grab
-	// information that previously Mixer didn't care about. Move that to the configuration part
-	// of Mixer.
-	cfg, err := readBuildBundlesConfig(b.Config.GetConfigFileName())
-	if err != nil {
-		return err
-	}
-
-	if _, ok := set[cfg.UpdateBundle]; !ok {
-		return fmt.Errorf("couldn't find bundle %q specified in configuration as the update bundle", cfg.UpdateBundle)
+	if _, ok := set[b.Config.Swupd.Bundle]; !ok {
+		return fmt.Errorf("couldn't find bundle %q specified in configuration as the update bundle",
+			b.Config.Swupd.Bundle)
 	}
 
 	// Write INI files. These are used to communicate to the next step of mixing (build update).
@@ -662,15 +592,15 @@ func (b *Builder) buildBundles(set bundleSet) error {
 emptydir=%s/empty
 imagebase=%s/image/
 outputdir=%s/www/
-`, b.Config.Builder.ServerStateDir, b.Config.Builder.ServerStateDir, b.Config.Builder.ServerStateDir)
-	if cfg.HasServerSection {
-		fmt.Fprintf(&serverINI, `
+
 [Debuginfo]
 banned=%s
 lib=%s
 src=%s
-`, cfg.DebugInfoBanned, cfg.DebugInfoLib, cfg.DebugInfoSrc)
-	}
+`, b.Config.Builder.ServerStateDir, b.Config.Builder.ServerStateDir,
+		b.Config.Builder.ServerStateDir, b.Config.Server.DebugInfoBanned,
+		b.Config.Server.DebugInfoLib, b.Config.Server.DebugInfoSrc)
+
 	err = ioutil.WriteFile(filepath.Join(b.Config.Builder.ServerStateDir, "server.ini"), serverINI.Bytes(), 0644)
 	if err != nil {
 		return err
@@ -746,7 +676,7 @@ src=%s
 		return err
 	}
 
-	updateBundle := set[cfg.UpdateBundle]
+	updateBundle := set[b.Config.Swupd.Bundle]
 	var osCore *bundle
 	for _, bundle := range set {
 		if bundle.Name == "os-core" {
@@ -765,7 +695,7 @@ src=%s
 	}
 
 	// install all bundles in the set (including os-core) to the full chroot
-	err = buildFullChroot(cfg, b, &set, packagerCmd, buildVersionDir, version)
+	err = buildFullChroot(b, &set, packagerCmd, buildVersionDir, version)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
All the values inside buildBundlesConfig are already parsed and
available in the code through builder.Config, so there is no need to
parse them again from the config file.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>