### PR TITLE
Create DNF conf as part of mixer init

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -222,6 +222,11 @@ func (b *Builder) InitMix(upstreamVer string, mixVer string, allLocal bool, allU
 		}
 	}
 
+	// Create the DNF conf early in case we want to edit before building a first mix
+	if err := b.NewDNFConfIfNeeded(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -1,0 +1,51 @@
+package builder
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func mustExist(t *testing.T, name string) {
+	t.Helper()
+	_, err := os.Stat(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func cleanup(path string) {
+	_ = os.RemoveAll(path)
+}
+
+func TestNewDNFConfOnInit(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "dnf-testdir-")
+	if err != nil {
+		t.Fatalf("couldn't create temporary directory to write test cases: %s", err)
+	}
+	defer cleanup(testDir)
+	conf := testDir + "/builder.conf"
+
+	b := New()
+	b.Config.LoadDefaultsForPath(testDir)
+
+	if err = b.Config.InitConfigPath(conf); err != nil {
+		t.Errorf("Failed to init default config: %s", err)
+	}
+
+	if err = b.Config.SaveConfig(); err != nil {
+		t.Errorf("Failed to create default config: %s", err)
+	}
+
+	if err = b.Config.LoadConfig(conf); err != nil {
+		t.Errorf("Failed to load default builder.conf: %s", err)
+	}
+	Offline = true
+
+	err = b.InitMix("10", "10", false, false, true, "https://example.com", false)
+	if err != nil {
+		t.Errorf("Failed to initialize mix: %s", err)
+	}
+
+	mustExist(t, testDir+"/.yum-mix.conf")
+}

--- a/config/config.go
+++ b/config/config.go
@@ -121,7 +121,7 @@ func (config *MixConfig) CreateDefaultConfig() error {
 		return err
 	}
 
-	err := config.initConfigPath("")
+	err := config.InitConfigPath("")
 	if err != nil {
 		return err
 	}
@@ -184,7 +184,7 @@ func (config *MixConfig) SetProperty(propertyStr string, value string) error {
 // LoadConfig loads a configuration file from a provided path or from local directory
 // is none is provided
 func (config *MixConfig) LoadConfig(filename string) error {
-	if err := config.initConfigPath(filename); err != nil {
+	if err := config.InitConfigPath(filename); err != nil {
 		return err
 	}
 	if err := config.parseVersionAndConvert(); err != nil {
@@ -271,7 +271,7 @@ func (config *MixConfig) validate() error {
 
 // Convert parses an old config file and converts it to TOML format
 func (config *MixConfig) Convert(filename string) error {
-	if err := config.initConfigPath(filename); err != nil {
+	if err := config.InitConfigPath(filename); err != nil {
 		return err
 	}
 
@@ -296,12 +296,14 @@ func (config *MixConfig) Print() error {
 	return nil
 }
 
-func (config *MixConfig) initConfigPath(path string) error {
-	if path != "" {
-		config.filename = path
+// InitConfigPath sets the main config name to what was passed in,
+// or defaults to the current working directory + builder.conf
+func (config *MixConfig) InitConfigPath(fullpath string) error {
+	if fullpath != "" {
+		config.filename = fullpath
 		return nil
 	}
-
+	// Create a builder.conf in the current directory if none is passed in
 	pwd, err := os.Getwd()
 	if err != nil {
 		return err


### PR DESCRIPTION
One may wish to add or edit repos before building any mixes, but the DNF
(.yum-mix.conf) is not available until build-bundles is run.

Fixes #452

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>