### PR TITLE
Cli Rework

### DIFF
--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -521,7 +521,6 @@ var buildCmds = []*cobra.Command{
 func init() {
 	for _, cmd := range buildCmds {
 		buildCmd.AddCommand(cmd)
-		cmd.Flags().StringVarP(&configFile, "config", "c", "", "Builder config to use")
 	}
 
 	buildFormatBumpCmd.AddCommand(buildFormatNewCmd)

--- a/mixer/cmd/bundles.go
+++ b/mixer/cmd/bundles.go
@@ -264,7 +264,6 @@ var bundlesCmds = []*cobra.Command{
 func init() {
 	for _, cmd := range bundlesCmds {
 		bundleCmd.AddCommand(cmd)
-		cmd.Flags().StringVarP(&configFile, "config", "c", "", "Builder config to use")
 	}
 
 	RootCmd.AddCommand(bundleCmd)

--- a/mixer/cmd/config.go
+++ b/mixer/cmd/config.go
@@ -95,7 +95,6 @@ var configCmds = []*cobra.Command{
 func init() {
 	for _, cmd := range configCmds {
 		configCmd.AddCommand(cmd)
-		cmd.Flags().StringVarP(&configFile, "config", "c", "", "Builder config to use")
 	}
 
 	RootCmd.AddCommand(configCmd)

--- a/mixer/cmd/init.go
+++ b/mixer/cmd/init.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"strconv"
+
+	"github.com/clearlinux/mixer-tools/builder"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+type initCmdFlags struct {
+	allLocal    bool
+	allUpstream bool
+	noDefaults  bool
+	clearVer    string
+	mixver      int
+	upstreamURL string
+	git         bool
+	format      string
+}
+
+var initFlags initCmdFlags
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize the mixer workspace",
+	Long:  `Initialize the mixer workspace`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if _, err := strconv.Atoi(initFlags.clearVer); err != nil {
+			if initFlags.clearVer != "latest" {
+				// Note: output matches Cobra's default pflag error syntax, as
+				// if initFlags.clearVer were an int all along.
+				return errors.Errorf("invalid argument \"%s\" for \"--clear-version\" flag: %s", initFlags.clearVer, err)
+			}
+		}
+
+		b := builder.New()
+		if configFile == "" {
+			// Create default config if necessary
+			if err := b.Config.CreateDefaultConfig(); err != nil {
+				fail(err)
+			}
+		}
+
+		if err := b.Config.LoadConfig(configFile); err != nil {
+			fail(err)
+		}
+
+		b.State.LoadDefaults()
+		if initFlags.format != "" {
+			b.State.Mix.Format = initFlags.format
+		}
+		if err := b.State.Save(); err != nil {
+			fail(err)
+		}
+
+		err := b.InitMix(initFlags.clearVer, strconv.Itoa(initFlags.mixver), initFlags.allLocal, initFlags.allUpstream, initFlags.noDefaults, initFlags.upstreamURL, initFlags.git)
+		if err != nil {
+			fail(err)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(initCmd)
+
+	// Deprecated Init flags
+	unusedBoolFlag := false
+	initCmd.Flags().BoolVar(&unusedBoolFlag, "local-rpms", false, "")
+	_ = initCmd.Flags().MarkHidden("local-rpms")
+	_ = initCmd.Flags().MarkDeprecated("local-rpms", "Local rpm folders are now always created by default")
+
+	initCmd.Flags().BoolVar(&initFlags.allLocal, "all-local", false, "Initialize mix with all local bundles automatically included")
+	initCmd.Flags().BoolVar(&initFlags.allUpstream, "all-upstream", false, "Initialize mix with all upstream bundles automatically included")
+	initCmd.Flags().BoolVar(&initFlags.noDefaults, "no-default-bundles", false, "Skip adding default bundles to the mix")
+	initCmd.Flags().StringVar(&initFlags.clearVer, "clear-version", "latest", "Supply the Clear version to compose the mix from")
+	initCmd.Flags().StringVar(&initFlags.clearVer, "upstream-version", "latest", "Alias to --clear-version")
+	initCmd.Flags().IntVar(&initFlags.mixver, "mix-version", 10, "Supply the Mix version to build")
+	initCmd.Flags().StringVar(&initFlags.upstreamURL, "upstream-url", "https://download.clearlinux.org", "Supply an upstream URL to use for mixing")
+	initCmd.Flags().BoolVar(&initFlags.git, "git", false, "Track mixer's internal work dir with git")
+	initCmd.Flags().StringVar(&initFlags.format, "format", "", "Supply the format version for the mix")
+
+	externalDeps[initCmd] = []string{
+		"git",
+	}
+}

--- a/mixer/cmd/repos.go
+++ b/mixer/cmd/repos.go
@@ -90,7 +90,6 @@ var repoCmds = []*cobra.Command{
 func init() {
 	for _, cmd := range repoCmds {
 		repoCmd.AddCommand(cmd)
-		cmd.Flags().StringVarP(&configFile, "config", "c", "", "Builder config to use")
 	}
 
 	RootCmd.AddCommand(repoCmd)

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -21,7 +21,6 @@ import (
 	"os/exec"
 	"runtime/pprof"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/clearlinux/mixer-tools/builder"
@@ -96,61 +95,6 @@ var rootCmdFlags = struct {
 	cpuProfile string
 }{}
 
-type initCmdFlags struct {
-	allLocal    bool
-	allUpstream bool
-	noDefaults  bool
-	clearVer    string
-	mixver      int
-	upstreamURL string
-	git         bool
-	format      string
-}
-
-var initFlags initCmdFlags
-
-var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialize the mixer and workspace",
-	Long:  `Initialize the mixer and workspace`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if _, err := strconv.Atoi(initFlags.clearVer); err != nil {
-			if initFlags.clearVer != "latest" {
-				// Note: output matches Cobra's default pflag error syntax, as
-				// if initFlags.clearVer were an int all along.
-				return errors.Errorf("invalid argument \"%s\" for \"--clear-version\" flag: %s", initFlags.clearVer, err)
-			}
-		}
-
-		b := builder.New()
-		if configFile == "" {
-			// Create default config if necessary
-			if err := b.Config.CreateDefaultConfig(); err != nil {
-				fail(err)
-			}
-		}
-
-		if err := b.Config.LoadConfig(configFile); err != nil {
-			fail(err)
-		}
-
-		b.State.LoadDefaults()
-		if initFlags.format != "" {
-			b.State.Mix.Format = initFlags.format
-		}
-		if err := b.State.Save(); err != nil {
-			fail(err)
-		}
-
-		err := b.InitMix(initFlags.clearVer, strconv.Itoa(initFlags.mixver), initFlags.allLocal, initFlags.allUpstream, initFlags.noDefaults, initFlags.upstreamURL, initFlags.git)
-		if err != nil {
-			fail(err)
-		}
-
-		return nil
-	},
-}
-
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
@@ -178,28 +122,8 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&builder.Offline, "offline", false, "Skip caching upstream-bundles; work entirely with local-bundles")
 	RootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "", "Supply a specific builder.conf to use for mixing")
 
-	RootCmd.AddCommand(initCmd)
 	RootCmd.Flags().BoolVar(&rootCmdFlags.version, "version", false, "Print version information and quit")
 	RootCmd.Flags().BoolVar(&rootCmdFlags.check, "check", false, "Check all dependencies needed by mixer and quit")
-
-	// Deprecated Init flags
-	initCmd.Flags().BoolVar(&unusedBoolFlag, "local-rpms", false, "")
-	_ = initCmd.Flags().MarkHidden("local-rpms")
-	_ = initCmd.Flags().MarkDeprecated("local-rpms", "Local rpm folders are now always created by default")
-
-	initCmd.Flags().BoolVar(&initFlags.allLocal, "all-local", false, "Initialize mix with all local bundles automatically included")
-	initCmd.Flags().BoolVar(&initFlags.allUpstream, "all-upstream", false, "Initialize mix with all upstream bundles automatically included")
-	initCmd.Flags().BoolVar(&initFlags.noDefaults, "no-default-bundles", false, "Skip adding default bundles to the mix")
-	initCmd.Flags().StringVar(&initFlags.clearVer, "clear-version", "latest", "Supply the Clear version to compose the mix from")
-	initCmd.Flags().StringVar(&initFlags.clearVer, "upstream-version", "latest", "Alias to --clear-version")
-	initCmd.Flags().IntVar(&initFlags.mixver, "mix-version", 10, "Supply the Mix version to build")
-	initCmd.Flags().StringVar(&initFlags.upstreamURL, "upstream-url", "https://download.clearlinux.org", "Supply an upstream URL to use for mixing")
-	initCmd.Flags().BoolVar(&initFlags.git, "git", false, "Track mixer's internal work dir with git")
-	initCmd.Flags().StringVar(&initFlags.format, "format", "", "Supply the format version for the mix")
-
-	externalDeps[initCmd] = []string{
-		"git",
-	}
 }
 
 func cancelRun(cmd *cobra.Command) {

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -63,6 +63,8 @@ var RootCmd = &cobra.Command{
 				}
 				os.Exit(0)
 			}
+
+			return nil
 		}
 
 		// Commands that don't require the config to be pre-parsed must be

--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -242,6 +242,7 @@ func init() {
 
 	RootCmd.PersistentFlags().BoolVar(&builder.Native, "native", false, "Run mixer command on native host instead of in a container")
 	RootCmd.PersistentFlags().BoolVar(&builder.Offline, "offline", false, "Skip caching upstream-bundles; work entirely with local-bundles")
+	RootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "", "Supply a specific builder.conf to use for mixing")
 
 	RootCmd.AddCommand(initCmd)
 	RootCmd.Flags().BoolVar(&rootCmdFlags.version, "version", false, "Print version information and quit")
@@ -258,7 +259,6 @@ func init() {
 	initCmd.Flags().StringVar(&initFlags.clearVer, "clear-version", "latest", "Supply the Clear version to compose the mix from")
 	initCmd.Flags().StringVar(&initFlags.clearVer, "upstream-version", "latest", "Alias to --clear-version")
 	initCmd.Flags().IntVar(&initFlags.mixver, "mix-version", 10, "Supply the Mix version to build")
-	initCmd.Flags().StringVar(&configFile, "config", "", "Supply a specific builder.conf to use for mixing")
 	initCmd.Flags().StringVar(&initFlags.upstreamURL, "upstream-url", "https://download.clearlinux.org", "Supply an upstream URL to use for mixing")
 	initCmd.Flags().BoolVar(&initFlags.git, "git", false, "Track mixer's internal work dir with git")
 	initCmd.Flags().StringVar(&initFlags.format, "format", "", "Supply the format version for the mix")

--- a/mixer/cmd/rpms.go
+++ b/mixer/cmd/rpms.go
@@ -35,7 +35,6 @@ var rpmCmds = []*cobra.Command{
 func init() {
 	for _, cmd := range rpmCmds {
 		RootCmd.AddCommand(cmd)
-		cmd.Flags().StringVarP(&configFile, "config", "c", "", "Builder config to use")
 	}
 
 	externalDeps[addRPMCmd] = []string{

--- a/mixer/cmd/versions.go
+++ b/mixer/cmd/versions.go
@@ -63,7 +63,6 @@ func init() {
 	versionsCmd.AddCommand(versionsUpdateCmd)
 	RootCmd.AddCommand(versionsCmd)
 
-	versionsUpdateCmd.Flags().StringVarP(&configFile, "config", "c", "", "Builder config to use")
 	versionsUpdateCmd.Flags().Uint32Var(&versionsUpdateFlags.mixVersion, "mix-version", 0, "Set a specific mix version")
 	versionsUpdateCmd.Flags().StringVar(&versionsUpdateFlags.upstreamVersion, "upstream-version", "", "Next upstream version (either version number or 'latest')")
 	versionsUpdateCmd.Flags().StringVar(&versionsUpdateFlags.upstreamVersion, "clear-version", "", "Alias to --upstream-version")


### PR DESCRIPTION
This might not look like, but it is part of my offline patch. It was so complicated to track all code paths that I end up cleaning up the root code path on the cli module.

This PR includes a couple cleanups and refactor in `cmd` as well as a major rework of root's preRun function.