### PR TITLE
 swupd/format_switch: do not fail on 0 format

### DIFF
--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -301,11 +301,10 @@ func (MoM *Manifest) writeBundleManifests(newManifests []*Manifest, out string) 
 			continue
 		}
 
-		// TODO: remove this after a format bump in Clear Linux
-		// this is a hack to set maximum contentsize to the incorrect maximum
-		// set in swupd-client v3.15.3
-		bMan.setMaxContentSizeHack()
-		// end hack
+		// this sets maximum contentsize to the incorrect maximum set in
+		// swupd-client v3.15.3 if the manifest is in the format where the
+		// bug was introduced.
+		bMan.setMaxContentSizeForFormat()
 
 		// sort by version then by filename, previously to this sort these bundles
 		// were sorted by file name only to make processing easier

--- a/swupd/format_switch.go
+++ b/swupd/format_switch.go
@@ -81,3 +81,14 @@ func manifestTemplateForFormat(f uint) (*template.Template, error) {
 		return nil, fmt.Errorf("unsupported format %v", f)
 	}
 }
+
+// this is a hack to allow users to update using swupd-client v3.15.3 which performs a
+// check on contentsize with a maximum a couple of orders off the intended maximum.
+const badMax uint64 = 2000000000
+
+func (m *Manifest) setMaxContentSizeForFormat() {
+	// this bug only existed in format 25
+	if m.Header.Format == 25 && m.Header.ContentSize >= badMax {
+		m.Header.ContentSize = badMax - 1
+	}
+}

--- a/swupd/format_switch.go
+++ b/swupd/format_switch.go
@@ -15,7 +15,6 @@
 package swupd
 
 import (
-	"fmt"
 	"text/template"
 )
 
@@ -63,23 +62,21 @@ includes:	{{.Name}}
 
 // manifestTemplateForFormat returns the *template.Template for creating
 // manifests for the provided format f
-func manifestTemplateForFormat(f uint) (*template.Template, error) {
+func manifestTemplateForFormat(f uint) (t *template.Template) {
 	switch {
-	case f > 0 && f <= 25:
+	case f <= 25:
 		// initial format, everything 0-25 uses this format
-		return template.Must(template.New("manifest").Parse(manTemplates[25])), nil
+		t = template.Must(template.New("manifest").Parse(manTemplates[25]))
 	case f > 25:
 		// template for format 26
-		return template.Must(template.New("manifest").Parse(manTemplates[26])), nil
+		t = template.Must(template.New("manifest").Parse(manTemplates[26]))
 		// when a new format is required it must be added here and the 'case f
 		// > 25' must be modified to 'case f > 25 && f < <new_format>'. The
 		// <new_format> does not necessarily have to be 27 as format 27 may be
 		// created due to a content breaking change instead of a manifest
 		// format breaking change.
-	default:
-		// we do not support format 0 or below
-		return nil, fmt.Errorf("unsupported format %v", f)
 	}
+	return
 }
 
 // this is a hack to allow users to update using swupd-client v3.15.3 which performs a

--- a/swupd/format_switch_test.go
+++ b/swupd/format_switch_test.go
@@ -68,3 +68,47 @@ func TestManifestFormats25to26(t *testing.T) {
 	checkManifestContains(t, ts.Dir, "30", "test-bundle", expSubs...)
 	checkManifestContains(t, ts.Dir, "30", "MoM", "minversion:\t20")
 }
+
+func TestFormat25BadContentSize(t *testing.T) {
+	testCases := []struct {
+		testName    string
+		format      uint
+		contentsize uint64
+		expected    uint64
+	}{
+		// broken format
+		{"format25: badMax + 1", 25, badMax + 1, badMax - 1},
+		{"format25: badMax * 2", 25, badMax * 2, badMax - 1},
+		{"format25: badMax", 25, badMax, badMax - 1},
+		{"format25: badMax / 2", 25, badMax / 2, badMax / 2},
+		// good format
+		{"format26: badMax + 1", 26, badMax + 1, badMax + 1},
+		{"format26: badMax * 2", 26, badMax * 2, badMax * 2},
+		{"format26: badMax", 26, badMax, badMax},
+		{"format26: badMax / 2", 26, badMax / 2, badMax / 2},
+		// older good format
+		{"format24: badMax + 1", 24, badMax + 1, badMax + 1},
+		{"format24: badMax * 2", 24, badMax * 2, badMax * 2},
+		{"format24: badMax", 24, badMax, badMax},
+		{"format24: badMax / 2", 24, badMax / 2, badMax / 2},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			m := &Manifest{
+				Header: ManifestHeader{
+					Format:      tc.format,
+					ContentSize: tc.contentsize,
+				},
+			}
+			m.setMaxContentSizeForFormat()
+			if m.Header.ContentSize != tc.expected {
+				t.Errorf("%d contentsize set to %d, expected %d",
+					tc.contentsize,
+					m.Header.ContentSize,
+					tc.expected,
+				)
+			}
+		})
+	}
+}

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -905,16 +905,3 @@ func fileContentInManifest(f *File, m *Manifest) bool {
 	}
 	return false
 }
-
-// this is a hack to allow users to update using swupd-client v3.15.3 which performs a
-// check on contentsize with a maximum a couple of orders off the intended maximum.
-// Remove this code (and the caller) when a format bump has occurred in Clear.
-var badMax uint64 = 2000000000
-
-func (m *Manifest) setMaxContentSizeHack() {
-	if m.Header.ContentSize >= badMax {
-		m.Header.ContentSize = badMax - 1
-	}
-}
-
-// end hack

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -298,10 +298,7 @@ func (m *Manifest) WriteManifest(w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	t, err := manifestTemplateForFormat(m.Header.Format)
-	if err != nil {
-		return fmt.Errorf("couldn't write Manifest.%s: %s", m.Name, err)
-	}
+	t := manifestTemplateForFormat(m.Header.Format)
 	err = t.Execute(w, m)
 	if err != nil {
 		return fmt.Errorf("couldn't write Manifest.%s: %s", m.Name, err)


### PR DESCRIPTION
It is not the responsibility of the format_switch to check for non-zero
format, as this is an internal function and validation on the format
happens well before this function is called. It simplifies the caller so
it doesn't have to handle an error that will never occur and simplifies
the function itself so it doesn't have to explicitly check for
format == 0.

Based on #470 