### PR TITLE
builder: Fix URL build for base URL with subpath

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -171,17 +172,16 @@ func (b *Builder) getLatestUpstreamVersion() (string, error) {
 // buildUpstreamURL builds the full upstream URL based on a b.UpstreamURL and a
 // supplied subpath
 func (b *Builder) buildUpstreamURL(subpath string) (string, error) {
-	// Build the URL
-	end, err := url.Parse(subpath)
-	if err != nil {
-		return "", err
-	}
 	base, err := url.Parse(b.UpstreamURL)
 	if err != nil {
 		return "", err
 	}
 
-	return base.ResolveReference(end).String(), nil
+	for _, token := range strings.Split(subpath, "/") {
+		base.Path = path.Join(base.Path, token)
+	}
+
+	return base.String(), nil
 }
 
 // DownloadFileFromUpstreamAsString will download a file from the Upstream URL


### PR DESCRIPTION
When building the upstream URL, if the `b.UpstreamURL` was set do a url
with a subpath included, the subpath was being discarded by
`URL.ResolveReference()`. In order to preserve the subpath in the base,
the provided subpath must be manually added to the base URL object.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>