### PR TITLE
swupd: do not update delete versions over minversions

### DIFF
--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -400,8 +400,8 @@ func TestCreateManifestsMVDeletes(t *testing.T) {
 	// now create a minversion and make sure the deletes persist
 	ts.MinVersion = 30
 	ts.createManifests(30)
-	fileDeletedInManifest(t, ts.parseManifest(30, "test-bundle"), 30, "/foo")
-	fileDeletedInManifest(t, ts.parseManifest(30, "full"), 30, "/foo")
+	fileDeletedInManifest(t, ts.parseManifest(30, "test-bundle"), 20, "/foo")
+	fileDeletedInManifest(t, ts.parseManifest(30, "full"), 20, "/foo")
 }
 
 func TestCreateManifestsFormatDeletes(t *testing.T) {

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -420,12 +420,6 @@ func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, minVersion uint32) 
 			// file
 			if !of.Present() {
 				if of.Status == StatusDeleted && m.Header.Format == oldManifest.Header.Format {
-					// copy over old deleted files
-					// append as-is
-					if of.Version < minVersion {
-						// set delete to minVersion
-						of.Version = minVersion
-					}
 					m.Files = append(m.Files, of)
 				}
 				ox++


### PR DESCRIPTION
Fixes #455
Minversions should not update deleted files to the minversion as this
may cause swupd to attempt to delete content twice. This exacerbates
issues where a directory (/usr/local/bin) was mistakenly deleted in a
version because it was mistakenly added earlier. Updating the delete to
the minversion then causes the directory to be deleted off the client
system again.