### PR TITLE
build: Add increment flag support to build all

### DIFF
--- a/bat/tests/09-build-all-delta-packs/Makefile
+++ b/bat/tests/09-build-all-delta-packs/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/09-build-all-delta-packs/description.txt
+++ b/bat/tests/09-build-all-delta-packs/description.txt
@@ -1,0 +1,4 @@
+09-build-all-delta-packs
+==================
+This test case tests the 'mixer build delta-packs' command when generating
+content with 'mixer build all'.

--- a/bat/tests/09-build-all-delta-packs/run.bats
+++ b/bat/tests/09-build-all-delta-packs/run.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  global_setup
+}
+
+@test "build delta-packs after build all" {
+  current_ver=$(get-current-version)
+  mixer-init-stripped-down "$current_ver" 10
+  sudo -E mixer build all --native --increment
+  mixer-build-all
+  sudo -E mixer build delta-packs --native --previous-versions=1
+
+  test $(< mixversion) -eq 20
+  test -e update/www/20/pack-os-core-from-10.tar
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -404,12 +404,14 @@ var buildAllCmd = &cobra.Command{
 			failf("Couldn't build update: %s", err)
 		}
 
-		ver, err := strconv.Atoi(b.MixVer)
-		if err != nil {
-			fail(err)
-		}
-		if err = b.UpdateMixVer(ver + 10); err != nil {
-			failf("Couldn't update Mix Version")
+		if buildFlags.increment {
+			ver, err := strconv.Atoi(b.MixVer)
+			if err != nil {
+				fail(err)
+			}
+			if err = b.UpdateMixVer(ver + 10); err != nil {
+				failf("Couldn't update Mix Version")
+			}
 		}
 	},
 }


### PR DESCRIPTION
Now the 'mixer build all' command supports the --increment flag. When the
--increment flag is passed to 'mixer build all', the mixversion will be
incremented. Otherwise, the mixversion will remain unchanged. This fixes
an issue where delta packs could not be created after using 'mixer build all'.

Fixes #445

Signed-off-by: John Akre <john.w.akre@intel.com>