### PR TITLE
'mixer config' improvements

### DIFF
--- a/bat/tests/09-config/Makefile
+++ b/bat/tests/09-config/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/09-config/description.txt
+++ b/bat/tests/09-config/description.txt
@@ -1,0 +1,4 @@
+09-config
+===================
+This test reproduces usage scenarios for `mixer config` subcommand.
+It tests the setter and getter on both the config and the state file.

--- a/bat/tests/09-config/run.bats
+++ b/bat/tests/09-config/run.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  global_setup
+}
+
+@test "test config setter and getter" {
+  mixer-init-stripped-down $CLRVER 10
+
+  # Setter and getter on builder.conf
+  mixer config set Swupd.BUNDLE test-bundle
+  bundle=$(mixer config get Swupd.BUNDLE)
+  test $bundle = "test-bundle"
+
+  # Setter and Getter on mixer.state
+  mixer config set Mix.FORMAT 99
+  format=$(mixer config get Mix.FORMAT)
+  test $format -eq 99
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/config/base.go
+++ b/config/base.go
@@ -1,0 +1,81 @@
+// Copyright © 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// BaseConfig is a generic interface for TOML configs in mixer
+type BaseConfig interface {
+	Save() error
+}
+
+// SetProperty parses a property in the format "Section.Property", finds and sets it within the
+// config structure and saves the config file.
+func SetProperty(bc BaseConfig, propertyStr string, value string) error {
+	tokens := strings.Split(propertyStr, ".")
+	property, sections := tokens[len(tokens)-1], tokens[:len(tokens)-1]
+
+	sectionV := reflect.ValueOf(bc).Elem()
+	for i := 0; i < len(sections); i++ {
+		sectionV = sectionV.FieldByName(sections[i])
+
+		if !sectionV.IsValid() {
+			return fmt.Errorf("Unknown config sectionV: '%s'", tokens[i])
+		}
+	}
+
+	sectionT := reflect.TypeOf(sectionV.Interface())
+	for i := 0; i < sectionV.NumField(); i++ {
+		tag, ok := sectionT.Field(i).Tag.Lookup("toml")
+
+		if ok && tag == property {
+			sectionV.Field(i).SetString(value)
+			return bc.Save()
+		}
+	}
+
+	return fmt.Errorf("Property not found in config file: '%s'", property)
+}
+
+// GetProperty parses a property in the format Section.Property, finds the property and returns its
+// current value
+func GetProperty(bc BaseConfig, propertyStr string) (string, error) {
+	tokens := strings.Split(propertyStr, ".")
+	property, sections := tokens[len(tokens)-1], tokens[:len(tokens)-1]
+
+	sectionV := reflect.ValueOf(bc).Elem()
+	for i := 0; i < len(sections); i++ {
+		sectionV = sectionV.FieldByName(sections[i])
+
+		if !sectionV.IsValid() {
+			return "", fmt.Errorf("Unknown config sectionV: '%s'", tokens[i])
+		}
+	}
+
+	sectionT := reflect.TypeOf(sectionV.Interface())
+	for i := 0; i < sectionV.NumField(); i++ {
+		tag, ok := sectionT.Field(i).Tag.Lookup("toml")
+
+		if ok && tag == property {
+			return sectionV.Field(i).String(), nil
+		}
+	}
+
+	return "", fmt.Errorf("Property not found in config file: '%s'", property)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -185,6 +185,33 @@ func (config *MixConfig) SetProperty(propertyStr string, value string) error {
 	return errors.Errorf("Property not found in config file: '%s'", property)
 }
 
+// GetProperty parse a property in the format Section.Property, finds the property and returns its
+// current value
+func (config *MixConfig) GetProperty(propertyStr string) (string, error) {
+	tokens := strings.Split(propertyStr, ".")
+	property, sections := tokens[len(tokens)-1], tokens[:len(tokens)-1]
+
+	sectionV := reflect.ValueOf(config).Elem()
+	for i := 0; i < len(sections); i++ {
+		sectionV = sectionV.FieldByName(sections[i])
+
+		if !sectionV.IsValid() {
+			return "", errors.Errorf("Unknown config sectionV: '%s'", tokens[i])
+		}
+	}
+
+	sectionT := reflect.TypeOf(sectionV.Interface())
+	for i := 0; i < sectionV.NumField(); i++ {
+		tag, ok := sectionT.Field(i).Tag.Lookup("toml")
+
+		if ok && tag == property {
+			return sectionV.Field(i).String(), nil
+		}
+	}
+
+	return "", errors.Errorf("Property not found in config file: '%s'", property)
+}
+
 // LoadConfig loads a configuration file from a provided path or from local directory
 // is none is provided
 func (config *MixConfig) LoadConfig(filename string) error {

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/pkg/errors"
@@ -130,11 +129,11 @@ func (config *MixConfig) CreateDefaultConfig(localrpms bool) error {
 		return err
 	}
 
-	return config.SaveConfig()
+	return config.Save()
 }
 
-// SaveConfig saves the properties in MixConfig to a TOML config file
-func (config *MixConfig) SaveConfig() error {
+// Save saves the properties in MixConfig to a TOML config file
+func (config *MixConfig) Save() error {
 	var buffer bytes.Buffer
 	buffer.Write([]byte("#VERSION " + config.version + "\n\n"))
 
@@ -155,61 +154,6 @@ func (config *MixConfig) SaveConfig() error {
 	_, err = buffer.WriteTo(w)
 
 	return err
-}
-
-// SetProperty parse a property in the format "Section.Property", finds and sets it within the
-// config structure and saves the config file.
-func (config *MixConfig) SetProperty(propertyStr string, value string) error {
-	tokens := strings.Split(propertyStr, ".")
-	property, sections := tokens[len(tokens)-1], tokens[:len(tokens)-1]
-
-	sectionV := reflect.ValueOf(config).Elem()
-	for i := 0; i < len(sections); i++ {
-		sectionV = sectionV.FieldByName(sections[i])
-
-		if !sectionV.IsValid() {
-			return errors.Errorf("Unknown config sectionV: '%s'", tokens[i])
-		}
-	}
-
-	sectionT := reflect.TypeOf(sectionV.Interface())
-	for i := 0; i < sectionV.NumField(); i++ {
-		tag, ok := sectionT.Field(i).Tag.Lookup("toml")
-
-		if ok && tag == property {
-			sectionV.Field(i).SetString(value)
-			return config.SaveConfig()
-		}
-	}
-
-	return errors.Errorf("Property not found in config file: '%s'", property)
-}
-
-// GetProperty parse a property in the format Section.Property, finds the property and returns its
-// current value
-func (config *MixConfig) GetProperty(propertyStr string) (string, error) {
-	tokens := strings.Split(propertyStr, ".")
-	property, sections := tokens[len(tokens)-1], tokens[:len(tokens)-1]
-
-	sectionV := reflect.ValueOf(config).Elem()
-	for i := 0; i < len(sections); i++ {
-		sectionV = sectionV.FieldByName(sections[i])
-
-		if !sectionV.IsValid() {
-			return "", errors.Errorf("Unknown config sectionV: '%s'", tokens[i])
-		}
-	}
-
-	sectionT := reflect.TypeOf(sectionV.Interface())
-	for i := 0; i < sectionV.NumField(); i++ {
-		tag, ok := sectionT.Field(i).Tag.Lookup("toml")
-
-		if ok && tag == property {
-			return sectionV.Field(i).String(), nil
-		}
-	}
-
-	return "", errors.Errorf("Property not found in config file: '%s'", property)
 }
 
 // LoadConfig loads a configuration file from a provided path or from local directory

--- a/config/config_convert.go
+++ b/config/config_convert.go
@@ -96,7 +96,7 @@ func (config *MixConfig) convertCurrent() error {
 	// Set config to the current format
 	config.version = CurrentConfigVersion
 
-	return config.SaveConfig()
+	return config.Save()
 }
 
 func (config *MixConfig) convertLegacy() error {
@@ -121,7 +121,7 @@ func (config *MixConfig) convertLegacy() error {
 	// Set config to the current format
 	config.version = CurrentConfigVersion
 
-	return config.SaveConfig()
+	return config.Save()
 }
 
 func (config *MixConfig) convertFormat() error {

--- a/mixer/cmd/config.go
+++ b/mixer/cmd/config.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/clearlinux/mixer-tools/config"
 	"github.com/spf13/cobra"
 )
@@ -85,11 +87,34 @@ var configSetCmd = &cobra.Command{
 	},
 }
 
+var configGetCmd = &cobra.Command{
+	Use:   "get <property>",
+	Short: "Get a property in the config file",
+	Long: `This command will parse the provided property in the format 'Section.Property'
+	and return its value. The value returned is the value used by mixer, which will be
+	either the value set in the config file or the default value if the property has not
+	been defined in the file.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		var mc config.MixConfig
+		if err := mc.LoadConfig(configFile); err != nil {
+			fail(err)
+		}
+
+		if value, err := mc.GetProperty(args[0]); err != nil {
+			fail(err)
+		} else {
+			fmt.Println(value)
+		}
+	},
+}
+
 // List of all config commands
 var configCmds = []*cobra.Command{
 	configValidateCmd,
 	configConvertCmd,
 	configSetCmd,
+	configGetCmd,
 }
 
 func init() {

--- a/mixer/cmd/config.go
+++ b/mixer/cmd/config.go
@@ -75,7 +75,7 @@ var configSetCmd = &cobra.Command{
 			return err
 		}
 
-		return mc.SetProperty(args[0], args[1])
+		return config.SetProperty(&mc, args[0], args[1])
 	},
 }
 
@@ -93,7 +93,7 @@ var configGetCmd = &cobra.Command{
 			return err
 		}
 
-		if value, err := mc.GetProperty(args[0]); err != nil {
+		if value, err := config.GetProperty(&mc, args[0]); err != nil {
 			return err
 		} else {
 			fmt.Println(value)

--- a/mixer/cmd/config.go
+++ b/mixer/cmd/config.go
@@ -32,16 +32,13 @@ var configValidateCmd = &cobra.Command{
 	Short: "Parse a config file and print its properties",
 	Long: `Parse a builder config file and display its properties. Properties containing
 environment variables will be expanded`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		var mc config.MixConfig
 		if err := mc.LoadConfig(configFile); err != nil {
-			fail(err)
+			return err
 		}
 
-		if err := mc.Print(); err != nil {
-			fail(err)
-		}
-
+		return mc.Print()
 	},
 }
 
@@ -51,19 +48,17 @@ var configConvertCmd = &cobra.Command{
 	Long: `Convert an old config file to the new TOML format. The command will generate
 a backup file of the old config and will replace it with the converted one. Environment
 variables will not be expanded and the values will not be validated`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		/* If no state file exists, it must be created first to ensure the FORMAT value
 		is transferred from old configs before conversion */
 		var ms config.MixState
 		if err := ms.Load(); err != nil {
-			fail(err)
+			return err
 		}
 
 		var mc config.MixConfig
-		if err := mc.Convert(configFile); err != nil {
-			fail(err)
-		}
 
+		return mc.Convert(configFile)
 	},
 }
 
@@ -74,16 +69,13 @@ var configSetCmd = &cobra.Command{
 	assign the provided value and update the config file. The command will only validate
 	the existence of the provided property, but will not validate the value provided.`,
 	Args: cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		var mc config.MixConfig
 		if err := mc.LoadConfig(configFile); err != nil {
-			fail(err)
+			return err
 		}
 
-		if err := mc.SetProperty(args[0], args[1]); err != nil {
-			fail(err)
-		}
-
+		return mc.SetProperty(args[0], args[1])
 	},
 }
 
@@ -95,17 +87,19 @@ var configGetCmd = &cobra.Command{
 	either the value set in the config file or the default value if the property has not
 	been defined in the file.`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		var mc config.MixConfig
 		if err := mc.LoadConfig(configFile); err != nil {
-			fail(err)
+			return err
 		}
 
 		if value, err := mc.GetProperty(args[0]); err != nil {
-			fail(err)
+			return err
 		} else {
 			fmt.Println(value)
 		}
+
+		return nil
 	},
 }
 

--- a/mixin/helpers.go
+++ b/mixin/helpers.go
@@ -109,7 +109,7 @@ func setUpMixDir(upstreamVer, mixVer int) error {
 	c.Swupd.Bundle = "os-core"
 	c.Swupd.ContentURL = "file:///usr/share/mix/update/www"
 	c.Swupd.VersionURL = "file:///usr/share/mix/update/www"
-	if err = c.SaveConfig(); err != nil {
+	if err = c.Save(); err != nil {
 		return err
 	}
 	err = ioutil.WriteFile(filepath.Join(mixWS, "mixversion"),


### PR DESCRIPTION
This PR allows `mixer config` subcommand to also manipulate `mixer.state` file. It also adds a the `mixer config get ` subcommand to read values in the format `Section.Property`.