### PR TITLE
Remove /etc/dnf tree in full chroot

### DIFF
--- a/bat/tests/12-no-state-variables-in-full/Makefile
+++ b/bat/tests/12-no-state-variables-in-full/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/12-no-state-variables-in-full/description.txt
+++ b/bat/tests/12-no-state-variables-in-full/description.txt
@@ -1,0 +1,5 @@
+12-no-state-variables-in-full
+===================================
+This test case creates a simple mix and checks that no state paths
+exist in the full chroot, which should be removed during the build
+bundles phase

--- a/bat/tests/12-no-state-variables-in-full/run.bats
+++ b/bat/tests/12-no-state-variables-in-full/run.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  global_setup
+}
+
+@test "Test that state paths do not exist in the full chroot" {
+  upstreamver=$(get-last-format-boundary)
+  mixer-init-stripped-down $upstreamver 10
+
+  #Create initial version in the old format
+  mixer-build-bundles > $LOGDIR/build_bundles.log
+
+  toRemove="/etc/dnf /var/lib/cache/yum /var/cache/yum /var/cache/dnf /var/lib/dnf /var/lib/rpm"
+  for f in $toRemove; do
+    test ! -d update/image/10/full/$f
+  done
+}

--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -481,6 +481,7 @@ func clearDNFCache(packagerCmd []string) error {
 
 func rmDNFStatePaths(fullDir string) {
 	dnfStatePaths := []string{
+		"/etc/dnf",
 		"/var/lib/cache/yum",
 		"/var/cache/yum",
 		"/var/cache/dnf",


### PR DESCRIPTION
DNF creates two additional state directories in the full chroot if they missing: `/etc/dnf/` and `/etc/dnf/modules.d`.

Update the DNF state path slice so that the `/etc/dnf` directory tree is removed from the full chroot after full chroot creation. This avoids adding those two directories to Manifest.full.