### PR TITLE
bundles: Ignore name validation for `bundle list`

### DIFF
--- a/bat/tests/01-bundle-commands/run.bats
+++ b/bat/tests/01-bundle-commands/run.bats
@@ -17,12 +17,16 @@ setup() {
 }
 
 @test "List the bundles in the mix" {
+  mixer bundle edit foo.bar --suppress-editor # 'bundle list' should work even if an invalid bundle is created
+
   run mixer $MIXARGS bundle list
   [[ ${#lines[@]} -eq 4 ]]              # Exactly 4 bundles in the mix
   [[ "$output" =~ os-core[[:space:]] ]] # To avoid just matching os-core-update
   [[ "$output" =~ os-core-update ]]
   [[ "$output" =~ kernel-native ]]
   [[ "$output" =~ bootloader ]]
+
+  rm -f local-bundles/foo.bar           # Delete invalid bundle (test case clean up)
 }
 
 @test "Add an upstream bundle to the mix" {

--- a/builder/bundle_control.go
+++ b/builder/bundle_control.go
@@ -214,9 +214,6 @@ func (b *Builder) getBundleFromName(name string) (*bundle, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = validateBundleFilename(path); err != nil {
-		return nil, err
-	}
 
 	return bundle, nil
 }
@@ -374,6 +371,9 @@ func (b *Builder) AddBundles(bundles []string, allLocal bool, allUpstream bool, 
 
 		bundle, err := b.getBundleFromName(bName)
 		if err != nil {
+			return err
+		}
+		if err = validateBundleName(bName); err != nil {
 			return err
 		}
 		if b.isLocalBundle(bundle.Filename) {


### PR DESCRIPTION
Currently, as part of `bundle list`, all the bundle names are read
and validated. As a result, `bundle list` fails if an invalid
bundle exists even if it is not added to the mix. This commit removes
bundle name validation as part of `bundle list` thereby fixing #461.

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>