### PR TITLE
lint: Fix unchecked return on Fprintf

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -354,7 +354,7 @@ func (b *Builder) ReadVersions() error {
 	}
 	ver, err = ioutil.ReadFile(filepath.Join(b.Config.Builder.VersionPath, b.UpstreamURLFile))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "WARNING: %s/%s does not exist, run mixer init to generate\n", b.Config.Builder.VersionPath, b.UpstreamURLFile)
+		fmt.Printf("Warning: %s/%s does not exist, run mixer init to generate\n", b.Config.Builder.VersionPath, b.UpstreamURLFile)
 		b.UpstreamURL = ""
 	} else {
 		b.UpstreamURL = strings.TrimSpace(string(ver))
@@ -1046,7 +1046,9 @@ func (b *Builder) ListBundles(listType listType, tree bool) error {
 			if _, exists := bundles[bundle]; !exists {
 				included = "(included)"
 			}
-			fmt.Fprintf(tw, "%s\t%s\t%s\n", bundle, location, included)
+			if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", bundle, location, included); err != nil {
+				return err
+			}
 		}
 	case LocalList:
 		// Only print the top-level set
@@ -1064,7 +1066,9 @@ func (b *Builder) ListBundles(listType listType, tree bool) error {
 			if _, exists := upstreamBundles[bundle]; exists {
 				masking = "(masking upstream)"
 			}
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", bundle, pkg, mix, masking)
+			if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", bundle, pkg, mix, masking); err != nil {
+				return err
+			}
 		}
 	case UpstreamList:
 		// Only print the top-level set
@@ -1082,7 +1086,9 @@ func (b *Builder) ListBundles(listType listType, tree bool) error {
 			if _, exists := localBundles[bundle]; exists {
 				masked = "(masked by local)"
 			}
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", bundle, pkg, mix, masked)
+			if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", bundle, pkg, mix, masked); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -2118,7 +2124,7 @@ func (b *Builder) BuildDeltaPacksPreviousVersions(prev, to uint32, printReport b
 		var m *swupd.Manifest
 		m, err = swupd.ParseManifestFile(filepath.Join(outputDir, fmt.Sprint(cur), "Manifest.MoM"))
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "could not find manifest for previous version %d, skipping...\n", cur)
+			fmt.Printf("Warning: Could not find manifest for previous version %d, skipping...\n", cur)
 			continue
 		}
 		previousManifests = append(previousManifests, m)
@@ -2170,7 +2176,7 @@ func (b *Builder) BuildDeltaPacksPreviousVersions(prev, to uint32, printReport b
 	wg.Wait()
 
 	for i := 0; i < len(deltaErrors); i++ {
-		fmt.Fprintf(os.Stderr, "%s\n", deltaErrors[i])
+		_, _ = fmt.Fprintf(os.Stderr, "%s\n", deltaErrors[i])
 	}
 
 	// Simply pack all deltas up since they are now created
@@ -2234,7 +2240,7 @@ func createDeltaPacks(fromMoM *swupd.Manifest, toMoM *swupd.Manifest, printRepor
 				fmt.Printf("  Creating delta pack for bundle %q from %d to %d\n", b.Name, b.FromVersion, b.ToVersion)
 				info, err := swupd.CreatePack(b.Name, b.FromVersion, b.ToVersion, outputDir, bundleDir, numWorkers)
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "ERROR: Pack %q from %d to %d FAILED to be created: %s\n", b.Name, b.FromVersion, b.ToVersion, err)
+					_, _ = fmt.Fprintf(os.Stderr, "ERROR: Pack %q from %d to %d FAILED to be created: %s\n", b.Name, b.FromVersion, b.ToVersion, err)
 					// Do not exit on errors, we have logging for all other failures and deltas are optional
 					continue
 				}

--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -588,7 +588,7 @@ func (b *Builder) buildBundles(set bundleSet) error {
 
 	// Write INI files. These are used to communicate to the next step of mixing (build update).
 	var serverINI bytes.Buffer
-	fmt.Fprintf(&serverINI, `[Server]
+	_, err = fmt.Fprintf(&serverINI, `[Server]
 emptydir=%s/empty
 imagebase=%s/image/
 outputdir=%s/www/
@@ -600,6 +600,9 @@ src=%s
 `, b.Config.Builder.ServerStateDir, b.Config.Builder.ServerStateDir,
 		b.Config.Builder.ServerStateDir, b.Config.Server.DebugInfoBanned,
 		b.Config.Server.DebugInfoLib, b.Config.Server.DebugInfoSrc)
+	if err != nil {
+		return err
+	}
 
 	err = ioutil.WriteFile(filepath.Join(b.Config.Builder.ServerStateDir, "server.ini"), serverINI.Bytes(), 0644)
 	if err != nil {
@@ -609,7 +612,9 @@ src=%s
 	// in bundleset to check for that. See also readGroupsINI in swupd package.
 	var groupsINI bytes.Buffer
 	for _, bundle := range set {
-		fmt.Fprintf(&groupsINI, "[%s]\ngroup=%s\n\n", bundle.Name, bundle.Name)
+		if _, err = fmt.Fprintf(&groupsINI, "[%s]\ngroup=%s\n\n", bundle.Name, bundle.Name); err != nil {
+			return err
+		}
 	}
 	err = ioutil.WriteFile(filepath.Join(b.Config.Builder.ServerStateDir, "groups.ini"), groupsINI.Bytes(), 0644)
 	if err != nil {
@@ -642,7 +647,9 @@ src=%s
 		// TODO: Should we embed this information in groups.ini? (Maybe rename it to bundles.ini)
 		var includes bytes.Buffer
 		for _, inc := range bundle.DirectIncludes {
-			fmt.Fprintf(&includes, "%s\n", inc)
+			if _, err = fmt.Fprintf(&includes, "%s\n", inc); err != nil {
+				return err
+			}
 		}
 		err = ioutil.WriteFile(filepath.Join(buildVersionDir, name+"-includes"), includes.Bytes(), 0644)
 		if err != nil {
@@ -833,7 +840,9 @@ func createVersionsFile(baseDir string, packagerCmd []string) error {
 	for _, e := range versions {
 		// TODO: change users of "versions" file to not rely on this exact formatting (version
 		// starting at column 51). E.g. this doesn't handle very well packages with large names.
-		fmt.Fprintf(w, "%-50s%s\n", e.name, e.version)
+		if _, err = fmt.Fprintf(w, "%-50s%s\n", e.name, e.version); err != nil {
+			return err
+		}
 	}
 	return w.Flush()
 }
@@ -861,7 +870,9 @@ func fixOSRelease(filename, version string) error {
 		if strings.HasPrefix(text, "VERSION_ID=") {
 			text = "VERSION_ID=" + version
 		}
-		fmt.Fprintln(&newBuf, text)
+		if _, err = fmt.Fprintln(&newBuf, text); err != nil {
+			return err
+		}
 	}
 
 	err = scanner.Err()

--- a/builder/stopwatch.go
+++ b/builder/stopwatch.go
@@ -25,7 +25,9 @@ func (sw *stopWatch) Start(name string) {
 		if len(sw.entries) > 0 {
 			fmt.Println()
 		}
-		fmt.Fprintf(sw.w, "=> %s\n", name)
+		if _, err := fmt.Fprintf(sw.w, "=> %s\n", name); err != nil {
+			fmt.Println("Warning: Unable to write to stopwatch log")
+		}
 	}
 	sw.entries = append(sw.entries, stopWatchEntry{name: name})
 	sw.t = time.Now()
@@ -56,10 +58,19 @@ func (sw *stopWatch) WriteSummary(w io.Writer) {
 		}
 	}
 	var sum time.Duration
-	fmt.Fprintf(w, "\nTIMINGS\n")
+	if _, err := fmt.Fprintf(w, "\nTIMINGS\n"); err != nil {
+		fmt.Println("Warning: Unable to write to stopwatch log")
+		return
+	}
 	for _, e := range sw.entries {
-		fmt.Fprintf(w, "  %-*s %s\n", max, e.name, e.d.Truncate(time.Millisecond))
+		if _, err := fmt.Fprintf(w, "  %-*s %s\n", max, e.name, e.d.Truncate(time.Millisecond)); err != nil {
+			fmt.Println("Warning: Unable to write to stopwatch log")
+			return
+		}
 		sum += e.d
 	}
-	fmt.Fprintf(w, "TOTAL: %s\n", sum.Truncate(time.Millisecond))
+	if _, err := fmt.Fprintf(w, "TOTAL: %s\n", sum.Truncate(time.Millisecond)); err != nil {
+		fmt.Println("Warning: Unable to write to stopwatch log")
+		return
+	}
 }

--- a/internal/client/state.go
+++ b/internal/client/state.go
@@ -201,7 +201,7 @@ func (cs *State) GetFullfile(version, hash string) error {
 
 	hdr, err = tr.Next()
 	if err == nil {
-		fmt.Fprintf(os.Stderr, "! ignoring unexpected extra content in %s: %s\n", tarredFilename, hdr.Name)
+		fmt.Printf("Warning: Ignoring unexpected extra content in %s: %s\n", tarredFilename, hdr.Name)
 	}
 
 	return nil
@@ -330,9 +330,9 @@ func (cs *State) extractFullfile(hdr *tar.Header, r io.Reader) error {
 				return nil
 			}
 		} else if herr != nil {
-			fmt.Fprintf(os.Stderr, "! couldn't calculate hash for existing file %s, removing to extract it again\n", filename)
+			fmt.Printf("Warning: Couldn't calculate hash for existing file %s, removing to extract it again\n", filename)
 		} else {
-			fmt.Fprintf(os.Stderr, "! existing file %s has invalid hash %s, removing to extract it again\n", filename, hash)
+			fmt.Printf("Warning: Existing file %s has invalid hash %s, removing to extract it again\n", filename, hash)
 		}
 		err = os.Remove(filename)
 		if err != nil {

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -364,11 +364,11 @@ func fail(err error) {
 	if rootCmdFlags.cpuProfile != "" {
 		pprof.StopCPUProfile()
 	}
-	fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+	_, _ = fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
 	os.Exit(1)
 }
 
 func failf(format string, a ...interface{}) {
-	fmt.Fprintf(os.Stderr, fmt.Sprintf("ERROR: %s\n", format), a...)
+	_, _ = fmt.Fprintf(os.Stderr, fmt.Sprintf("ERROR: %s\n", format), a...)
 	os.Exit(1)
 }

--- a/mixin/root_cmd.go
+++ b/mixin/root_cmd.go
@@ -41,6 +41,6 @@ func Execute() {
 }
 
 func fail(err error) {
-	fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+	_, _ = fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
 	os.Exit(1)
 }

--- a/swupd/bundleinfo.go
+++ b/swupd/bundleinfo.go
@@ -95,7 +95,7 @@ func (m *Manifest) addFilesFromBundleInfo(c config, version uint32) error {
 		fullPath := filepath.Join(chrootDir, fpath)
 		fi, err := os.Lstat(fullPath)
 		if os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "Warning: Missing file, assuming %%ghost: %s\n", fpath)
+			fmt.Printf("Warning: Missing file, assuming %%ghost: %s\n", fpath)
 			continue
 		}
 		if err != nil {
@@ -107,7 +107,7 @@ func (m *Manifest) addFilesFromBundleInfo(c config, version uint32) error {
 			if strings.Contains(err.Error(), "hash calculation error") {
 				return err
 			}
-			fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
+			fmt.Printf("Warning: %s\n", err)
 		}
 	}
 

--- a/swupd/cmd/create-fullfiles/main.go
+++ b/swupd/cmd/create-fullfiles/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 func usage() {
-	fmt.Fprintf(os.Stderr, `Usage: create-fullfiles [FLAGS] STATEDIR VERSION
+	_, _ = fmt.Fprintf(os.Stderr, `Usage: create-fullfiles [FLAGS] STATEDIR VERSION
 Flags:
 `)
 	flag.PrintDefaults()

--- a/swupd/cmd/create-pack/main.go
+++ b/swupd/cmd/create-pack/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 func usage() {
-	fmt.Fprintf(os.Stderr, `Create pack files using a swupd state directory
+	_, _ = fmt.Fprintf(os.Stderr, `Create pack files using a swupd state directory
 
 Usage:
   create-pack [FLAGS] STATEDIR FROM_VERSION TO_VERSION BUNDLE

--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -353,7 +353,7 @@ func CreateManifests(version uint32, minVersion uint32, format uint, statedir st
 
 	c, err = getConfig(statedir)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Found server.ini, but was unable to read it. "+
+		fmt.Printf("Warning: Found server.ini, but was unable to read it. " +
 			"Continuing with default configuration\n")
 	}
 

--- a/swupd/filesystem.go
+++ b/swupd/filesystem.go
@@ -102,7 +102,7 @@ func (m *Manifest) createManifestRecord(rootPath, path string, version uint32) e
 		if strings.Contains(err.Error(), "hash calculation error") {
 			return err
 		}
-		fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
+		fmt.Printf("Warning: %s\n", err)
 	}
 
 	// this is a file to skip
@@ -129,7 +129,7 @@ func (m *Manifest) addFilesFromChroot(rootPath, removePrefix string) error {
 			if strings.Contains(err.Error(), "hash calculation error") {
 				return err
 			}
-			fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
+			fmt.Printf("Warning: %s\n", err)
 		}
 		return nil
 	})


### PR DESCRIPTION
This patch adds error checking for all uses of Fprintf and changes
Warning messages that were using stderr to use stdout instead to keep
then consistent with the rest of the code.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>