### PR TITLE
Increase bsdiff delta creation timeout

### DIFF
--- a/swupd/delta.go
+++ b/swupd/delta.go
@@ -156,13 +156,11 @@ func createDelta(c *config, delta *Delta) error {
 	oldPath := filepath.Join(c.imageBase, fmt.Sprint(delta.from.Version), "full", delta.from.Name)
 	newPath := filepath.Join(c.imageBase, fmt.Sprint(delta.to.Version), "full", delta.to.Name)
 
-	// Set timeout to 1 minute (60 seconds) for bsdiff
-	// The majority of all delta creations take significantly less than 1 minute
-	// to run, which signifies that bsdiff is working on a delta that may be very
-	// large, or very difficult to diff. In all the cases where bsdiff took
-	// multiple minutes to finish, the delta ended up not being used because it
-	// was larger than the compressed fullfile. This attempts to skip those cases.
-	if err := helpers.RunCommandTimeout(60, "bsdiff", oldPath, newPath, delta.Path); err != nil {
+	// Set timeout to 8 minutes (480 seconds) for bsdiff.
+	// The majority of all delta creations take significantly less than 8
+	// minutes; the deltas that take longer usually indicate that old/new
+	// files are large or very difficult to diff.
+	if err := helpers.RunCommandTimeout(480, "bsdiff", oldPath, newPath, delta.Path); err != nil {
 		_ = os.Remove(delta.Path)
 		if exitErr, ok := errors.Cause(err).(*exec.ExitError); ok {
 			// bsdiff returns 1 that stands for "FULLDL", i.e. it decided that


### PR DESCRIPTION
After much testing of recent Clear Linux OS builds, I have determined that a 1-minute timeout for delta creation is not long enough.

In Clear Linux OS, there are several large (~250MB) files in the 'gcc' package that change on a regular basis (sometimes once a day), and delta creation for these files takes between 5.5 and 6.5 minutes each. The delta sizes are around 9-10MB, significantly smaller than the new compressed fullfile size of 49-55MB.

To accomodate these deltas, the timeout should be at least 7 minutes. For one recent build (26170), one of the delta creations took 6min40sec, approaching 7 minutes. To be safe, I am increasing the timeout to 8 minutes in case the build server is under heavier load.

I did regenerate the deltas that originally prompted adding the 1 minute timeout. They *are* larger than the new compressed fullfile, and they take several minutes to create. But these cases are actually rare,
instead of common, as the source code comment implies. I've updated the code comment.