### PR TITLE
cmd: do not warn when using format from mixer.state

### DIFF
--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -104,8 +104,6 @@ var RootCmd = &cobra.Command{
 				log.Println("Warning: The host format and mix upstream format do not match.",
 					"Mixer may be incompatible with this format; running natively may fail.")
 			}
-		} else if !builder.Offline {
-			log.Printf("Warning: Using Format=%s from mixer.state for this build.\n", b.State.Mix.Format)
 		}
 
 		// For non-bump build commands, check if building across a format


### PR DESCRIPTION
Since mixer.state is the expected and supported way for users to set
the format for their builds do not print a warning when doing so. This
warning was being printed for almost every operation, including adding
and removing bundles from the mix.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>