### PR TITLE
Fprintf combo

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -1046,7 +1046,9 @@ func (b *Builder) ListBundles(listType listType, tree bool) error {
 			if _, exists := bundles[bundle]; !exists {
 				included = "(included)"
 			}
-			fmt.Fprintf(tw, "%s\t%s\t%s\n", bundle, location, included)
+			if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", bundle, location, included); err != nil {
+				return err
+			}
 		}
 	case LocalList:
 		// Only print the top-level set
@@ -1064,7 +1066,9 @@ func (b *Builder) ListBundles(listType listType, tree bool) error {
 			if _, exists := upstreamBundles[bundle]; exists {
 				masking = "(masking upstream)"
 			}
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", bundle, pkg, mix, masking)
+			if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", bundle, pkg, mix, masking); err != nil {
+				return err
+			}
 		}
 	case UpstreamList:
 		// Only print the top-level set
@@ -1082,7 +1086,9 @@ func (b *Builder) ListBundles(listType listType, tree bool) error {
 			if _, exists := localBundles[bundle]; exists {
 				masked = "(masked by local)"
 			}
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", bundle, pkg, mix, masked)
+			if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", bundle, pkg, mix, masked); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"math"
 	"net/url"
 	"os"
@@ -230,7 +231,7 @@ func (b *Builder) InitMix(upstreamVer string, mixVer string, allLocal bool, allU
 	// Deprecate '.clearurl' --> 'upstreamurl'
 	if _, err := os.Stat(filepath.Join(b.Config.Builder.VersionPath, ".clearurl")); err == nil {
 		b.UpstreamURLFile = ".clearurl"
-		fmt.Println("Warning: '.clearurl' has been deprecated. Please rename file to 'upstreamurl'")
+		log.Println("Warning: '.clearurl' has been deprecated. Please rename file to 'upstreamurl'")
 	}
 	if err := ioutil.WriteFile(filepath.Join(b.Config.Builder.VersionPath, b.UpstreamURLFile), []byte(upstreamURL), 0644); err != nil {
 		return err
@@ -250,7 +251,7 @@ func (b *Builder) InitMix(upstreamVer string, mixVer string, allLocal bool, allU
 	// Deprecate '.clearversion' --> 'upstreamversion'
 	if _, err := os.Stat(filepath.Join(b.Config.Builder.VersionPath, ".clearversion")); err == nil {
 		b.UpstreamVerFile = ".clearversion"
-		fmt.Println("Warning: '.clearversion' has been deprecated. Please rename file to 'upstreamversion'")
+		log.Println("Warning: '.clearversion' has been deprecated. Please rename file to 'upstreamversion'")
 	}
 	if err := ioutil.WriteFile(filepath.Join(b.Config.Builder.VersionPath, b.UpstreamVerFile), []byte(upstreamVer), 0644); err != nil {
 		return err
@@ -260,7 +261,7 @@ func (b *Builder) InitMix(upstreamVer string, mixVer string, allLocal bool, allU
 	// Deprecate '.mixversion' --> 'mixversion'
 	if _, err := os.Stat(filepath.Join(b.Config.Builder.VersionPath, ".mixversion")); err == nil {
 		b.MixVerFile = ".mixversion"
-		fmt.Println("Warning: '.mixversion' has been deprecated. Please rename file to 'mixversion'")
+		log.Println("Warning: '.mixversion' has been deprecated. Please rename file to 'mixversion'")
 	}
 	if err := ioutil.WriteFile(filepath.Join(b.Config.Builder.VersionPath, b.MixVerFile), []byte(mixVer), 0644); err != nil {
 		return err
@@ -326,7 +327,7 @@ func (b *Builder) ReadVersions() error {
 	// Deprecate '.mixversion' --> 'mixversion'
 	if _, err := os.Stat(filepath.Join(b.Config.Builder.VersionPath, ".mixversion")); err == nil {
 		b.MixVerFile = ".mixversion"
-		fmt.Println("Warning: '.mixversion' has been deprecated. Please rename file to 'mixversion'")
+		log.Println("Warning: '.mixversion' has been deprecated. Please rename file to 'mixversion'")
 	}
 	ver, err := ioutil.ReadFile(filepath.Join(b.Config.Builder.VersionPath, b.MixVerFile))
 	if err != nil {
@@ -338,7 +339,7 @@ func (b *Builder) ReadVersions() error {
 	// Deprecate '.clearversion' --> 'upstreamversion'
 	if _, err = os.Stat(filepath.Join(b.Config.Builder.VersionPath, ".clearversion")); err == nil {
 		b.UpstreamVerFile = ".clearversion"
-		fmt.Println("Warning: '.clearversion' has been deprecated. Please rename file to 'upstreamversion'")
+		log.Println("Warning: '.clearversion' has been deprecated. Please rename file to 'upstreamversion'")
 	}
 	ver, err = ioutil.ReadFile(filepath.Join(b.Config.Builder.VersionPath, b.UpstreamVerFile))
 	if err != nil {
@@ -350,11 +351,11 @@ func (b *Builder) ReadVersions() error {
 	// Deprecate '.clearversion' --> 'upstreamurl'
 	if _, err = os.Stat(filepath.Join(b.Config.Builder.VersionPath, ".clearurl")); err == nil {
 		b.UpstreamURLFile = ".clearurl"
-		fmt.Println("Warning: '.clearurl' has been deprecated. Please rename file to 'upstreamurl'")
+		log.Println("Warning: '.clearurl' has been deprecated. Please rename file to 'upstreamurl'")
 	}
 	ver, err = ioutil.ReadFile(filepath.Join(b.Config.Builder.VersionPath, b.UpstreamURLFile))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "WARNING: %s/%s does not exist, run mixer init to generate\n", b.Config.Builder.VersionPath, b.UpstreamURLFile)
+		log.Printf("Warning: %s/%s does not exist, run mixer init to generate\n", b.Config.Builder.VersionPath, b.UpstreamURLFile)
 		b.UpstreamURL = ""
 	} else {
 		b.UpstreamURL = strings.TrimSpace(string(ver))
@@ -845,7 +846,7 @@ func (b *Builder) RemoveBundles(bundles []string, mix bool, local bool, git bool
 				if !mix && inMix {
 					// Check if bundle is still available upstream
 					if _, err := b.getBundlePath(bundle); err != nil {
-						fmt.Printf("Warning: Invalid bundle left in mix: %q\n", bundle)
+						log.Printf("Warning: Invalid bundle left in mix: %q\n", bundle)
 					} else {
 						fmt.Printf("Mix bundle %q now points to upstream\n", bundle)
 					}
@@ -1302,7 +1303,7 @@ func (b *Builder) UpdateMixVer(version int) error {
 	// Deprecate '.mixversion' --> 'mixversion'
 	if _, err := os.Stat(filepath.Join(b.Config.Builder.VersionPath, ".mixversion")); err == nil {
 		b.MixVerFile = ".mixversion"
-		fmt.Println("Warning: '.mixversion' has been deprecated. Please rename file to 'mixversion'")
+		log.Println("Warning: '.mixversion' has been deprecated. Please rename file to 'mixversion'")
 	}
 
 	b.MixVer = strconv.Itoa(version)
@@ -1379,7 +1380,7 @@ func (b *Builder) NewDNFConfIfNeeded() error {
 
 		t, err := textTemplate.New("dnfConfTemplate").Parse(dnfConfTemplate)
 		if err != nil {
-			helpers.PrintError(err)
+			log.Println(err)
 			return err
 		}
 
@@ -1718,11 +1719,11 @@ func (b *Builder) buildUpdateContent(params UpdateParameters, timer *stopWatch) 
 				return errors.Wrapf(err, "couldn't make pack for bundle %q", name)
 			}
 			if len(info.Warnings) > 0 {
-				fmt.Println("Warnings during pack:")
+				log.Println("Warnings during pack:")
 				for _, w := range info.Warnings {
-					fmt.Printf("  %s\n", w)
+					log.Printf("  %s\n", w)
 				}
-				fmt.Println()
+				log.Println()
 			}
 			fmt.Printf("  Fullfiles in pack: %d\n", info.FullfileCount)
 			fmt.Printf("  Deltas in pack: %d\n", info.DeltaCount)
@@ -1796,7 +1797,7 @@ func (b *Builder) AddRepo(name, url string) error {
 
 	f, err := os.OpenFile(b.Config.Builder.DNFConf, os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
-		helpers.PrintError(err)
+		log.Println(err)
 		return err
 	}
 
@@ -1814,7 +1815,7 @@ func (b *Builder) AddRepo(name, url string) error {
 
 	t, err := textTemplate.New("dnfConfRepoTemplate").Parse(dnfConfRepoTemplate)
 	if err != nil {
-		helpers.PrintError(err)
+		log.Println(err)
 		return err
 	}
 
@@ -2124,7 +2125,7 @@ func (b *Builder) BuildDeltaPacksPreviousVersions(prev, to uint32, printReport b
 		var m *swupd.Manifest
 		m, err = swupd.ParseManifestFile(filepath.Join(outputDir, fmt.Sprint(cur), "Manifest.MoM"))
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "could not find manifest for previous version %d, skipping...\n", cur)
+			log.Printf("Warning: Could not find manifest for previous version %d, skipping...\n", cur)
 			continue
 		}
 		previousManifests = append(previousManifests, m)
@@ -2176,7 +2177,7 @@ func (b *Builder) BuildDeltaPacksPreviousVersions(prev, to uint32, printReport b
 	wg.Wait()
 
 	for i := 0; i < len(deltaErrors); i++ {
-		fmt.Fprintf(os.Stderr, "%s\n", deltaErrors[i])
+		log.Printf("%s\n", deltaErrors[i])
 	}
 
 	// Simply pack all deltas up since they are now created
@@ -2240,16 +2241,16 @@ func createDeltaPacks(fromMoM *swupd.Manifest, toMoM *swupd.Manifest, printRepor
 				fmt.Printf("  Creating delta pack for bundle %q from %d to %d\n", b.Name, b.FromVersion, b.ToVersion)
 				info, err := swupd.CreatePack(b.Name, b.FromVersion, b.ToVersion, outputDir, bundleDir, numWorkers)
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "ERROR: Pack %q from %d to %d FAILED to be created: %s\n", b.Name, b.FromVersion, b.ToVersion, err)
+					log.Printf("ERROR: Pack %q from %d to %d FAILED to be created: %s\n", b.Name, b.FromVersion, b.ToVersion, err)
 					// Do not exit on errors, we have logging for all other failures and deltas are optional
 					continue
 				}
 
 				if len(info.Warnings) > 0 {
 					for _, w := range info.Warnings {
-						fmt.Printf("    WARNING: %s\n", w)
+						log.Printf("    Warning: %s\n", w)
 					}
-					fmt.Println()
+					log.Println()
 				}
 				if printReport {
 					max := 0

--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -588,7 +588,7 @@ func (b *Builder) buildBundles(set bundleSet) error {
 
 	// Write INI files. These are used to communicate to the next step of mixing (build update).
 	var serverINI bytes.Buffer
-	fmt.Fprintf(&serverINI, `[Server]
+	_, _ = fmt.Fprintf(&serverINI, `[Server]
 emptydir=%s/empty
 imagebase=%s/image/
 outputdir=%s/www/
@@ -609,7 +609,7 @@ src=%s
 	// in bundleset to check for that. See also readGroupsINI in swupd package.
 	var groupsINI bytes.Buffer
 	for _, bundle := range set {
-		fmt.Fprintf(&groupsINI, "[%s]\ngroup=%s\n\n", bundle.Name, bundle.Name)
+		_, _ = fmt.Fprintf(&groupsINI, "[%s]\ngroup=%s\n\n", bundle.Name, bundle.Name)
 	}
 	err = ioutil.WriteFile(filepath.Join(b.Config.Builder.ServerStateDir, "groups.ini"), groupsINI.Bytes(), 0644)
 	if err != nil {
@@ -642,7 +642,7 @@ src=%s
 		// TODO: Should we embed this information in groups.ini? (Maybe rename it to bundles.ini)
 		var includes bytes.Buffer
 		for _, inc := range bundle.DirectIncludes {
-			fmt.Fprintf(&includes, "%s\n", inc)
+			_, _ = fmt.Fprintf(&includes, "%s\n", inc)
 		}
 		err = ioutil.WriteFile(filepath.Join(buildVersionDir, name+"-includes"), includes.Bytes(), 0644)
 		if err != nil {
@@ -833,7 +833,10 @@ func createVersionsFile(baseDir string, packagerCmd []string) error {
 	for _, e := range versions {
 		// TODO: change users of "versions" file to not rely on this exact formatting (version
 		// starting at column 51). E.g. this doesn't handle very well packages with large names.
-		fmt.Fprintf(w, "%-50s%s\n", e.name, e.version)
+		_, err = fmt.Fprintf(w, "%-50s%s\n", e.name, e.version)
+		if err != nil {
+			return err
+		}
 	}
 	return w.Flush()
 }
@@ -861,7 +864,7 @@ func fixOSRelease(filename, version string) error {
 		if strings.HasPrefix(text, "VERSION_ID=") {
 			text = "VERSION_ID=" + version
 		}
-		fmt.Fprintln(&newBuf, text)
+		_, _ = fmt.Fprintln(&newBuf, text)
 	}
 
 	err = scanner.Err()

--- a/builder/docker.go
+++ b/builder/docker.go
@@ -17,6 +17,7 @@ package builder
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -171,7 +172,7 @@ func (b *Builder) prepareContainer() (string, error) {
 	}
 	fmt.Println("Updating docker image")
 	if err = helpers.RunCommand("docker", "pull", imageName); err != nil {
-		fmt.Printf("WARNING: Unable to pull docker image for format %s. Trying with cached image\n", format)
+		log.Printf("Warning: Unable to pull docker image for format %s. Trying with cached image\n", format)
 	}
 
 	return imageName, nil

--- a/builder/stopwatch.go
+++ b/builder/stopwatch.go
@@ -1,8 +1,8 @@
 package builder
 
 import (
-	"fmt"
 	"io"
+	"log"
 	"time"
 )
 
@@ -21,11 +21,12 @@ type stopWatchEntry struct {
 }
 
 func (sw *stopWatch) Start(name string) {
+	logger := log.New(sw.w, "", log.Ldate|log.Ltime)
 	if sw.w != nil {
 		if len(sw.entries) > 0 {
-			fmt.Println()
+			logger.Println(sw.w, "")
 		}
-		fmt.Fprintf(sw.w, "=> %s\n", name)
+		logger.Printf("=> %s\n", name)
 	}
 	sw.entries = append(sw.entries, stopWatchEntry{name: name})
 	sw.t = time.Now()
@@ -46,6 +47,7 @@ func (sw *stopWatch) Stop() {
 }
 
 func (sw *stopWatch) WriteSummary(w io.Writer) {
+	logger := log.New(w, "", log.Ldate|log.Ltime)
 	if len(sw.entries) == 0 {
 		return
 	}
@@ -56,10 +58,10 @@ func (sw *stopWatch) WriteSummary(w io.Writer) {
 		}
 	}
 	var sum time.Duration
-	fmt.Fprintf(w, "\nTIMINGS\n")
+	logger.Printf("\nTIMINGS\n")
 	for _, e := range sw.entries {
-		fmt.Fprintf(w, "  %-*s %s\n", max, e.name, e.d.Truncate(time.Millisecond))
+		logger.Printf("  %-*s %s\n", max, e.name, e.d.Truncate(time.Millisecond))
 		sum += e.d
 	}
-	fmt.Fprintf(w, "TOTAL: %s\n", sum.Truncate(time.Millisecond))
+	logger.Printf("TOTAL: %s\n", sum.Truncate(time.Millisecond))
 }

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ package config
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -267,7 +268,7 @@ func (config *MixConfig) validate() error {
 	}
 
 	if config.hasFormatField {
-		fmt.Println("WARNING: FORMAT value was transferred to mixer.state file")
+		log.Println("Warning: FORMAT value was transferred to mixer.state file")
 	}
 
 	return nil

--- a/config/config_convert.go
+++ b/config/config_convert.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -201,8 +202,8 @@ func (config *MixConfig) parseLegacy() error {
 			return err
 		}
 		config.Mixer.LocalBundleDir = filepath.Join(pwd, "local-bundles")
-		fmt.Printf("WARNING: LOCAL_BUNDLE_DIR not found in builder.conf. Falling back to %q.\n", config.Mixer.LocalBundleDir)
-		fmt.Println("Please set this value to the location you want local bundle definition files to be stored.")
+		log.Printf("Warning: LOCAL_BUNDLE_DIR not found in builder.conf. Falling back to %q.\n", config.Mixer.LocalBundleDir)
+		log.Println("Please set this value to the location you want local bundle definition files to be stored.")
 	}
 
 	return nil

--- a/config/state.go
+++ b/config/state.go
@@ -18,8 +18,8 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
-	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"regexp"
 
@@ -123,7 +123,7 @@ func (state *MixState) Load() error {
 	f, err := os.Open(state.filename)
 	if err != nil {
 		// If state does not exists, create a default state
-		fmt.Println("WARNING: Using FORMAT value from " + state.formatSource)
+		log.Println("Warning: Using FORMAT value from " + state.formatSource)
 		return state.Save()
 	}
 	defer func() {

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -40,11 +40,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// PrintError is a utility function to emit an error to the console
-func PrintError(e error) {
-	fmt.Fprintf(os.Stderr, "***Error: %v\n", e)
-}
-
 // CreateCertTemplate will construct the template for needed openssl metadata
 // instead of using an attributes.cnf file
 func CreateCertTemplate() *x509.Certificate {

--- a/internal/client/state.go
+++ b/internal/client/state.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -201,7 +202,7 @@ func (cs *State) GetFullfile(version, hash string) error {
 
 	hdr, err = tr.Next()
 	if err == nil {
-		fmt.Fprintf(os.Stderr, "! ignoring unexpected extra content in %s: %s\n", tarredFilename, hdr.Name)
+		log.Printf("Warning: Ignoring unexpected extra content in %s: %s\n", tarredFilename, hdr.Name)
 	}
 
 	return nil
@@ -330,9 +331,9 @@ func (cs *State) extractFullfile(hdr *tar.Header, r io.Reader) error {
 				return nil
 			}
 		} else if herr != nil {
-			fmt.Fprintf(os.Stderr, "! couldn't calculate hash for existing file %s, removing to extract it again\n", filename)
+			log.Printf("Warning: Couldn't calculate hash for existing file %s, removing to extract it again\n", filename)
 		} else {
-			fmt.Fprintf(os.Stderr, "! existing file %s has invalid hash %s, removing to extract it again\n", filename, hash)
+			log.Printf("Warning: Existing file %s has invalid hash %s, removing to extract it again\n", filename, hash)
 		}
 		err = os.Remove(filename)
 		if err != nil {

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"runtime/pprof"
@@ -98,13 +99,13 @@ var RootCmd = &cobra.Command{
 			}
 
 			if hostFormat == "" {
-				fmt.Println("Warning: Unable to determine host format. Running natively may fail.")
+				log.Println("Warning: Unable to determine host format. Running natively may fail.")
 			} else if hostFormat != upstreamFormat {
-				fmt.Println("Warning: The host format and mix upstream format do not match.",
+				log.Println("Warning: The host format and mix upstream format do not match.",
 					"Mixer may be incompatible with this format; running natively may fail.")
 			}
 		} else if !builder.Offline {
-			fmt.Printf("Warning: Using Format=%s from mixer.state for this build.\n", b.State.Mix.Format)
+			log.Printf("Warning: Using Format=%s from mixer.state for this build.\n", b.State.Mix.Format)
 		}
 
 		// For non-bump build commands, check if building across a format
@@ -113,7 +114,7 @@ var RootCmd = &cobra.Command{
 		if !cmdContains(cmd, "format-bump") && !cmdContains(cmd, "upstream-format") && cmdContains(cmd, "build") && !cmdContains(cmd, "image") {
 			// --offline=true AND --native=false, try to see if container exists
 			if builder.Offline && !builder.Native {
-				fmt.Println("Warning: Unable to determine upstream format in --offline mode, build may fail if building across format boundaries.")
+				log.Println("Warning: Unable to determine upstream format in --offline mode, build may fail if building across format boundaries.")
 				if err := b.RunCommandInContainer(reconstructCommand(cmd, args)); err != nil {
 					fail(err)
 				}
@@ -364,11 +365,11 @@ func fail(err error) {
 	if rootCmdFlags.cpuProfile != "" {
 		pprof.StopCPUProfile()
 	}
-	fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+	log.Printf("ERROR: %s\n", err)
 	os.Exit(1)
 }
 
 func failf(format string, a ...interface{}) {
-	fmt.Fprintf(os.Stderr, fmt.Sprintf("ERROR: %s\n", format), a...)
+	log.Printf(fmt.Sprintf("ERROR: %s\n", format), a...)
 	os.Exit(1)
 }

--- a/mixin/root_cmd.go
+++ b/mixin/root_cmd.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"fmt"
+	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -41,6 +41,6 @@ func Execute() {
 }
 
 func fail(err error) {
-	fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+	log.Printf("ERROR: %s\n", err)
 	os.Exit(1)
 }

--- a/swupd/bundleinfo.go
+++ b/swupd/bundleinfo.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -95,7 +96,7 @@ func (m *Manifest) addFilesFromBundleInfo(c config, version uint32) error {
 		fullPath := filepath.Join(chrootDir, fpath)
 		fi, err := os.Lstat(fullPath)
 		if os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "Warning: Missing file, assuming %%ghost: %s\n", fpath)
+			log.Printf("Warning: Missing file, assuming %%ghost: %s\n", fpath)
 			continue
 		}
 		if err != nil {
@@ -107,7 +108,7 @@ func (m *Manifest) addFilesFromBundleInfo(c config, version uint32) error {
 			if strings.Contains(err.Error(), "hash calculation error") {
 				return err
 			}
-			fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
+			log.Printf("Warning: %s\n", err)
 		}
 	}
 

--- a/swupd/cmd/create-fullfiles/main.go
+++ b/swupd/cmd/create-fullfiles/main.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -16,7 +15,7 @@ import (
 )
 
 func usage() {
-	fmt.Fprintf(os.Stderr, `Usage: create-fullfiles [FLAGS] STATEDIR VERSION
+	log.Printf(`Usage: create-fullfiles [FLAGS] STATEDIR VERSION
 Flags:
 `)
 	flag.PrintDefaults()

--- a/swupd/cmd/create-pack/main.go
+++ b/swupd/cmd/create-pack/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 func usage() {
-	fmt.Fprintf(os.Stderr, `Create pack files using a swupd state directory
+	log.Printf(`Create pack files using a swupd state directory
 
 Usage:
   create-pack [FLAGS] STATEDIR FROM_VERSION TO_VERSION BUNDLE
@@ -130,11 +130,11 @@ func main() {
 		}
 
 		if len(info.Warnings) > 0 {
-			fmt.Println("Warnings during pack:")
+			log.Println("Warnings during pack:")
 			for _, w := range info.Warnings {
-				fmt.Printf("  %s\n", w)
+				log.Printf("  %s\n", w)
 			}
-			fmt.Println()
+			log.Println()
 		}
 		fmt.Printf("  Fullfiles in pack: %d\n", info.FullfileCount)
 		fmt.Printf("  Deltas in pack: %d\n", info.DeltaCount)

--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -17,6 +17,7 @@ package swupd
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -353,7 +354,7 @@ func CreateManifests(version uint32, minVersion uint32, format uint, statedir st
 
 	c, err = getConfig(statedir)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Found server.ini, but was unable to read it. "+
+		log.Printf("Warning: Found server.ini, but was unable to read it. " +
 			"Continuing with default configuration\n")
 	}
 

--- a/swupd/filesystem.go
+++ b/swupd/filesystem.go
@@ -16,6 +16,7 @@ package swupd
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -102,7 +103,7 @@ func (m *Manifest) createManifestRecord(rootPath, path string, version uint32) e
 		if strings.Contains(err.Error(), "hash calculation error") {
 			return err
 		}
-		fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
+		log.Printf("Warning: %s\n", err)
 	}
 
 	// this is a file to skip
@@ -129,7 +130,7 @@ func (m *Manifest) addFilesFromChroot(rootPath, removePrefix string) error {
 			if strings.Contains(err.Error(), "hash calculation error") {
 				return err
 			}
-			fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
+			log.Printf("Warning: %s\n", err)
 		}
 		return nil
 	})


### PR DESCRIPTION
This PR add fixes and improvements to different scenarios where `Fprint*` is used in the code. Each commit can be viewed as a separate PR since they are handling different issues, but since they are needed together to pass lint testing and they are fairly simple individually, they can be review all at once.

The first 3 commits add proper error handling to different parts of the code. The last commit changes the code to use `log` package to handle error and warning messages.