### PR TITLE
cmd: Never check is bump needed with --offline

### DIFF
--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -111,19 +111,22 @@ var RootCmd = &cobra.Command{
 		// If so: inform, stage, and exit.
 		// If not: run command in container and cancel pre-run
 		if !cmdContains(cmd, "format-bump") && !cmdContains(cmd, "upstream-format") && cmdContains(cmd, "build") && !cmdContains(cmd, "image") {
-			// --offline=true AND --native=false, try to see if container exists
-			if builder.Offline && !builder.Native {
-				fmt.Println("Warning: Unable to determine upstream format in --offline mode, build may fail if building across format boundaries.")
-				if err := b.RunCommandInContainer(reconstructCommand(cmd, args)); err != nil {
-					fail(err)
+			if builder.Offline {
+				// --offline=true AND --native=false, try to see if container exists
+				if !builder.Native {
+					fmt.Println("Warning: Unable to determine upstream format in --offline mode, build may fail if building across format boundaries.")
+					if err := b.RunCommandInContainer(reconstructCommand(cmd, args)); err != nil {
+						fail(err)
+					}
+					return nil
 				}
-				return nil
-			}
-			if bumpNeeded, err := b.CheckBumpNeeded(false); err != nil {
-				return err
-			} else if bumpNeeded {
-				cancelRun(cmd)
-				return nil
+			} else {
+				if bumpNeeded, err := b.CheckBumpNeeded(false); err != nil {
+					return err
+				} else if bumpNeeded {
+					cancelRun(cmd)
+					return nil
+				}
 			}
 
 			// If Native==false


### PR DESCRIPTION
Whenever the --offline flag is provided mixer will be unable to fetch
version information from upstream, so this check must be skipped.
This patch fixes an issues where mixer would try to connect during
`build bundles` step even when --offline flag was provided.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>