### PR TITLE
bundles: Fixes bundle edit issue (#448)

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -1130,7 +1130,7 @@ editLoop:
 		// Ignore return from command; parsing below is what will reveal errors
 		_ = helpers.RunCommandInput(os.Stdin, editorCmd, path)
 
-		err := validateBundleFile(path, BasicValidation)
+		err := validateBundleFile(path, BasicValidationIgnoreName)
 		if err == nil {
 			// Clean-up backup
 			if err = os.Remove(backup); err != nil {
@@ -1207,6 +1207,10 @@ func (b *Builder) EditBundles(bundles []string, suppressEditor bool, add bool, g
 	}
 
 	for _, bundle := range bundles {
+		if err = validateBundleFilename(bundle); err != nil {
+			fmt.Println(err)
+			continue
+		}
 		path, _ := b.getBundlePath(bundle)
 		if !b.isLocalBundle(path) {
 			localPath := filepath.Join(b.Config.Mixer.LocalBundleDir, bundle)

--- a/builder/bundleset.go
+++ b/builder/bundleset.go
@@ -128,15 +128,17 @@ type ValidationLevel int
 // Enum of available validation levels
 const (
 	BasicValidation ValidationLevel = iota
+	BasicValidationIgnoreName
 	StrictValidation
 )
 
 func validateBundleFile(filename string, lvl ValidationLevel) error {
 	var errText string
 
-	// Basic Validation
-	if err := validateBundleFilename(filename); err != nil {
-		errText = err.Error() + "\n"
+	if lvl != BasicValidationIgnoreName {
+		if err := validateBundleFilename(filename); err != nil {
+			errText = err.Error() + "\n"
+		}
 	}
 
 	b, err := parseBundleFile(filename)
@@ -145,22 +147,17 @@ func validateBundleFile(filename string, lvl ValidationLevel) error {
 		return errors.New(errText)
 	}
 
-	if lvl == BasicValidation {
-		if errText != "" {
-			return errors.New(strings.TrimSuffix(errText, "\n"))
-		}
-		return nil
-	}
-
 	// Strict Validation
-	err = validateBundle(b)
-	if err != nil {
-		errText += err.Error() + "\n"
-	}
+	if lvl == StrictValidation {
+		err = validateBundle(b)
+		if err != nil {
+			errText += err.Error() + "\n"
+		}
 
-	name := filepath.Base(filename)
-	if name != b.Header.Title {
-		errText += fmt.Sprintf("Bundle name %q and bundle header Title %q do not match\n", name, b.Header.Title)
+		name := filepath.Base(filename)
+		if name != b.Header.Title {
+			errText += fmt.Sprintf("Bundle name %q and bundle header Title %q do not match\n", name, b.Header.Title)
+		}
 	}
 
 	if errText != "" {


### PR DESCRIPTION
Fixes bundle edit to not create bundle and backup if name is invalid.

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>