### PR TITLE
bundles: Add valid bundles and skip invalid ones

### DIFF
--- a/bat/tests/bundle-commands/run.bats
+++ b/bat/tests/bundle-commands/run.bats
@@ -96,6 +96,20 @@ setup() {
   rm -f local-bundles/foocar
 }
 
+@test "Skip invalid bundles from mix" {
+  mixer $MIXARGS bundle create foocar foo.car foojar --add      # Create and add valid as well as invalid bundles
+
+  mixer $MIXARGS bundle list | grep -q foocar     # "foocar" bundle is in the mix
+  mixer $MIXARGS bundle list | grep -q foojar     # "foojar" bundle is in the mix
+
+  run $(mixer $MIXARGS bundle list | grep foo.car)              # "foo.car" is an invalid bundle and is not in the mix
+  [[ ${#lines[@]} -eq 0 ]]
+
+  # Delete bundle from local-bundles and mix (test case clean up)
+  mixer $MIXARGS bundle remove foocar foojar
+  rm -f local-bundles/foocar local-bundles/foojar local-bundles/foo.car
+}
+
 @test "Validate a bundle" {
   echo "package" >> $BATS_TEST_DIRNAME/local-bundles/foobar
   mixer $MIXARGS bundle create foo.bar

--- a/builder/bundle_control.go
+++ b/builder/bundle_control.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -375,10 +376,12 @@ func (b *Builder) AddBundles(bundles []string, allLocal bool, allUpstream bool, 
 
 		bundle, err := b.getBundleFromName(bName)
 		if err != nil {
-			return err
+			log.Println("Warning: " + err.Error() + "; skipping")
+			continue
 		}
 		if err = validateBundleName(bName); err != nil {
-			return err
+			log.Println("Warning: " + err.Error() + "; skipping")
+			continue
 		}
 		if b.isLocalBundle(bundle.Filename) {
 			fmt.Printf("Adding bundle %q from local bundles\n", bName)


### PR DESCRIPTION
`bundle add` will now add valid bundles and skip only the invalid ones,
thereby fixing issue #489.

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>