### PR TITLE
cmd: Skip format bump check if running offline

### DIFF
--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -119,11 +119,13 @@ var RootCmd = &cobra.Command{
 				}
 				return nil
 			}
-			if bumpNeeded, err := b.CheckBumpNeeded(false); err != nil {
-				return err
-			} else if bumpNeeded {
-				cancelRun(cmd)
-				return nil
+			if !builder.Offline {
+				if bumpNeeded, err := b.CheckBumpNeeded(false); err != nil {
+					return err
+				} else if bumpNeeded {
+					cancelRun(cmd)
+					return nil
+				}
 			}
 
 			// If Native==false


### PR DESCRIPTION
Format bump check requires fetching format for current upstream which
cannot be done if there is no network available. If `--offline` flag is
provided, this check must be skipped.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>