### PR TITLE
Config convert

### DIFF
--- a/bat/tests/07-config-conversion/Makefile
+++ b/bat/tests/07-config-conversion/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./builder.conf.bkp ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles current.conf
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/07-config-conversion/configs/1.0_builder.conf
+++ b/bat/tests/07-config-conversion/configs/1.0_builder.conf
@@ -1,0 +1,23 @@
+#VERSION 1.0
+
+[Builder]
+  CERT = "/home/clr/mix/Swupd_Root.pem"
+  SERVER_STATE_DIR = "/home/clr/mix/update"
+  VERSIONS_PATH = "/home/clr/mix"
+  YUM_CONF = "/home/clr/mix/.yum-mix.conf"
+
+[Swupd]
+  BUNDLE = "os-core-update"
+  CONTENTURL = "<URL where the content will be hosted>"
+  VERSIONURL = "<URL where the version of the mix will be hosted>"
+
+[Server]
+  DEBUG_INFO_BANNED = "true"
+  DEBUG_INFO_LIB = "/usr/lib/debug"
+  DEBUG_INFO_SRC = "/usr/src/debug"
+
+[Mixer]
+  LOCAL_BUNDLE_DIR = "/home/clr/mix/local-bundles"
+  LOCAL_REPO_DIR = ""
+  LOCAL_RPM_DIR = ""
+  DOCKER_IMAGE_PATH = "clearlinux/mixer"

--- a/bat/tests/07-config-conversion/configs/legacy_builder.conf
+++ b/bat/tests/07-config-conversion/configs/legacy_builder.conf
@@ -1,0 +1,21 @@
+[Builder]
+SERVER_STATE_DIR=/home/clr/mix/update
+BUNDLE_DIR=/home/clr/mix/mix-bundles
+YUM_CONF=/home/clr/mix/.yum-mix.conf
+CERT=/home/clr/mix/Swupd_Root.pem
+VERSIONS_PATH=/home/clr/mix
+
+[swupd]
+BUNDLE=os-core-update
+CONTENTURL=<URL where the content will be hosted>
+VERSIONURL=<URL where the version of the mix will be hosted>
+FORMAT=1
+
+[Server]
+debuginfo_banned=true
+debuginfo_lib=/usr/lib/debug
+debuginfo_src=/usr/src/debug
+
+[Mixer]
+LOCAL_BUNDLE_DIR=/home/clr/mix/local-bundles
+DOCKER_IMAGE_PATH=clearlinux/mixer

--- a/bat/tests/07-config-conversion/configs/nover_builder.conf
+++ b/bat/tests/07-config-conversion/configs/nover_builder.conf
@@ -1,0 +1,22 @@
+[Builder]
+  CERT = "/home/clr/mix/Swupd_Root.pem"
+  SERVER_STATE_DIR = "/home/clr/mix/update"
+  VERSIONS_PATH = "/home/clr/mix"
+  YUM_CONF = "/home/clr/mix/.yum-mix.conf"
+
+[Swupd]
+  BUNDLE = "os-core-update"
+  CONTENTURL = "<URL where the content will be hosted>"
+  VERSIONURL = "<URL where the version of the mix will be hosted>"
+  FORMAT = "1"
+
+[Server]
+  DEBUG_INFO_BANNED = "true"
+  DEBUG_INFO_LIB = "/usr/lib/debug"
+  DEBUG_INFO_SRC = "/usr/src/debug"
+
+[Mixer]
+  LOCAL_BUNDLE_DIR = "/home/clr/mix/local-bundles"
+  LOCAL_REPO_DIR = ""
+  LOCAL_RPM_DIR = ""
+  DOCKER_IMAGE_PATH = "clearlinux/mixer"

--- a/bat/tests/07-config-conversion/description.txt
+++ b/bat/tests/07-config-conversion/description.txt
@@ -1,0 +1,6 @@
+07-config-conversion
+===================
+This test simulates conversion between config file versions. It initiates a
+mix, replaces the default config with an older version and try to perform
+the conversion. It also checks if the format value is properly transferred
+to mixer.state

--- a/bat/tests/07-config-conversion/run.bats
+++ b/bat/tests/07-config-conversion/run.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  global_setup
+}
+
+@test "Convert to latest config" {
+  mixer init > /dev/null
+
+  #Backup current config
+  cp builder.conf current.conf
+
+  for f in "configs"/*
+  do
+    cp $f builder.conf
+    sed -i "s:/home/clr/mix:$PWD:g" builder.conf
+
+    mixer config validate > /dev/null
+
+    diff builder.conf current.conf
+  done
+
+}
+
+@test "Test format transfer" {
+  mixer init > /dev/null
+
+  cp configs/nover_builder.conf builder.conf
+
+  rm mixer.state
+
+  mixer config validate > /dev/null
+
+  #check if format was transfered from builder.conf to mixer.state
+  test $(sed -n 's/[ ]*FORMAT[ ="]*\([0-9]\+\)[ "]*/\1/p' mixer.state) -eq 1
+}
+
+@test "Test format keep" {
+  mixer init > /dev/null
+
+  #Save initial format
+  format=$(sed -n 's/[ ]*FORMAT[ ="]*\([0-9]\+\)[ "]*/\1/p' mixer.state)
+
+  cp configs/nover_builder.conf builder.conf
+
+  mixer config validate > /dev/null
+
+  #check if format has been preserved
+  test $(sed -n 's/[ ]*FORMAT[ ="]*\([0-9]\+\)[ "]*/\1/p' mixer.state) -eq $format
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/config/config_convert.go
+++ b/config/config_convert.go
@@ -1,0 +1,215 @@
+// Copyright © 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/BurntSushi/toml"
+	"github.com/clearlinux/mixer-tools/helpers"
+	"github.com/pkg/errors"
+)
+
+// CurrentConfigVersion holds the current version of the config file
+const CurrentConfigVersion = "1.0"
+
+func (config *MixConfig) parseVersion(reader *bufio.Reader) (bool, error) {
+	verBytes, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+
+	r := regexp.MustCompile("^#VERSION ([0-9]+.[0-9])+\n")
+	match := r.FindStringSubmatch(string(verBytes))
+
+	if len(match) != 2 {
+		return false, nil
+	}
+
+	config.version = match[1]
+
+	return true, nil
+}
+
+func (config *MixConfig) parseVersionAndConvert() error {
+	// Reset version for files without versioning
+	config.version = "0.0"
+
+	f, err := os.Open(config.filename)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	// Read config version
+	reader := bufio.NewReader(f)
+	found, err := config.parseVersion(reader)
+	if err != nil {
+		return err
+	}
+
+	//Already on latest version
+	if found && config.version == CurrentConfigVersion {
+		return nil
+	}
+
+	fmt.Printf("Converting config to version %s\n", CurrentConfigVersion)
+
+	if err := helpers.CopyFile(config.filename+".bkp", config.filename); err != nil {
+		return err
+	}
+
+	fmt.Printf("Old config saved as %s\n", config.filename+".bkp")
+
+	if !found {
+		return config.convertLegacy()
+	}
+
+	return config.convertCurrent()
+}
+
+func (config *MixConfig) convertCurrent() error {
+	// Version only exists in New Config, so parse builder.conf as TOML
+	if err := config.parse(); err != nil {
+		return err
+	}
+
+	// Make sure the converted config is in the New Format
+	UseNewConfig = true
+
+	// Set config to the current format
+	config.version = CurrentConfigVersion
+
+	return config.SaveConfig()
+}
+
+func (config *MixConfig) convertLegacy() error {
+	// Assume missing version and try to parse as TOML
+	if _, err := toml.DecodeFile(config.filename, &config); err != nil {
+		// Try parsing as INI
+		if err := config.parseLegacy(); err != nil {
+			return err
+		}
+	} else {
+		config.hasFormatField = true
+	}
+
+	// If the config still has the FORMAT value in it, check if
+	// it was already transferred to mixer.state
+	if config.hasFormatField {
+		if err := config.convertFormat(); err != nil {
+			return err
+		}
+	}
+
+	// Make sure the converted config is in the New Format
+	UseNewConfig = true
+
+	// Set config to the current format
+	config.version = CurrentConfigVersion
+
+	return config.SaveConfig()
+}
+
+func (config *MixConfig) convertFormat() error {
+	confBytes, err := ioutil.ReadFile(config.filename)
+	if err != nil {
+		return err
+	}
+
+	r := regexp.MustCompile(`FORMAT[\s"=]*([0-9]+)[\s"]*\n`)
+	match := r.FindStringSubmatch(string(confBytes))
+	if len(match) != 2 {
+		return nil
+	}
+
+	var state MixState
+	state.LoadDefaults()
+
+	_, err = os.Stat(state.filename)
+	if err == nil {
+		// mixer.state already exist, so don't overwrite it
+		return nil
+	}
+
+	state.Mix.Format = match[1]
+	return state.Save()
+}
+
+func (config *MixConfig) parseLegacy() error {
+	lines, err := helpers.ReadFileAndSplit(config.filename)
+	if err != nil {
+		return errors.Wrap(err, "Failed to read buildconf")
+	}
+
+	var format string
+
+	// Map the builder values to the regex here to make it easier to assign
+	fields := []struct {
+		re       string
+		dest     *string
+		required bool
+	}{
+		// [Builder]
+		{`^CERT\s*=\s*`, &config.Builder.Cert, true},
+		{`^SERVER_STATE_DIR\s*=\s*`, &config.Builder.ServerStateDir, true},
+		{`^VERSIONS_PATH\s*=\s*`, &config.Builder.VersionPath, true},
+		{`^YUM_CONF\s*=\s*`, &config.Builder.DNFConf, true},
+		// [Swupd]
+		{`^BUNDLE\s*=\s*`, &config.Swupd.Bundle, false},
+		{`^CONTENTURL\s*=\s*`, &config.Swupd.ContentURL, false},
+		{`^FORMAT\s*=\s*`, &format, true},
+		{`^VERSIONURL\s*=\s*`, &config.Swupd.VersionURL, false},
+		// [Server]
+		{`^debuginfo_banned\s*=\s*`, &config.Server.DebugInfoBanned, false},
+		{`^debuginfo_lib\s*=\s*`, &config.Server.DebugInfoLib, false},
+		{`^debuginfo_src\s*=\s*`, &config.Server.DebugInfoSrc, false},
+		// [Mixer]
+		{`^LOCAL_BUNDLE_DIR\s*=\s*`, &config.Mixer.LocalBundleDir, false},
+		{`^LOCAL_REPO_DIR\s*=\s*`, &config.Mixer.LocalRepoDir, false},
+		{`^LOCAL_RPM_DIR\s*=\s*`, &config.Mixer.LocalRPMDir, false},
+		{`^DOCKER_IMAGE_PATH\s*=\s*`, &config.Mixer.DockerImgPath, false},
+	}
+
+	for _, h := range fields {
+		r := regexp.MustCompile(h.re)
+		for _, i := range lines {
+			if m := r.FindIndex([]byte(i)); m != nil {
+				*h.dest = i[m[1]:]
+			}
+		}
+	}
+
+	config.hasFormatField = format != ""
+
+	if config.Mixer.LocalBundleDir == "" {
+		pwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		config.Mixer.LocalBundleDir = filepath.Join(pwd, "local-bundles")
+		fmt.Printf("WARNING: LOCAL_BUNDLE_DIR not found in builder.conf. Falling back to %q.\n", config.Mixer.LocalBundleDir)
+		fmt.Println("Please set this value to the location you want local bundle definition files to be stored.")
+	}
+
+	return nil
+}

--- a/config/config_convert.go
+++ b/config/config_convert.go
@@ -93,9 +93,6 @@ func (config *MixConfig) convertCurrent() error {
 		return err
 	}
 
-	// Make sure the converted config is in the New Format
-	UseNewConfig = true
-
 	// Set config to the current format
 	config.version = CurrentConfigVersion
 
@@ -120,9 +117,6 @@ func (config *MixConfig) convertLegacy() error {
 			return err
 		}
 	}
-
-	// Make sure the converted config is in the New Format
-	UseNewConfig = true
 
 	// Set config to the current format
 	config.version = CurrentConfigVersion

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/clearlinux/mixer-tools/builder"
-	"github.com/clearlinux/mixer-tools/config"
 	"github.com/clearlinux/mixer-tools/helpers"
 	"github.com/pkg/errors"
 
@@ -132,9 +131,6 @@ var buildUpstreamFormatCmd = &cobra.Command{
 
 		for bumpNeeded {
 			cmdToRun := strings.Split("mixer build format-bump new", " ")
-			if config.UseNewConfig {
-				cmdToRun = append(cmdToRun, "--new-config")
-			}
 			if err = b.RunCommandInContainer(cmdToRun); err != nil {
 				fail(err)
 			}
@@ -147,9 +143,6 @@ var buildUpstreamFormatCmd = &cobra.Command{
 				fail(err)
 			}
 			cmdToRun = strings.Split("mixer build format-bump old", " ")
-			if config.UseNewConfig {
-				cmdToRun = append(cmdToRun, "--new-config")
-			}
 			if err = b.RunCommandInContainer(cmdToRun); err != nil {
 				fail(err)
 			}
@@ -178,16 +171,10 @@ var buildFormatBumpCmd = &cobra.Command{
 			fail(err)
 		}
 		cmdToRun := strings.Split("mixer build format-bump new", " ")
-		if config.UseNewConfig {
-			cmdToRun = append(cmdToRun, "--new-config")
-		}
 		if err := b.RunCommandInContainer(cmdToRun); err != nil {
 			fail(err)
 		}
 		cmdToRun = strings.Split("mixer build format-bump old", " ")
-		if config.UseNewConfig {
-			cmdToRun = append(cmdToRun, "--new-config")
-		}
 		if err := b.RunCommandInContainer(cmdToRun); err != nil {
 			fail(err)
 		}

--- a/mixer/cmd/config.go
+++ b/mixer/cmd/config.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"github.com/clearlinux/mixer-tools/config"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -74,9 +73,6 @@ var configSetCmd = &cobra.Command{
 	the existence of the provided property, but will not validate the value provided.`,
 	Args: cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		if !config.UseNewConfig {
-			fail(errors.New("config set requires `--new-config` flag`"))
-		}
 		var mc config.MixConfig
 		if err := mc.LoadConfig(configFile); err != nil {
 			fail(err)

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/clearlinux/mixer-tools/builder"
-	"github.com/clearlinux/mixer-tools/config"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -233,7 +232,9 @@ func init() {
 	_ = RootCmd.Flags().MarkDeprecated("new-swupd", "new functionality is now the standard behavior, this flag is obsolete and no longer used")
 
 	// TODO: Remove this once we drop the old config format
-	RootCmd.PersistentFlags().BoolVar(&config.UseNewConfig, "new-config", true, "Set this property to false to use the old INI config format. Ignored for all commands but 'init'")
+	RootCmd.PersistentFlags().BoolVar(&unusedBoolFlag, "new-config", true, "")
+	_ = RootCmd.Flags().MarkHidden("new-config")
+	_ = RootCmd.Flags().MarkDeprecated("new-config", "The config file is now automatically converted and the new format is always used")
 
 	RootCmd.PersistentFlags().BoolVar(&builder.Native, "native", false, "Run mixer command on native host instead of in a container")
 	RootCmd.PersistentFlags().BoolVar(&builder.Offline, "offline", false, "Skip caching upstream-bundles; work entirely with local-bundles")

--- a/mixin/root_cmd.go
+++ b/mixin/root_cmd.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/clearlinux/mixer-tools/config"
 	"github.com/spf13/cobra"
 )
 
@@ -36,7 +35,6 @@ var RootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	config.UseNewConfig = true
 	if err := RootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
This patch introduces automatic config conversion, which will update all users to the latest version of mixer config. With this, we can also get rid of the INI config (we only keep the parser to be able to convert from it).

In order to keep config cleaner, all the conversion code now lives in the new config_convert.go file. This way there is no code referencing the old INI config in config.go anymore, nor any conditional branching to handle different versions of the config. 

I also added bat tests to check for the special conversion cases and to test conversion from all older versions.
