### PR TITLE
Revert "helpers: Reduce download timeout"

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -365,10 +365,7 @@ func ListVisibleFiles(dirname string) ([]string, error) {
 }
 
 func getDownloadFileReader(url string) (*io.ReadCloser, error) {
-	httpClient := http.Client{
-		Timeout: time.Duration(10 * time.Second),
-	}
-	resp, err := httpClient.Get(url)
+	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This reverts commit 9cf854d8d6e45dcb087c0bf4f61bfc633c16e43b.

The reduction to the timeout has caused failures for users on slow
networks, so this must be reverted to the default values.

The reduction to the timeout was added to improve user experience when
connection failed due to a proxy error. It would take mixer too long to
fail and the error message didn't indicate what the problem could be.

The error is now properly indicated, so even if it takes a while for the
error to occur the first time, the user should be able to identify the
problem on the spot.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>