### PR TITLE
init: Always set localrpms

### DIFF
--- a/bat/tests/07-config-conversion/configs/1.0_builder.conf
+++ b/bat/tests/07-config-conversion/configs/1.0_builder.conf
@@ -18,6 +18,6 @@
 
 [Mixer]
   LOCAL_BUNDLE_DIR = "/home/clr/mix/local-bundles"
-  LOCAL_REPO_DIR = ""
-  LOCAL_RPM_DIR = ""
+  LOCAL_REPO_DIR = "/home/clr/mix/local-yum"
+  LOCAL_RPM_DIR = "/home/clr/mix/local-rpms"
   DOCKER_IMAGE_PATH = "clearlinux/mixer"

--- a/bat/tests/07-config-conversion/configs/legacy_builder.conf
+++ b/bat/tests/07-config-conversion/configs/legacy_builder.conf
@@ -18,4 +18,6 @@ debuginfo_src=/usr/src/debug
 
 [Mixer]
 LOCAL_BUNDLE_DIR=/home/clr/mix/local-bundles
+LOCAL_REPO_DIR=/home/clr/mix/local-yum
+LOCAL_RPM_DIR=/home/clr/mix/local-rpms
 DOCKER_IMAGE_PATH=clearlinux/mixer

--- a/bat/tests/07-config-conversion/configs/nover_builder.conf
+++ b/bat/tests/07-config-conversion/configs/nover_builder.conf
@@ -17,6 +17,6 @@
 
 [Mixer]
   LOCAL_BUNDLE_DIR = "/home/clr/mix/local-bundles"
-  LOCAL_REPO_DIR = ""
-  LOCAL_RPM_DIR = ""
+  LOCAL_REPO_DIR = "/home/clr/mix/local-yum"
+  LOCAL_RPM_DIR = "/home/clr/mix/local-rpms"
   DOCKER_IMAGE_PATH = "clearlinux/mixer"

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -108,7 +108,7 @@ func New() *Builder {
 // NewFromConfig creates a new Builder with the given Configuration.
 func NewFromConfig(conf string) (*Builder, error) {
 	b := New()
-	if err := b.Config.LoadDefaults(false); err != nil {
+	if err := b.Config.LoadDefaults(); err != nil {
 		return nil, err
 	}
 	if err := b.State.Load(); err != nil {

--- a/builder/init.go
+++ b/builder/init.go
@@ -36,17 +36,13 @@ func (b *Builder) getLatestUpstreamVersion() (string, error) {
 // initDirs creates the directories mixer uses
 func (b *Builder) initDirs() error {
 	// Create folder to store local rpms if defined but doesn't already exist
-	if b.Config.Mixer.LocalRPMDir != "" {
-		if err := os.MkdirAll(b.Config.Mixer.LocalRPMDir, 0777); err != nil {
-			return errors.Wrap(err, "Failed to create local rpms directory")
-		}
+	if err := os.MkdirAll(b.Config.Mixer.LocalRPMDir, 0777); err != nil {
+		return errors.Wrap(err, "Failed to create local rpms directory")
 	}
 
 	// Create folder for local dnf repo if defined but doesn't already exist
-	if b.Config.Mixer.LocalRepoDir != "" {
-		if err := os.MkdirAll(b.Config.Mixer.LocalRepoDir, 0777); err != nil {
-			return errors.Wrap(err, "Failed to create local rpms directory")
-		}
+	if err := os.MkdirAll(b.Config.Mixer.LocalRepoDir, 0777); err != nil {
+		return errors.Wrap(err, "Failed to create local rpms directory")
 	}
 
 	// Create folder for local bundle files

--- a/config/config.go
+++ b/config/config.go
@@ -72,18 +72,18 @@ type mixerConf struct {
 }
 
 // LoadDefaults sets sane values for the config properties
-func (config *MixConfig) LoadDefaults(localrpms bool) error {
+func (config *MixConfig) LoadDefaults() error {
 	pwd, err := os.Getwd()
 	if err != nil {
 		return err
 	}
 
-	config.LoadDefaultsForPath(localrpms, pwd)
+	config.LoadDefaultsForPath(pwd)
 	return nil
 }
 
 // LoadDefaultsForPath sets sane values for config properties using `path` as base directory
-func (config *MixConfig) LoadDefaultsForPath(localrpms bool, path string) {
+func (config *MixConfig) LoadDefaultsForPath(path string) {
 
 	// [Builder]
 	config.Builder.Cert = filepath.Join(path, "Swupd_Root.pem")
@@ -105,13 +105,8 @@ func (config *MixConfig) LoadDefaultsForPath(localrpms bool, path string) {
 	config.Mixer.LocalBundleDir = filepath.Join(path, "local-bundles")
 	config.Mixer.DockerImgPath = "clearlinux/mixer"
 
-	if localrpms {
-		config.Mixer.LocalRPMDir = filepath.Join(path, "local-rpms")
-		config.Mixer.LocalRepoDir = filepath.Join(path, "local-yum")
-	} else {
-		config.Mixer.LocalRPMDir = ""
-		config.Mixer.LocalRepoDir = ""
-	}
+	config.Mixer.LocalRPMDir = filepath.Join(path, "local-rpms")
+	config.Mixer.LocalRepoDir = filepath.Join(path, "local-yum")
 
 	config.version = CurrentConfigVersion
 	config.filename = filepath.Join(path, "builder.conf")
@@ -121,8 +116,8 @@ func (config *MixConfig) LoadDefaultsForPath(localrpms bool, path string) {
 
 // CreateDefaultConfig creates a default builder.conf using the active
 // directory as base path for the variables values.
-func (config *MixConfig) CreateDefaultConfig(localrpms bool) error {
-	if err := config.LoadDefaults(localrpms); err != nil {
+func (config *MixConfig) CreateDefaultConfig() error {
+	if err := config.LoadDefaults(); err != nil {
 		return err
 	}
 
@@ -280,7 +275,7 @@ func (config *MixConfig) Convert(filename string) error {
 		return err
 	}
 
-	if err := config.LoadDefaults(false); err != nil {
+	if err := config.LoadDefaults(); err != nil {
 		return err
 	}
 

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -166,7 +166,6 @@ type initCmdFlags struct {
 	noDefaults  bool
 	clearVer    string
 	mixver      int
-	localRPMs   bool
 	upstreamURL string
 	git         bool
 	format      string
@@ -190,7 +189,7 @@ var initCmd = &cobra.Command{
 		b := builder.New()
 		if configFile == "" {
 			// Create default config if necessary
-			if err := b.Config.CreateDefaultConfig(initFlags.localRPMs); err != nil {
+			if err := b.Config.CreateDefaultConfig(); err != nil {
 				fail(err)
 			}
 		}
@@ -246,13 +245,17 @@ func init() {
 	RootCmd.Flags().BoolVar(&rootCmdFlags.version, "version", false, "Print version information and quit")
 	RootCmd.Flags().BoolVar(&rootCmdFlags.check, "check", false, "Check all dependencies needed by mixer and quit")
 
+	// Deprecated Init flags
+	initCmd.Flags().BoolVar(&unusedBoolFlag, "local-rpms", false, "")
+	_ = initCmd.Flags().MarkHidden("local-rpms")
+	_ = initCmd.Flags().MarkDeprecated("local-rpms", "Local rpm folders are now always created by default")
+
 	initCmd.Flags().BoolVar(&initFlags.allLocal, "all-local", false, "Initialize mix with all local bundles automatically included")
 	initCmd.Flags().BoolVar(&initFlags.allUpstream, "all-upstream", false, "Initialize mix with all upstream bundles automatically included")
 	initCmd.Flags().BoolVar(&initFlags.noDefaults, "no-default-bundles", false, "Skip adding default bundles to the mix")
 	initCmd.Flags().StringVar(&initFlags.clearVer, "clear-version", "latest", "Supply the Clear version to compose the mix from")
 	initCmd.Flags().StringVar(&initFlags.clearVer, "upstream-version", "latest", "Alias to --clear-version")
 	initCmd.Flags().IntVar(&initFlags.mixver, "mix-version", 10, "Supply the Mix version to build")
-	initCmd.Flags().BoolVar(&initFlags.localRPMs, "local-rpms", false, "Create and configure local RPMs directories")
 	initCmd.Flags().StringVar(&configFile, "config", "", "Supply a specific builder.conf to use for mixing")
 	initCmd.Flags().StringVar(&initFlags.upstreamURL, "upstream-url", "https://download.clearlinux.org", "Supply an upstream URL to use for mixing")
 	initCmd.Flags().BoolVar(&initFlags.git, "git", false, "Track mixer's internal work dir with git")

--- a/mixin/helpers.go
+++ b/mixin/helpers.go
@@ -105,7 +105,7 @@ func setUpMixDir(upstreamVer, mixVer int) error {
 		return err
 	}
 	var c config.MixConfig
-	c.LoadDefaultsForPath(true, "/usr/share/mix")
+	c.LoadDefaultsForPath("/usr/share/mix")
 	c.Swupd.Bundle = "os-core"
 	c.Swupd.ContentURL = "file:///usr/share/mix/update/www"
 	c.Swupd.VersionURL = "file:///usr/share/mix/update/www"


### PR DESCRIPTION
The existence of local repo and local rpms folder has no impact if they
are not used in the mix. This patch removes the `--local-rpms` flag for
`mixer init` and make it always true. This way both folders are always
created and configured in builder.conf during init.

This patch also update the test cases for config convert to address this
change since.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>