### PR TITLE
builder: Use same commenting rules for package file and bundles

### DIFF
--- a/builder/bundleset.go
+++ b/builder/bundleset.go
@@ -216,28 +216,38 @@ func validateBundle(b *bundle) error {
 // names to be converted to one-package bundles (pundles). Returns a map of package
 // names found in the file.
 func parsePackageBundleFile(filename string) (map[string]bool, error) {
-	packages := make(map[string]bool)
 	contents, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
 
-	pundleList := strings.Split(string(contents), "\n")
-	for _, p := range pundleList {
-		if len(p) == 0 {
-			// skip empty lines
-			continue
+	return parsePackageBundle(contents), nil
+}
+
+func parsePackageBundle(contents []byte) map[string]bool {
+	packages := make(map[string]bool)
+	scanner := bufio.NewScanner(bytes.NewReader(contents))
+
+	for scanner.Scan() {
+		p := scanner.Text()
+
+		// Drop comments.
+		comment := strings.Index(p, "#")
+		if comment > -1 {
+			p = p[:comment]
 		}
 
-		if p[0] == '#' {
-			// skip comments
+		p = strings.TrimSpace(p)
+
+		// Skip empty lines.
+		if len(p) == 0 {
 			continue
 		}
 
 		packages[p] = true
 	}
 
-	return packages, nil
+	return packages
 }
 
 // newBundleFromPackage creates a new bundle from a package name p

--- a/builder/bundleset_test.go
+++ b/builder/bundleset_test.go
@@ -445,3 +445,44 @@ func TestParseBundleSet(t *testing.T) {
 		}
 	}
 }
+
+func TestParseBundlePackages(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			"Simple",
+			"a\nb\nc\n",
+			[]string{"a", "b", "c"},
+		},
+		{
+			"Trim spaces, ignore empty lines",
+			" a \n\n\n\tb\t\nc   \n\n    \n\n",
+			[]string{"a", "b", "c"},
+		},
+		{
+			"Comments are ignored",
+			`
+# comment
+a   # end of line comment
+    # nothing but a comment
+b
+c#omment`,
+			[]string{"a", "b", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		result := parsePackageBundle([]byte(tt.input))
+		for _, p := range tt.expected {
+			if !result[p] {
+				t.Errorf("in case %q missing package %q", tt.name, p)
+			}
+		}
+		if len(result) != len(tt.expected) {
+			t.Errorf("in case %q got %d packages, but want %d\n", tt.name, len(result), len(tt.expected))
+		}
+	}
+}


### PR DESCRIPTION
Make package file parsing ignore '#' and anything after that until the
end of the line.  Also trim spaces.

This makes the comment syntax the same as bundle files.