### PR TITLE
battest: Get format boundary from latest

### DIFF
--- a/bat/lib/mixerlib.bash
+++ b/bat/lib/mixerlib.bash
@@ -99,9 +99,7 @@ download-rpm() {
 get-last-format-boundary() {
   latest=$(curl https://download.clearlinux.org/latest)
   format=$(curl https://download.clearlinux.org/update/$latest/format)
-  first=$(curl https://download.clearlinux.org/update/version/format$format/first)
-
-  echo $(($first-10))
+  echo $(curl https://download.clearlinux.org/update/version/format$(($format-1))/latest)
 }
 
 # vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
Instead of getting first version of the current format and subtracting,
use the previous format and get the latest version directly.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>