### PR TITLE
builder: Experimental bundles

### DIFF
--- a/builder/bundleset.go
+++ b/builder/bundleset.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/clearlinux/mixer-tools/swupd"
 )
 
 var (
@@ -17,18 +19,10 @@ var (
 	bundleHeaderFieldRegex = regexp.MustCompile(`^# \[([A-Z]+)\]:\s*(.*)$`)
 )
 
-type bundleHeader struct {
-	Title        string
-	Description  string
-	Status       string
-	Capabilities string
-	Maintainer   string
-}
-
 type bundle struct {
 	Name     string
 	Filename string
-	Header   bundleHeader
+	Header   swupd.BundleHeader
 
 	DirectIncludes []string
 	DirectPackages map[string]bool

--- a/builder/bundleset_test.go
+++ b/builder/bundleset_test.go
@@ -8,12 +8,14 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/clearlinux/mixer-tools/swupd"
 )
 
 func TestParseBundle(t *testing.T) {
 	tests := []struct {
 		Contents         []byte
-		ExpectedHeader   bundleHeader
+		ExpectedHeader   swupd.BundleHeader
 		ExpectedIncludes []string
 		ExpectedPackages map[string]bool
 		ShouldFail       bool
@@ -30,7 +32,7 @@ include(b)
 pkg1     # Comment
 pkg2
 `),
-			ExpectedHeader: bundleHeader{
+			ExpectedHeader: swupd.BundleHeader{
 				Title:        "fake",
 				Description:  "a description",
 				Status:       "a status",
@@ -50,7 +52,7 @@ pkg2
 include(a)
 pkg1
 `),
-			ExpectedHeader: bundleHeader{
+			ExpectedHeader: swupd.BundleHeader{
 				Title:       "fake",
 				Description: "a description",
 			},
@@ -67,7 +69,7 @@ pkg1
 include(a)
 pkg1 # [TITLE]: wrongtitle
 `),
-			ExpectedHeader: bundleHeader{
+			ExpectedHeader: swupd.BundleHeader{
 				Title:       "realtitle",
 				Description: "a description",
 			},

--- a/swupd/bundleinfo.go
+++ b/swupd/bundleinfo.go
@@ -24,10 +24,20 @@ import (
 	"strings"
 )
 
+// BundleHeader describes the meta information of a bundle
+type BundleHeader struct {
+	Title        string
+	Description  string
+	Status       string
+	Capabilities string
+	Maintainer   string
+}
+
 // BundleInfo describes the JSON object to be read from the *-info files
 type BundleInfo struct {
 	Name           string
 	Filename       string
+	Header         BundleHeader
 	DirectIncludes []string
 	DirectPackages map[string]bool
 	AllPackages    map[string]bool

--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -322,7 +322,7 @@ func (MoM *Manifest) writeIterativeManifests(newManifests []*Manifest, out strin
 		}
 
 		// add bundle to Manifest.MoM
-		if err = MoM.createManifestRecord(out, manPath, MoM.Header.Version, TypeIManifest); err != nil {
+		if err = MoM.createManifestRecord(out, manPath, MoM.Header.Version, TypeIManifest, bMan.BundleInfo.Header.Status); err != nil {
 			return nil, err
 		}
 
@@ -359,7 +359,7 @@ func (MoM *Manifest) writeBundleManifests(newManifests []*Manifest, out string) 
 		}
 
 		// add bundle to Manifest.MoM
-		if err = MoM.createManifestRecord(out, manPath, MoM.Header.Version, TypeManifest); err != nil {
+		if err = MoM.createManifestRecord(out, manPath, MoM.Header.Version, TypeManifest, bMan.BundleInfo.Header.Status); err != nil {
 			return nil, err
 		}
 	}
@@ -489,7 +489,7 @@ func CreateManifests(version uint32, minVersion uint32, format uint, statedir st
 	// itself as an index manifest may not have been created for this version.
 	osIdxDir := filepath.Join(c.outputDir, fmt.Sprint(osIdx.Header.Version))
 	osIdxPath := filepath.Join(osIdxDir, "Manifest."+osIdx.Name)
-	if err = newMoM.createManifestRecord(osIdxDir, osIdxPath, osIdx.Header.Version, TypeManifest); err != nil {
+	if err = newMoM.createManifestRecord(osIdxDir, osIdxPath, osIdx.Header.Version, TypeManifest, osIdx.BundleInfo.Header.Status); err != nil {
 		return nil, err
 	}
 

--- a/swupd/files.go
+++ b/swupd/files.go
@@ -52,12 +52,14 @@ const (
 	StatusUnset StatusFlag = iota
 	StatusDeleted
 	StatusGhosted
+	StatusExperimental
 )
 
 var statusBytes = map[StatusFlag]byte{
-	StatusUnset:   '.',
-	StatusDeleted: 'd',
-	StatusGhosted: 'g',
+	StatusUnset:        '.',
+	StatusDeleted:      'd',
+	StatusGhosted:      'g',
+	StatusExperimental: 'e',
 }
 
 // ModifierFlag describes specific characteristics of a file, used later by
@@ -158,6 +160,8 @@ func statusFromFlag(flag byte) (StatusFlag, error) {
 		return StatusDeleted, nil
 	case 'g':
 		return StatusGhosted, nil
+	case 'e':
+		return StatusExperimental, nil
 	case '.':
 		return StatusUnset, nil
 	default:
@@ -171,6 +175,8 @@ func (s StatusFlag) String() string {
 		return "d"
 	case StatusGhosted:
 		return "g"
+	case StatusExperimental:
+		return "e"
 	case StatusUnset:
 		return "."
 	}

--- a/swupd/filesystem.go
+++ b/swupd/filesystem.go
@@ -91,7 +91,7 @@ func recordFromFile(rootPath, path, removePrefix string, fi os.FileInfo) (*File,
 }
 
 // createManifestRecord wraps createFileRecord to create a Manifest record for a MoM
-func (m *Manifest) createManifestRecord(rootPath, path string, version uint32, manifestType TypeFlag) error {
+func (m *Manifest) createManifestRecord(rootPath, path string, version uint32, manifestType TypeFlag, bundleStatus string) error {
 	fi, err := os.Stat(path)
 	if err != nil {
 		return err
@@ -113,6 +113,7 @@ func (m *Manifest) createManifestRecord(rootPath, path string, version uint32, m
 	// Only the bundle name should be part of the name in the manifest
 	file.Name = strings.Replace(file.Name, "/Manifest.", "", -1)
 	file.Type = manifestType
+	setManifestStatusForFormat(m.Header.Format, bundleStatus, &file.Status)
 	file.Version = version
 	m.Files = append(m.Files, file)
 	return nil

--- a/swupd/format_switch.go
+++ b/swupd/format_switch.go
@@ -61,6 +61,17 @@ includes:	{{.Name}}
 `,
 }
 
+const statusExperimental = "Experimental"
+
+func setManifestStatusForFormat(format uint, bundleStatus string, statusFlag *StatusFlag) {
+	if format > 26 {
+		// Experimental bundles are introduced in format 27 and should not be created in older formats
+		if bundleStatus == statusExperimental {
+			*statusFlag = StatusExperimental
+		}
+	}
+}
+
 // Delta manifests were introduced in format 26 and should not be created in older formats
 func writeDeltaManifestForFormat(tw *tar.Writer, outputDir string, dManifest *Manifest, toVersion uint32) error {
 	if dManifest == nil || dManifest.Header.Format <= 25 {

--- a/swupd/format_switch_test.go
+++ b/swupd/format_switch_test.go
@@ -193,3 +193,28 @@ func TestFormat25BadContentSize(t *testing.T) {
 		})
 	}
 }
+
+// Experimental bundles added in format 27
+func TestFormats26to27ExperimentalBundles(t *testing.T) {
+	ts := newTestSwupd(t, "format26to27ExperimentalBundles")
+	defer ts.cleanup()
+
+	var header BundleHeader
+	header.Status = "Experimental"
+
+	// Format 26 should not recognize experimental bundles
+	ts.Format = 26
+	ts.Bundles = []string{"test-bundle1"}
+	ts.addFile(10, "test-bundle1", "/foo", "content")
+	ts.addHeader(10, "test-bundle1", header)
+	ts.createManifests(10)
+	checkManifestNotContains(t, ts.Dir, "10", "MoM", "Me..\t")
+
+	// Format 27 should recognize experimental bundles
+	ts.Format = 27
+	ts.Bundles = []string{"test-bundle2"}
+	ts.addFile(20, "test-bundle2", "/foo", "content")
+	ts.addHeader(20, "test-bundle2", header)
+	ts.createManifests(20)
+	checkManifestContains(t, ts.Dir, "20", "MoM", "Me..\t")
+}

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -510,6 +510,32 @@ func (fs *testFileSystem) addToBundleInfo(version uint32, bundle, file string) {
 	}
 }
 
+func (fs *testFileSystem) addHeaderToBundleInfo(version uint32, bundle string, header BundleHeader) {
+	bundleInfoPath := filepath.Join(fs.Dir, "image", fmt.Sprint(version), bundle+"-info")
+	biBytes, err := ioutil.ReadFile(bundleInfoPath)
+	if err != nil {
+		fs.t.Fatal(err)
+	}
+
+	var bi BundleInfo
+	err = json.Unmarshal(biBytes, &bi)
+	if err != nil {
+		fs.t.Fatal(err)
+	}
+
+	bi.Header = header
+
+	b, err := json.Marshal(&bi)
+	if err != nil {
+		fs.t.Fatal(err)
+	}
+
+	err = ioutil.WriteFile(bundleInfoPath, b, 0644)
+	if err != nil {
+		fs.t.Fatal(err)
+	}
+}
+
 func (fs *testFileSystem) addIncludesToBundleInfo(version uint32, bundle string, includes []string) {
 	bundleInfoPath := filepath.Join(fs.Dir, "image", fmt.Sprint(version), bundle+"-info")
 	biBytes, err := ioutil.ReadFile(bundleInfoPath)
@@ -573,6 +599,16 @@ func (fs *testFileSystem) addExtraFile(version uint32, bundle, file, content str
 	}
 
 	fs.addToFullChroot(version, file, content)
+}
+
+func (fs *testFileSystem) addHeader(version uint32, bundle string, header BundleHeader) {
+	fs.t.Helper()
+	path := filepath.Join(fs.Dir, "image", fmt.Sprint(version), bundle+"-info")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		fs.initBundleInfo(version, bundle, []string{})
+	}
+
+	fs.addHeaderToBundleInfo(version, bundle, header)
 }
 
 func (fs *testFileSystem) addIncludes(version uint32, bundle string, includes []string) {


### PR DESCRIPTION
From format 27 onwards, Mixer will recognize bundles with "[Status] : Experimental"
as experimental bundles and mark their status flag as "e" in the Manifest.MoM.

i.e. These bundles will include an "e" in the 2nd position of the manifest flags,
as shown here:

Me.. 4b91c3122e7e32f1e3edb597c6f89ff32cfffd977afb5e5 10 some-bundle

Fixes #497

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>