### PR TITLE
Enable iterative manifests with 0 file count

### DIFF
--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -82,6 +82,7 @@ func initBundles(ui UpdateInfo, c config, numWorkers int) ([]*Manifest, error) {
 					TimeStamp: ui.timeStamp,
 				},
 				Name: bundleName,
+				Type: ManifestBundle,
 			}
 
 			if bundleName == "full" {
@@ -459,6 +460,7 @@ func CreateManifests(version uint32, minVersion uint32, format uint, statedir st
 			Previous:   lastVersion,
 			TimeStamp:  timeStamp,
 		},
+		Type: ManifestMoM,
 	}
 	// if min-version wasn't explicitly set we need to carry the header forward
 	// from the old MoM

--- a/swupd/packs.go
+++ b/swupd/packs.go
@@ -237,6 +237,7 @@ func WritePack(w io.Writer, fromManifest, toManifest *Manifest, outputDir, chroo
 		dManifest = &Manifest{
 			Header: fromManifest.Header,
 			Name:   fromManifest.Name,
+			Type:   ManifestDelta,
 		}
 		dManifest.Header.ContentSize = 0
 


### PR DESCRIPTION
When a bundle is updated to only modify which bundles are included, an
iterative manifest can be generated with 0 files. This change adds a
type field to the Manifest struct to determine when an iterative
manifest is used and allows the creation of iterative manifests with
a 0 file count.

Fixes #516

Signed-off-by: John Akre <john.w.akre@intel.com>