### PR TITLE
swupd: increase test coverage

### DIFF
--- a/swupd/archive_test.go
+++ b/swupd/archive_test.go
@@ -1,0 +1,115 @@
+package swupd
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewCompressedTarReaderUncompressedRegularFile(t *testing.T) {
+	testCases := []string{
+		"/etc/protocols",
+		"/usr/share/defaults/etc/protocols",
+		"/usr/share/doc/systemd/LICENSE.GPL2",
+	}
+	for _, tc := range testCases {
+		var f *os.File
+		var err error
+		if f, err = os.Open(tc); err != nil {
+			// not checking non-existent files
+			// not testing the os.Open call
+			continue
+		}
+		defer func() {
+			_ = f.Close()
+		}()
+		_, err = NewCompressedTarReader(f)
+		if err != nil {
+			t.Errorf("NewCompressedTarReader returned error %v for uncompressed regular file %s",
+				err, tc)
+		}
+	}
+}
+
+func TestNewCompressedTarReaderBzip2(t *testing.T) {
+	// create origin uncompressed file
+	f, err := ioutil.TempFile("", "bzip2test")
+	if err != nil {
+		t.Fatalf("couldn't create test file")
+	}
+	defer func() {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+	}()
+	// write data to test file
+	if _, err = f.Write([]byte("testdata\ntestmoredata")); err != nil {
+		t.Fatalf("couldn't write to test file")
+	}
+
+	// need unique name for tar file, so create now
+	tarf, err := ioutil.TempFile("", "bzip2testtar*.tar")
+	if err != nil {
+		t.Fatalf("couldn't create test tar")
+	}
+	defer func() {
+		_ = tarf.Close()
+		_ = os.Remove(tarf.Name())
+	}()
+
+	// tarRegularFullfile needs a FileInfo on the origin file
+	fi, err := os.Lstat(f.Name())
+	if err != nil {
+		t.Fatalf("couldn't get file info for test file: %s", err)
+	}
+
+	// tar the origin file, result is an uncompressed tar archive
+	if err = tarRegularFullfile(tarf, f.Name(), filepath.Base(tarf.Name()), fi); err != nil {
+		t.Fatalf("unable to tar a regular fullfile for test: %s", err)
+	}
+
+	// create the output compressed tar file
+	out, err := ioutil.TempFile("", "bzip2testCompressed*.tar")
+	if err != nil {
+		t.Fatalf("Couldn't create test compressed tarfile")
+	}
+	defer func() {
+		_ = out.Close()
+		_ = os.Remove(out.Name())
+	}()
+
+	// select external-bzip2 compressor
+	var compressor compressFunc
+	for _, fc := range fullfileCompressors {
+		if fc.Name == "external-bzip2" {
+			compressor = fc.Func
+			break
+		}
+	}
+	if compressor == nil {
+		t.Fatalf("unable to find bzip2 compression function")
+	}
+
+	// compress using bzip2
+	if err := compressor(out, f); err != nil {
+		t.Fatalf("failed to compress %s using bzip2", f.Name())
+	}
+
+	// need to seek back to the beginning to uncompress
+	if _, err := out.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("unable to seek to start of fullfile")
+	}
+
+	// test NewCompressedTarReader
+	if _, err := NewCompressedTarReader(out); err != nil {
+		t.Errorf("NewCompressedTarReader unable to uncompress bzip2 file: %s", err)
+	}
+}
+
+func TestCompressedTarReaderCloseNil(t *testing.T) {
+	ctr := CompressedTarReader{}
+	if ctr.Close() != nil {
+		t.Error("expected nil return with undefined close")
+	}
+}

--- a/swupd/fullchroot_test.go
+++ b/swupd/fullchroot_test.go
@@ -1,0 +1,28 @@
+package swupd
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSyncToFull(t *testing.T) {
+	d, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal("couldn't create test directory")
+	}
+
+	if err = os.MkdirAll(filepath.Join(d, "10/testbundle/test"), 0755); err != nil {
+		t.Fatal("couldn't create bundle test directory")
+	}
+
+	if err = syncToFull(10, "testbundle", d); err != nil {
+		t.Errorf("syncToFull failed with valid input: %s", err)
+	}
+
+	if _, err = os.Stat(filepath.Join(d, "10/full/test")); err != nil {
+		t.Errorf("syncToFull failed to sync test file to full chroot: %s", err)
+	}
+
+}

--- a/swupd/fullfiles.go
+++ b/swupd/fullfiles.go
@@ -26,7 +26,7 @@ import (
 )
 
 // debugFullfiles is a flag to turn on debug statements for fullfile creation.
-const debugFullfiles = false
+var debugFullfiles = false
 
 type compressFunc func(dst io.Writer, src io.Reader) error
 

--- a/swupd/fullfiles_test.go
+++ b/swupd/fullfiles_test.go
@@ -132,6 +132,82 @@ func TestCreateFullfiles(t *testing.T) {
 	}
 }
 
+func TestCreateFullfilesErrorPaths(t *testing.T) {
+	if _, err := CreateFullfiles(nil, "/tmp/bogusdir", "/tmp/bogusdir", 1); err == nil {
+		t.Error("CreateFullfiles did not return error on bogus chroot directory")
+	}
+}
+
+func TestCreateDirectoryFullfileErrorPaths(t *testing.T) {
+	if err := createDirectoryFullfile("bogusfile", "bogus", "bogus", nil); err == nil {
+		t.Error("createDirectoryFullfile did not return error on bogus file")
+	}
+
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal("couldn't create test file")
+	}
+	defer func() {
+		_ = os.Remove(f.Name())
+	}()
+
+	if err := createDirectoryFullfile(f.Name(), f.Name(), "bogus", nil); err == nil {
+		t.Error("createDirectoryFullfile did not return error on regular file")
+	}
+}
+
+func TestCreateLinkFullfileErrorPaths(t *testing.T) {
+	if err := createLinkFullfile("bogusfile", "bogus", "bogus", nil); err == nil {
+		t.Error("createLinkFullfile did not return error on bogus file")
+	}
+
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal("couldn't create test file")
+	}
+	defer func() {
+		_ = os.Remove(f.Name())
+	}()
+
+	if err := createLinkFullfile(f.Name(), f.Name(), "bogus", nil); err == nil {
+		t.Error("createLinkFullfile did not return error on regular file")
+	}
+}
+
+func TestCreateRegularFullfileErrorPaths(t *testing.T) {
+	debugFullfiles = true
+	if err := createRegularFullfile("bogusfile", "bogus", "bogus", nil); err == nil {
+		t.Error("createRegularFullfile did not return error on bogus file")
+	}
+
+	d, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal("couldn't create test directory")
+	}
+	defer func() {
+		_ = os.RemoveAll(d)
+	}()
+
+	if err := createRegularFullfile(d, "bogus", "bogus", nil); err == nil {
+		t.Error("createRegularFullfile did not return error on directory")
+	}
+}
+
+func TestTarRegularFullfileErrorPaths(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal("couldn't create test file")
+	}
+	defer func() {
+		_ = os.Remove(f.Name())
+	}()
+
+	var fi os.FileInfo
+	if err = tarRegularFullfile(f, "test", "test", fi); err == nil {
+		t.Error("tarRegularFullfile did not return error on invalid fileinfo")
+	}
+}
+
 func mustHaveMatchingHash(t *testing.T, path string) {
 	t.Helper()
 	expectedHash := filepath.Base(path)

--- a/swupd/packs.go
+++ b/swupd/packs.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 )
 
-const debugPacks = false
+var debugPacks = false
 
 // PackState describes whether and how a file was packed.
 type PackState int


### PR DESCRIPTION
Improves test coverage for following files:
* archive.go up to >80%
* manifest_format.go to 100%
* packs.go up to >85%
* fullfiles.go up to >80%
* fullchroot.go add explicit test
Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>