### PR TITLE
bundles: Remove editor option for `bundle edit`

### DIFF
--- a/afb.sh
+++ b/afb.sh
@@ -33,7 +33,7 @@ pushd afb-test
 # init minimal mix with original format
 mixer init --no-default-bundles --format 1
 # create bundle to be deleted
-mixer bundle edit foo
+mixer bundle create foo
 # mark as deleted
 sed -i "s/\(# \[STATUS\]:\).*/\1 Deprecated/" local-bundles/foo
 # add minimal bundles including deleted bundle

--- a/afb.sh
+++ b/afb.sh
@@ -33,7 +33,7 @@ pushd afb-test
 # init minimal mix with original format
 mixer init --no-default-bundles --format 1
 # create bundle to be deleted
-mixer bundle edit foo --suppress-editor
+mixer bundle edit foo
 # mark as deleted
 sed -i "s/\(# \[STATUS\]:\).*/\1 Deprecated/" local-bundles/foo
 # add minimal bundles including deleted bundle

--- a/bat/lib/mixerlib.bash
+++ b/bat/lib/mixerlib.bash
@@ -82,7 +82,7 @@ mixer-add-rpms() {
 }
 
 create-empty-local-bundle() {
-  mixer bundle edit $1 --suppress-editor
+  mixer bundle edit $1
 }
 
 add-package-to-local-bundle() {

--- a/bat/lib/mixerlib.bash
+++ b/bat/lib/mixerlib.bash
@@ -82,7 +82,7 @@ mixer-add-rpms() {
 }
 
 create-empty-local-bundle() {
-  mixer bundle edit $1
+  mixer bundle create $1
 }
 
 add-package-to-local-bundle() {

--- a/bat/tests/bundle-commands/run.bats
+++ b/bat/tests/bundle-commands/run.bats
@@ -17,7 +17,7 @@ setup() {
 }
 
 @test "List the bundles in the mix" {
-  mixer bundle edit foo.bar --suppress-editor # 'bundle list' should work even if an invalid bundle is created
+  mixer bundle create foo.bar           # 'bundle list' should work even if an invalid bundle is created
 
   run mixer $MIXARGS bundle list
   [[ ${#lines[@]} -eq 4 ]]              # Exactly 4 bundles in the mix
@@ -37,7 +37,7 @@ setup() {
   [[ "$output" =~ editors[[:space:]]+\(upstream ]] # "editors" bundle is from upstream
 }
 
-@test "Edit upstream bundle" {
+@test "Create upstream bundle" {
   run mixer $MIXARGS bundle list
   [[ "$output" =~ editors[[:space:]]+\(upstream ]]              # "editors" bundle is from upstream
   [[ $(ls -1q $BATS_TEST_DIRNAME/local-bundles | wc -l) == 0 ]] # Nothing in local-bundles
@@ -45,7 +45,7 @@ setup() {
   run mixer $MIXARGS bundle list local
   [[ ${#lines[@]} -eq 0 ]]                                      # 'list local' returns no results
 
-  mixer $MIXARGS bundle edit editors
+  mixer $MIXARGS bundle create editors
   [[ $(ls -1q $BATS_TEST_DIRNAME/local-bundles) = "editors" ]]  # local-bundles only has "editors"
 
   run mixer $MIXARGS bundle list
@@ -57,31 +57,36 @@ setup() {
 }
 
 @test "Create original bundle and add to mix" {
-  mixer $MIXARGS bundle edit foobar --add
+  mixer $MIXARGS bundle create foobar --add
+  mixer $MIXARGS bundle edit foocar --suppress-editor --add     # `edit` command test
 
   run ls -1q $BATS_TEST_DIRNAME/local-bundles
-  [[ ${#lines[@]} -eq 2 ]]                     # 2 bundles in local-bundles
+  [[ ${#lines[@]} -eq 3 ]]                     # 3 bundles in local-bundles
   [[ "$output" =~ foobar ]]                    # local-bundles now contains "foobar"
+  [[ "$output" =~ foocar ]]                    # local-bundles now contains "foocar"
 
   run mixer $MIXARGS bundle list
   [[ "$output" =~ foobar[[:space:]]+\(local ]] # "foobar" bundle is from local
+  [[ "$output" =~ foocar[[:space:]]+\(local ]] # "foocar" bundle is from local
 
   run mixer $MIXARGS bundle list local
-  [[ ${#lines[@]} -eq 2 ]]                     # 'list local' returns 2 results
+  [[ ${#lines[@]} -eq 3 ]]                     # 'list local' returns 3 results
   [[ "$output" =~ .*foobar.* ]]                # "foobar" bundle is in output
+  [[ "$output" =~ .*foocar.* ]]                # "foocar" bundle is in output
+
 }
 
 @test "Remove bundle from mix" {
   mixer $MIXARGS bundle remove editors
 
-  [[ $(ls -1q $BATS_TEST_DIRNAME/local-bundles | wc -l) == 2 ]] # Still 2 bundles in local-bundles
+  [[ $(ls -1q $BATS_TEST_DIRNAME/local-bundles | wc -l) == 3 ]] # Still 3 bundles in local-bundles
 
   ! mixer $MIXARGS bundle list | grep -q editors                # "editors" no longer in mix
 }
 
 @test "Validate a bundle" {
   echo "package" >> $BATS_TEST_DIRNAME/local-bundles/foobar
-  mixer $MIXARGS bundle edit foo.bar
+  mixer $MIXARGS bundle create foo.bar
 
   run mixer $MIXARGS bundle validate foobar
   [[ "$status" -eq 0 ]]                        # basic validation should pass

--- a/builder/bundle_control.go
+++ b/builder/bundle_control.go
@@ -751,15 +751,15 @@ func createBundleFile(bundle string, path string) error {
 	return err
 }
 
-// EditBundles copies a list of bundles from upstream-bundles to local-bundles
-// (if they are not already there) or creates a blank template if they are new.
+// CreateBundles copies a list of bundles from upstream-bundles to local-bundles
+// if they are not already there or creates a blank template if they are new.
 // 'add' will also add the bundles to the mix.
-func (b *Builder) EditBundles(bundles []string, add bool, git bool) error {
+func (b *Builder) CreateBundles(bundles []string, add bool, git bool) error {
 	// Fetch upstream bundle files if needed
 	if err := b.getUpstreamBundles(b.UpstreamVer, true); err != nil {
 		return err
 	}
-
+	var err error
 	for _, bundle := range bundles {
 		path, _ := b.getBundlePath(bundle)
 		if !b.isLocalBundle(path) {
@@ -767,20 +767,21 @@ func (b *Builder) EditBundles(bundles []string, add bool, git bool) error {
 
 			if path == "" {
 				// Bundle not found upstream, so create new
-				if err := createBundleFile(bundle, localPath); err != nil {
+				if err = createBundleFile(bundle, localPath); err != nil {
 					return errors.Wrapf(err, "Failed to write bundle template for bundle %q", bundle)
 				}
 			} else {
 				// Bundle found upstream, so copy over
-				if err := helpers.CopyFile(localPath, path); err != nil {
+				if err = helpers.CopyFile(localPath, path); err != nil {
 					return err
 				}
 			}
 		}
+		fmt.Printf("Created bundle %q in %q\n", bundle, b.Config.Mixer.LocalBundleDir)
 	}
 
 	if add {
-		if err := b.AddBundles(bundles, false, false, false); err != nil {
+		if err = b.AddBundles(bundles, false, false, false); err != nil {
 			return err
 		}
 	}

--- a/builder/bundleset.go
+++ b/builder/bundleset.go
@@ -141,8 +141,7 @@ func validateBundleFile(filename string, lvl ValidationLevel) error {
 
 	b, err := parseBundleFile(filename)
 	if err != nil {
-		errText += err.Error()
-		return errors.New(errText)
+		errText += err.Error() + "\n"
 	}
 
 	if lvl == BasicValidation {

--- a/docs/mixer.1.rst
+++ b/docs/mixer.1.rst
@@ -86,9 +86,8 @@ SUBCOMMANDS
 ``bundle``
 
     Perform various configuration actions on local and upstream bundles. The
-    user can add or remove bundles from their mix, edit local and upstream
-    bundles, create new bundle definitions, or validate local bundle definition
-    files. See ``mixer.bundle``\(1) for more details.
+    user can add or remove bundles from their mix, create new bundle definitions,
+    or validate local bundle definition files. See ``mixer.bundle``\(1) for more details.
 
 ``config``
 

--- a/docs/mixer.bundle.1
+++ b/docs/mixer.bundle.1
@@ -79,30 +79,18 @@ Display \fBbundle add\fP help information and exit.
 \fBedit\fP
 .INDENT 0.0
 .INDENT 3.5
-Edits local and upstream bundle definition files. This command will locate
-the bundle (looking first in local\-bundles, then in upstream\-bundles), and
-launch an editor to edit it. If the bundle is only found upstream, the
-bundle file will first be copied to your local\-bundles directory for
-editing. If the bundle is not found anywhere, a blank template is created
-with the correct name. When the editor closes, the bundle file is then
-parsed for validity.
-.sp
-The editor is configured via environment variables. VISUAL takes precedence
-to EDITOR. If neither are set, the tool defaults to nano. If nano is not
-installed, the tool will skip editing, and act as if \(aq\-\-suppress\-editor\(aq had
-been passed.
-.sp
-Passing \(aq\-\-suppress\-editor\(aq will suppress launching the editor, and will
-thus only copy the bundle file to local\-bundles (if it is only found
-upstream), or create the blank template (if it was not found anywhere). This
-can be useful if you want to add a bundle to local\-bundles, but wish to edit
-it at a later time.
+Creates local and upstream bundle definition files.
+This command will locate the bundle by first looking in local\-bundles,
+and then in upstream\-bundles. If the bundle is only found upstream, the
+bundle file will be copied to your local\-bundles directory.
+If the bundle is not found anywhere, a blank template is created
+with the correct name.
 .sp
 Passing \(aq\-\-add\(aq will also add the bundle(s) to your mix. Please note that
-bundles are added after all bundles are edited, and thus will not be added
+bundles are added after all bundles are created, and thus will not be added
 if any errors are encountered earlier on.
 .sp
-In addition to the global options \fBmixer bundle edit\fP takes the following
+In addition to the global options \fBmixer bundle create\fP takes the following
 options.
 .INDENT 0.0
 .IP \(bu 2
@@ -124,7 +112,7 @@ version control.
 .IP \(bu 2
 \fB\-h, \-\-help\fP
 .sp
-Display \fBbundle edit\fP help information and exit.
+Display \fBbundle create\fP help information and exit.
 .IP \(bu 2
 \fB\-\-suppress\-editor\fP
 .sp
@@ -217,7 +205,7 @@ checked; upstream bundles are trusted as valid. Valid bundles yield no
 output. Any invalid bundles will yield a non\-zero return code.
 .sp
 Basic validation includes checking syntax and structure, and that the bundle
-has a valid name. Commands like \fBmixer bundle edit\fP run basic validation
+has a valid name. Commands like \fBmixer bundle add\fP run basic validation
 automatically.
 .sp
 In addition to the global options \fBmixer bundle remove\fP takes the

--- a/docs/mixer.bundle.1.rst
+++ b/docs/mixer.bundle.1.rst
@@ -58,18 +58,19 @@ SUBCOMMANDS
 
       Display ``bundle add`` help information and exit.
 
-``edit``
+``create``
 
-    Create new bundles or copy existing bundles. This command will locate the
-    bundle (looking first in local-bundles, then in upstream-bundles). If the bundle is only found upstream,
+    Create new bundles or copy existing bundles.
+    This command will locate the bundle by first looking in local-bundles,
+    and then in upstream-bundles. If the bundle is only found upstream,
     the bundle file will be copied to your local-bundles directory. If the bundle is
     not found anywhere, a blank template will be created with the correct name.
 
     Passing '--add' will also add the bundle(s) to your mix. Please note that
-    bundles are added after all bundles are edited, and thus will not be added
+    bundles are added after all bundles are created, and thus will not be added
     if any errors are encountered earlier on.
 
-    In addition to the global options ``mixer bundle edit`` takes the following
+    In addition to the global options ``mixer bundle create`` takes the following
     options.
 
     - ``--add``
@@ -90,7 +91,7 @@ SUBCOMMANDS
 
     - ``-h, --help``
 
-      Display ``bundle edit`` help information and exit.
+      Display ``bundle create`` help information and exit.
 
 ``list [mix|local|upstream] [flags]``
 
@@ -164,7 +165,7 @@ SUBCOMMANDS
     output. Any invalid bundles will yield a non-zero return code.
 
     Basic validation includes checking syntax and structure, and that the bundle
-    has a valid name. Commands like ``mixer bundle edit`` run basic validation
+    has a valid name. Commands like ``mixer bundle add`` run basic validation
     automatically.
 
     In addition to the global options ``mixer bundle remove`` takes the

--- a/docs/mixer.bundle.1.rst
+++ b/docs/mixer.bundle.1.rst
@@ -60,24 +60,10 @@ SUBCOMMANDS
 
 ``edit``
 
-    Edits local and upstream bundle definition files. This command will locate
-    the bundle (looking first in local-bundles, then in upstream-bundles), and
-    launch an editor to edit it. If the bundle is only found upstream, the
-    bundle file will first be copied to your local-bundles directory for
-    editing. If the bundle is not found anywhere, a blank template is created
-    with the correct name. When the editor closes, the bundle file is then
-    parsed for validity.
-
-    The editor is configured via environment variables. VISUAL takes precedence
-    to EDITOR. If neither are set, the tool defaults to nano. If nano is not
-    installed, the tool will skip editing, and act as if '--suppress-editor' had
-    been passed.
-
-    Passing '--suppress-editor' will suppress launching the editor, and will
-    thus only copy the bundle file to local-bundles (if it is only found
-    upstream), or create the blank template (if it was not found anywhere). This
-    can be useful if you want to add a bundle to local-bundles, but wish to edit
-    it at a later time.
+    Create new bundles or copy existing bundles. This command will locate the
+    bundle (looking first in local-bundles, then in upstream-bundles). If the bundle is only found upstream,
+    the bundle file will be copied to your local-bundles directory. If the bundle is
+    not found anywhere, a blank template will be created with the correct name.
 
     Passing '--add' will also add the bundle(s) to your mix. Please note that
     bundles are added after all bundles are edited, and thus will not be added
@@ -105,11 +91,6 @@ SUBCOMMANDS
     - ``-h, --help``
 
       Display ``bundle edit`` help information and exit.
-
-    - ``--suppress-editor``
-
-      Suppress launching editor and only copy to local-bundles or create a
-      template for the bundle.
 
 ``list [mix|local|upstream] [flags]``
 

--- a/mixer/cmd/bundles.go
+++ b/mixer/cmd/bundles.go
@@ -153,24 +153,25 @@ var bundleListCmd = &cobra.Command{
 	},
 }
 
-// Bundle Edit command ('mixer bundle edit')
-type bundleEditCmdFlags struct {
-	add bool
-	git bool
+// Bundle Create command ('mixer bundle create')
+type bundleCreateCmdFlags struct {
+	copyOnly bool
+	add      bool
+	git      bool
 }
 
-var bundleEditFlags bundleEditCmdFlags
+var bundleCreateFlags bundleCreateCmdFlags
 
-var bundleEditCmd = &cobra.Command{
-	Use:   "edit <bundle> [<bundle>...]",
-	Short: "Create new bundles or copy existing bundles",
-	Long: `Create new bundles or copy existing bundles. This command will locate the
-bundle (looking first in local-bundles, then in upstream-bundles). If the bundle is only found upstream,
-the bundle file will be copied to your local-bundles directory. If the bundle is
-not found anywhere, a blank template will be created with the correct name.
+var bundleCreateCmd = &cobra.Command{
+	Use:     "create <bundle> [<bundle>...]",
+	Aliases: []string{"edit"},
+	Short:   "Create new bundles or copy existing bundles",
+	Long: `Create new bundles or copy existing bundles. This command will locate the bundle by first looking in
+local-bundles, and then in upstream-bundles. If the bundle is only found upstream, the bundle file will be copied to
+your local-bundles directory. If the bundle is not found anywhere, a blank template will be created with the correct name.
 
 Passing '--add' will also add the bundle(s) to your mix. Please note that
-bundles are added after all bundles are edited, and thus will not be added if
+bundles are added after all bundles are created, and thus will not be added if
 any errors are encountered earlier on.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -179,7 +180,7 @@ any errors are encountered earlier on.`,
 			fail(err)
 		}
 
-		err = b.EditBundles(args, bundleEditFlags.add, bundleEditFlags.git)
+		err = b.CreateBundles(args, bundleCreateFlags.add, bundleCreateFlags.git)
 		if err != nil {
 			fail(err)
 		}
@@ -202,7 +203,7 @@ checked; upstream bundles are trusted as valid. Valid bundles yield no output.
 Any invalid bundles will yield a non-zero return code.
 
 Basic validation includes checking syntax and structure, and that the bundle has
-a valid name. Commands like 'mixer bundle edit' run basic validation
+a valid name. Commands like 'mixer bundle add' run basic validation
 automatically.
 
 An optional '--strict' flag allows you to additionally check that the bundle 
@@ -245,7 +246,7 @@ var bundlesCmds = []*cobra.Command{
 	bundleAddCmd,
 	bundleRemoveCmd,
 	bundleListCmd,
-	bundleEditCmd,
+	bundleCreateCmd,
 	bundleValidateCmd,
 }
 
@@ -265,8 +266,13 @@ func init() {
 
 	bundleListCmd.Flags().BoolVar(&bundleListFlags.tree, "tree", false, "Pretty-print the list as a tree.")
 
-	bundleEditCmd.Flags().BoolVar(&bundleEditFlags.add, "add", false, "Add the bundle(s) to your mix")
-	bundleEditCmd.Flags().BoolVar(&bundleEditFlags.git, "git", false, "Automatically apply new git commit")
+	// TODO: Remove this flag once the  new changes to `edit`  (create) command stabilizes.
+	bundleCreateCmd.Flags().BoolVar(&bundleCreateFlags.copyOnly, "suppress-editor", false, "Suppress launching editor (only copy to local-bundles or create template)")
+	_ = bundleCreateCmd.Flags().MarkHidden("suppress-editor")
+	_ = bundleCreateCmd.Flags().MarkDeprecated("suppress-editor", "as the editor feature has been removed from mixer")
+
+	bundleCreateCmd.Flags().BoolVar(&bundleCreateFlags.add, "add", false, "Add the bundle(s) to your mix")
+	bundleCreateCmd.Flags().BoolVar(&bundleCreateFlags.git, "git", false, "Automatically apply new git commit")
 
 	bundleValidateCmd.Flags().BoolVar(&bundleValidateFlags.allLocal, "all-local", false, "Validate all local bundles")
 	bundleValidateCmd.Flags().BoolVar(&bundleValidateFlags.strict, "strict", false, "Strict validation (see usage)")

--- a/mixer/cmd/bundles.go
+++ b/mixer/cmd/bundles.go
@@ -155,31 +155,19 @@ var bundleListCmd = &cobra.Command{
 
 // Bundle Edit command ('mixer bundle edit')
 type bundleEditCmdFlags struct {
-	copyOnly bool
-	add      bool
-	git      bool
+	add bool
+	git bool
 }
 
 var bundleEditFlags bundleEditCmdFlags
 
 var bundleEditCmd = &cobra.Command{
 	Use:   "edit <bundle> [<bundle>...]",
-	Short: "Edit local and upstream bundles, or create new bundles",
-	Long: `Edits local and upstream bundle definition files. This command will locate the
-bundle (looking first in local-bundles, then in upstream-bundles), and launch
-an editor to edit it. If the bundle is only found upstream, the bundle file will
-first be copied to your local-bundles directory for editing. If the bundle is
-not found anywhere, a blank template is created with the correct name. When the
-editor closes, the bundle file is then parsed for validity.
-
-The editor is configured via environment variables. VISUAL takes precedence to
-EDITOR. If neither are set, the tool defaults to nano. If nano is not installed,
-the tool will skip editing, and act as if '--suppress-editor' had been passed.
-
-Passing '--suppress-editor' will suppress launching the editor, and will thus
-only copy the bundle file to local-bundles (if it is only found upstream), or
-create the blank template (if it was not found anywhere). This can be useful if
-you want to add a bundle to local-bundles, but wish to edit it at a later time.
+	Short: "Create new bundles or copy existing bundles",
+	Long: `Create new bundles or copy existing bundles. This command will locate the
+bundle (looking first in local-bundles, then in upstream-bundles). If the bundle is only found upstream,
+the bundle file will be copied to your local-bundles directory. If the bundle is
+not found anywhere, a blank template will be created with the correct name.
 
 Passing '--add' will also add the bundle(s) to your mix. Please note that
 bundles are added after all bundles are edited, and thus will not be added if
@@ -191,7 +179,7 @@ any errors are encountered earlier on.`,
 			fail(err)
 		}
 
-		err = b.EditBundles(args, bundleEditFlags.copyOnly, bundleEditFlags.add, bundleEditFlags.git)
+		err = b.EditBundles(args, bundleEditFlags.add, bundleEditFlags.git)
 		if err != nil {
 			fail(err)
 		}
@@ -277,7 +265,6 @@ func init() {
 
 	bundleListCmd.Flags().BoolVar(&bundleListFlags.tree, "tree", false, "Pretty-print the list as a tree.")
 
-	bundleEditCmd.Flags().BoolVar(&bundleEditFlags.copyOnly, "suppress-editor", false, "Suppress launching editor (only copy to local-bundles or create template)")
 	bundleEditCmd.Flags().BoolVar(&bundleEditFlags.add, "add", false, "Add the bundle(s) to your mix")
 	bundleEditCmd.Flags().BoolVar(&bundleEditFlags.git, "git", false, "Automatically apply new git commit")
 

--- a/mixin/package.go
+++ b/mixin/package.go
@@ -142,7 +142,7 @@ func addPackage(pkg string, build bool, bundleName string) (string, error) {
 		bundle = bundleName
 	}
 
-	err = b.EditBundles([]string{bundle}, true, false)
+	err = b.CreateBundles([]string{bundle}, true, false)
 	if err != nil {
 		return "", err
 	}

--- a/mixin/package.go
+++ b/mixin/package.go
@@ -142,7 +142,7 @@ func addPackage(pkg string, build bool, bundleName string) (string, error) {
 		bundle = bundleName
 	}
 
-	err = b.EditBundles([]string{bundle}, true, true, false)
+	err = b.EditBundles([]string{bundle}, true, false)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
`bundle edit` will no longer open the editor. It will just create new bundles or copy existing bundles.
This command will locate the bundle (looking first in local-bundles, then in upstream-bundles).
If the bundle is only found upstream, the bundle file will be copied to the local-bundles directory.
If the bundle is not found anywhere, a blank template will be created with the correct name.

This commit also fixes issue #448 and increases test coverage for `bundle validate`.

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>