### PR TITLE
AFB: Add afb.sh script to outline format bump steps

### DIFF
--- a/afb.sh
+++ b/afb.sh
@@ -1,6 +1,28 @@
 #!/bin/bash
 
 ###############################################################################
+# FORMAT BUMPS
+#
+# A format defines a range of OS versions that have compatible update metadata
+# and content. An update client can update a system from the oldest version in
+# the format to the latest version in the format without worrying about
+# compatibility issues in the update content for the version it is updating to.
+#
+# A format bump occurs when the update metadata or content is changed in such a
+# way that will cause client updates to break. In this case the format number
+# must be incremented so clients will not attempt to update to the new versions
+# in the new format without crossing the format boundary. Update clients update
+# only to the latest build in their format. Once that update is complete the
+# update client may then update forward again because the last version in the
+# current format has identical content to the first version in the new format,
+# including the new update client needed to understand the new format.
+#
+# Clients must be able to update to the latest version in their format using
+# the update metadata it understands. Once it is on that version it should also
+# be on the new format. To achieve this the following steps must be taken.
+###############################################################################
+
+###############################################################################
 # test setup
 ###############################################################################
 

--- a/afb.sh
+++ b/afb.sh
@@ -58,8 +58,8 @@ mixer build update --native
 # content relevant to the format bump to the mash to be used. Relevant content
 # should be the only change.
 #
-# Using original mixer for this build (may have to check out pre-format-bump
-# version)
+# mixer will create manifests and update content based on the format it is
+# building for. The format is set in the mixer.state file.
 ###############################################################################
 
 # update mixer to build version 20, which in our case is the +10
@@ -90,7 +90,8 @@ mixer build update --native
 # +20
 #
 # This is the first build in the new format. The content is the same as the +10
-# but the manifests might be created differently using new mixer.
+# but the manifests might be created differently if a new manifest template is
+# defined for the new format.
 ###############################################################################
 
 # update mixer to build version 30, which in our case is the +20

--- a/afb.sh
+++ b/afb.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+###############################################################################
+# test setup
+###############################################################################
+
+# test workspace
+mkdir afb-test
+pushd afb-test
+
+# init minimal mix with original format
+mixer init --no-default-bundles --format 1
+# create bundle to be deleted
+mixer bundle edit foo --suppress-editor
+# mark as deleted
+sed -i "s/\(# \[STATUS\]:\).*/\1 Deprecated/" local-bundles/foo
+# add minimal bundles including deleted bundle
+mixer bundle add os-core os-core-update foo
+
+###############################################################################
+# +0
+#
+# This is the last normal build in the original format. When doing a format
+# bump this build already exists. Building it now because the test needs a
+# normal starting version.
+###############################################################################
+
+# build bundles and updates regularly
+mixer build bundles --native
+mixer build update --native
+
+###############################################################################
+# +10
+#
+# This is the last build in the original format. At this point add ONLY the
+# content relevant to the format bump to the mash to be used. Relevant content
+# should be the only change.
+#
+# Using original mixer for this build (may have to check out pre-format-bump
+# version)
+###############################################################################
+
+# update mixer to build version 20, which in our case is the +10
+mixer versions update --mix-version 20
+# build bundles normally. At this point the bundles to be deleted should still
+# be part of the mixbundles list and the groups.ini
+mixer build bundles --native
+# remove all deleted bundles' content by replacing bundle-info files with empty
+# directories. This causes mixer to fall back to reading content for those
+# bundles from a chroot. The chroots for these bundles will be empty.
+for i in $(grep -lir "\[STATUS\]: Deprecated" upstream-bundles/ local-bundles/); do
+	b=$(basename $i)
+	rm -f update/image/20/$b-info; mkdir update/image/20/$b
+done
+# Replace the +10 version in /usr/lib/os-release with +20 version and write the
+# new format to the format file on disk.  This is so clients will already be on
+# the new format when they update to the +10 because the content is the same as
+# the +20.
+sed -i 's/\(VERSION_ID=\).*/\130/' update/image/20/full/usr/lib/os-release
+echo 2 > update/image/20/full/usr/share/defaults/swupd/format
+# build update based on the modified bundle information. This is *not* a
+# minversion and these manifests must be built with the mixer from the original
+# format (if manifest format changes).
+mixer build update --native
+
+
+###############################################################################
+# +20
+#
+# This is the first build in the new format. The content is the same as the +10
+# but the manifests might be created differently using new mixer.
+###############################################################################
+
+# update mixer to build version 30, which in our case is the +20
+mixer versions update --mix-version 30
+# update mixer.state to new format
+sed -i 's/\(FORMAT\).*/\1 = "2"/' mixer.state
+# Fully remove deleted bundles from groups.ini and mixbundles list. This will
+# cause the deprecated bundles to be removed from the MoM entirely. This will
+# not break users who had these bundles because the removed content in the +10
+# caused the bundles to be dropped from client systems at that point.
+for i in $(grep -lir "\[STATUS\]: Deprecated" upstream-bundles/ local-bundles/); do
+	b=$(basename $i)
+	mixer bundle remove $b; sed -i "/\[$b\]/d;/group=$b/d" update/groups.ini;
+done
+# link the +10 bundles to the +20 so we are building the update with the same
+# underlying content. The only things that might change are the manifests
+# (potentially the pack and full-file formats as well, though this is very
+# rare).
+cp -al update/image/20 update/image/30
+# build an update as a minversion, this is the first build where the manifests
+# identify as the new format
+mixer build update --native --min-version 30

--- a/bat/lib/mixerlib.bash
+++ b/bat/lib/mixerlib.bash
@@ -48,6 +48,10 @@ mixer-build-update() {
   sudo -E mixer $MIXARGS build update --config $BATS_TEST_DIRNAME/builder.conf --native=true
 }
 
+mixer-build-update-minversion() {
+  sudo -E mixer $MIXARGS build update --config $BATS_TEST_DIRNAME/builder.conf --native=true --min-version $1
+}
+
 mixer-build-all() {
   sudo -E mixer $MIXARGS build all --config $BATS_TEST_DIRNAME/builder.conf --native=true
 }
@@ -66,7 +70,7 @@ mixer-add-rpms() {
 }
 
 create-empty-local-bundle() {
-  touch $LOCAL_BUNDLE_DIR/$1
+  mixer bundle edit $1 --suppress-editor
 }
 
 add-package-to-local-bundle() {

--- a/bat/tests/08-manual-format-bump-flow/Makefile
+++ b/bat/tests/08-manual-format-bump-flow/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/08-manual-format-bump-flow/description.txt
+++ b/bat/tests/08-manual-format-bump-flow/description.txt
@@ -1,0 +1,4 @@
+08-manual-format-bump-flow
+=================================
+This test creates a format bump using a manual process (not auto-format-bump)
+and checks that all output is correct.

--- a/bat/tests/08-manual-format-bump-flow/run.bats
+++ b/bat/tests/08-manual-format-bump-flow/run.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  global_setup
+}
+
+@test "Perform manual format bump with simplified process" {
+  mixer-init-stripped-down $CLRVER 10
+  sed -i 's/\(FORMAT\).*/\1 = "1"/' mixer.state
+
+  # create bundle to be deleted
+  create-empty-local-bundle "foo"
+  # mark as deleted
+  sed -i "s/\(# \[STATUS\]:\).*/\1 Deprecated/" local-bundles/foo
+  # add foo bundle to mix
+  mixer-bundle-add "foo"
+
+  ###############################################################################
+  # +0
+  #
+  # This is the last normal build in the original format. When doing a format
+  # bump this build already exists. Building it now because the test needs a
+  # normal starting version.
+  ###############################################################################
+
+  # build bundles and updates regularly
+  mixer-build-bundles > $LOGDIR/build_bundles10.log
+  mixer-build-update > $LOGDIR/build_update10.log
+
+  ###############################################################################
+  # +10
+  #
+  # This is the last build in the original format. At this point add ONLY the
+  # content relevant to the format bump to the mash to be used. Relevant content
+  # should be the only change.
+  #
+  # mixer will create manifests and update content based on the format it is
+  # building for. The format is set in the mixer.state file.
+  ###############################################################################
+
+  # update mixer to build version 20, which in our case is the +10
+  mixer-versions-update 20
+  # build bundles normally. At this point the bundles to be deleted should still
+  # be part of the mixbundles list and the groups.ini
+  mixer-build-bundles > $LOGDIR/build_bundles20.log
+  # remove all deleted bundles' content by replacing bundle-info files with empty
+  # directories. This causes mixer to fall back to reading content for those
+  # bundles from a chroot. The chroots for these bundles will be empty.
+  for i in $(grep -lir "\[STATUS\]: Deprecated" local-bundles/); do
+    b=$(basename $i)
+    sudo rm -f update/image/20/$b-info; sudo mkdir update/image/20/$b
+  done
+  # Replace the +10 version in /usr/lib/os-release with +20 version and write the
+  # new format to the format file on disk.  This is so clients will already be on
+  # the new format when they update to the +10 because the content is the same as
+  # the +20.
+  sudo sed -i 's/\(VERSION_ID=\).*/\130/' update/image/20/full/usr/lib/os-release
+  echo 2 | sudo tee update/image/20/full/usr/share/defaults/swupd/format
+  # build update based on the modified bundle information. This is *not* a
+  # minversion and these manifests must be built with the mixer from the original
+  # format (if manifest format changes).
+  mixer-build-update > $LOGDIR/build_update20.log
+
+  # validate the +10 build
+  # MoM is the correct format
+  grep -P "MANIFEST\t1" update/www/20/Manifest.MoM
+  # bundle to be deleted still exists in the +10
+  grep -P "20\tfoo" update/www/20/Manifest.MoM
+  # deprecated bundle contains only one deleted file
+  grep -P "00000000000\t20\t/usr/share/clear/bundles/foo" update/www/20/Manifest.foo
+
+  ###############################################################################
+  # +20
+  #
+  # This is the first build in the new format. The content is the same as the +10
+  # but the manifests might be created differently if a new manifest template is
+  # defined for the new format.
+  ###############################################################################
+
+  # update mixer to build version 30, which in our case is the +20
+  mixer-versions-update 30
+  # update mixer.state to new format
+  sudo sed -i 's/\(FORMAT\).*/\1 = "2"/' mixer.state
+  # Fully remove deleted bundles from groups.ini and mixbundles list. This will
+  # cause the deprecated bundles to be removed from the MoM entirely. This will
+  # not break users who had these bundles because the removed content in the +10
+  # caused the bundles to be dropped from client systems at that point.
+  for i in $(grep -lir "\[STATUS\]: Deprecated" upstream-bundles/ local-bundles/); do
+    b=$(basename $i)
+    mixer-bundle-remove $b; sudo sed -i "/\[$b\]/d;/group=$b/d" update/groups.ini;
+  done
+  # link the +10 bundles to the +20 so we are building the update with the same
+  # underlying content. The only things that might change are the manifests
+  # (potentially the pack and full-file formats as well, though this is very
+  # rare).
+  sudo cp -al update/image/20 update/image/30
+  # build an update as a minversion, this is the first build where the manifests
+  # identify as the new format
+  mixer-build-update-minversion 30
+
+  # validate the +20 build
+  grep -P "MANIFEST\t2" update/www/30/Manifest.MoM
+  grep -v "foo" update/www/30/Manifest.MoM
+  test ! -f update/www/30/Manifest.foo
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
This script is intended as a reference and architecture document for a
new format bump flow. This format bump flow is much simpler than the
original/current flow which requires jumping back and forth between the
+20 and +10 builds to create the updates.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>