### PR TITLE
mixin: prevent removal of clear repo

### DIFF
--- a/bat/tests/mixin-repo-commands/Makefile
+++ b/bat/tests/mixin-repo-commands/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/mixin-repo-commands/description.txt
+++ b/bat/tests/mixin-repo-commands/description.txt
@@ -1,0 +1,3 @@
+mixin-repo-commands
+=====================
+This test validates various repo commands for mixin

--- a/bat/tests/mixin-repo-commands/run.bats
+++ b/bat/tests/mixin-repo-commands/run.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  global_setup
+}
+
+@test "Verify clear repo is unable to be removed by mixin" {
+  run sudo mixin repo remove clear
+
+  [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "The clear repo is mandatory and cannot be removed" ]]
+  [[ ! "$output" =~ "Removed clear repo." ]]
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/mixin/repo.go
+++ b/mixin/repo.go
@@ -126,6 +126,11 @@ func runAddRepo(cmd *cobra.Command, args []string) {
 }
 
 func runRemoveRepo(cmd *cobra.Command, args []string) {
+	if args[0] == "clear" {
+		err := fmt.Errorf("The clear repo is mandatory and cannot be removed")
+		fail(err)
+	}
+
 	err := repoPrep()
 	if err != nil {
 		fail(err)


### PR DESCRIPTION
The clear repo is mandatory for mixin. This change prevents mixin from
removing the clear repo.

Fixes #326

Signed-off-by: John Akre <john.w.akre@intel.com>