### PR TITLE
swupd: remove os-core-update-index file creation

### DIFF
--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -444,13 +444,19 @@ func CreateManifests(version uint32, minVersion uint32, format uint, statedir st
 		return nil, err
 	}
 
-	osIdxPath := filepath.Join(verOutput, "Manifest."+osIdx.Name)
-	if err = newMoM.createManifestRecord(verOutput, osIdxPath, version); err != nil {
+	// read index manifest from the version directory specified in the manifest
+	// itself as an index manifest may not have been created for this version.
+	osIdxDir := filepath.Join(c.outputDir, fmt.Sprint(osIdx.Header.Version))
+	osIdxPath := filepath.Join(osIdxDir, "Manifest."+osIdx.Name)
+	if err = newMoM.createManifestRecord(osIdxDir, osIdxPath, osIdx.Header.Version); err != nil {
 		return nil, err
 	}
 
 	// track here as well so the manifest tar is made
-	newManifests = append(newManifests, osIdx)
+	// but only if we made it new for this version
+	if osIdx.Header.Version == newMoM.Header.Version {
+		newManifests = append(newManifests, osIdx)
+	}
 
 	// handle full manifest
 	newFull.sortFilesVersionName()

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -429,7 +429,11 @@ func (fs *testFileSystem) addToFullChroot(version uint32, file, content string) 
 }
 
 func (fs *testFileSystem) addToBundleInfo(version uint32, bundle, file string) {
-	bundleInfoPath := filepath.Join(fs.Dir, "image", fmt.Sprint(version), bundle+"-info")
+	bundleInfoDir := filepath.Join(fs.Dir, "image", fmt.Sprint(version))
+	bundleInfoPath := filepath.Join(bundleInfoDir, bundle+"-info")
+	allbundleInfoDir := filepath.Join(bundleInfoDir, "full/usr/share/clear/allbundles")
+	allbundleInfoPath := filepath.Join(allbundleInfoDir, bundle+"-info")
+
 	biBytes, err := ioutil.ReadFile(bundleInfoPath)
 	if err != nil {
 		fs.t.Fatal(err)
@@ -448,8 +452,17 @@ func (fs *testFileSystem) addToBundleInfo(version uint32, bundle, file string) {
 		fs.t.Fatal(err)
 	}
 
-	err = ioutil.WriteFile(bundleInfoPath, b, 0644)
-	if err != nil {
+	// update regular info file
+	if err = ioutil.WriteFile(bundleInfoPath, b, 0644); err != nil {
+		fs.t.Fatal(err)
+	}
+
+	// update allbundle info file
+	if err = os.MkdirAll(allbundleInfoDir, 0755); err != nil {
+		fs.t.Fatal(err)
+	}
+
+	if err = ioutil.WriteFile(allbundleInfoPath, b, 0644); err != nil {
 		fs.t.Fatal(err)
 	}
 }

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -38,10 +38,7 @@ const IndexBundle = "os-core-update-index"
 
 // TODO make this configurable (optional and configurable bundle/filepath)
 // this should be done when configuration is in a more stable state
-const (
-	indexFileName     = "/usr/share/clear/os-core-update-index"
-	indexAllBundleDir = "/usr/share/clear/allbundles"
-)
+const indexAllBundleDir = "/usr/share/clear/allbundles"
 
 // ManifestHeader contains metadata for the manifest
 type ManifestHeader struct {
@@ -700,46 +697,17 @@ func fileContains(path string, sub string) bool {
 	return bytes.Contains(b, []byte(sub))
 }
 
-type bundleIndex struct {
-	fname string
-	bname string
-	bsize uint64
-}
-
-func constructIndex(c *config, ui *UpdateInfo, f2b []*bundleIndex) error {
-	// sort by filename then by bundle size
-	sort.Slice(f2b[:], func(i, j int) bool {
-		if f2b[i].fname == f2b[j].fname {
-			return f2b[i].bsize < f2b[j].bsize
-		}
-		return f2b[i].fname < f2b[j].fname
-	})
-
-	// construct content for the file
-	var output []byte
-	for _, line := range f2b {
-		strLine := fmt.Sprintf("%s\t%s\n", line.fname, line.bname)
-		output = append(output, []byte(strLine)...)
-	}
-
+// constructIndexTrackingFile writes an empty tracking file to the bundle chroot
+// and to the full chroot.
+func constructIndexTrackingFile(c *config, ui *UpdateInfo) error {
 	imageVerPath := filepath.Join(c.imageBase, fmt.Sprint(ui.version))
-	// write to bundle chroot
-	outputFileName := filepath.Join(imageVerPath, IndexBundle, indexFileName)
-	if err := createAndWrite(outputFileName, output); err != nil {
-		return err
-	}
-
 	trackingFile := filepath.Join("/usr/share/clear/bundles", IndexBundle)
+	// write to bundle chroot
 	if err := createAndWrite(filepath.Join(imageVerPath, IndexBundle, trackingFile), []byte{}); err != nil {
 		return err
 	}
 
-	// write to full chroot
-	fullFileName := filepath.Join(imageVerPath, "full", indexFileName)
-	if err := createAndWrite(fullFileName, output); err != nil {
-		return err
-	}
-
+	// write to full chroot and return any errors
 	return createAndWrite(filepath.Join(imageVerPath, "full", trackingFile), []byte{})
 }
 
@@ -749,7 +717,6 @@ func constructIndex(c *config, ui *UpdateInfo, f2b []*bundleIndex) error {
 // bundle in which the file will live. This bundle is added to the "full" manifest which
 // is part of the bundles slice. A pointer to the new manifest is returned on success.
 func writeIndexManifest(c *config, ui *UpdateInfo, bundles []*Manifest) (*Manifest, error) {
-	fileToBundles := []*bundleIndex{}
 	var newFull, newOsCore *Manifest
 	for _, b := range bundles {
 		if b.Name == "full" {
@@ -762,18 +729,6 @@ func writeIndexManifest(c *config, ui *UpdateInfo, bundles []*Manifest) (*Manife
 			// record for includes list
 			newOsCore = b
 		}
-
-		for _, f := range b.Files {
-			// only record present files that are TypeFile or TypeSymlink
-			if f.Present() && f.Type != TypeDirectory {
-				ftb := &bundleIndex{
-					f.Name,
-					b.Name,
-					b.Header.ContentSize,
-				}
-				fileToBundles = append(fileToBundles, ftb)
-			}
-		}
 	}
 
 	// no full manifest in bundles list
@@ -781,8 +736,8 @@ func writeIndexManifest(c *config, ui *UpdateInfo, bundles []*Manifest) (*Manife
 		return nil, errors.New("no full manifest found")
 	}
 
-	// construct the index file from the bundleIndex slice
-	if err := constructIndex(c, ui, fileToBundles); err != nil {
+	// construct the tracking files in the bundle and full chroots
+	if err := constructIndexTrackingFile(c, ui); err != nil {
 		return nil, err
 	}
 
@@ -873,6 +828,14 @@ func writeIndexManifest(c *config, ui *UpdateInfo, bundles []*Manifest) (*Manife
 
 	// done processing, sort by version before writing
 	idxMan.sortFilesVersionName()
+	// check that there is actually a change to this manifest before writing
+	if idxMan.Files[len(idxMan.Files)-1].Version < idxMan.Header.Version {
+		// return the old version of the manifest since there was no change
+		// in this version
+		return oldM, nil
+	}
+
+	// there were changes at this version, so write the manifest
 	manOutput := filepath.Join(c.outputDir, fmt.Sprint(ui.version), "Manifest."+IndexBundle)
 	if err := idxMan.WriteManifestFile(manOutput); err != nil {
 		return nil, err


### PR DESCRIPTION
The file was no longer being used due to the actual bundle-info files
being published in the os-core-update-index bundle. Because this file is
very large and requires an update every version remove this file.

This commit also fixes a bug where the os-core-update-index bundle was
being created for every build, regardless of changes. This was not a
visibile bug when the os-core-update-index file itself was being created
because it had changes every time. Now that that file does not change
per release we should not be writing the manifest every time.

Fixes #468 