### PR TITLE
create_manifests: Don't leak iterative manifests on minversions

### DIFF
--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -279,6 +279,11 @@ func addUnchangedManifests(appendTo *Manifest, appendFrom *Manifest, bundles []s
 
 		bundleName := f.Name
 		if f.Type == TypeIManifest {
+			// Don't add iterative manifests across minversion updates
+			if f.Version < appendTo.Header.MinVersion {
+				continue
+			}
+
 			// Only the most recent iterative manifest for a bundle is valid,
 			// so omit stale iterative manifests from the to MoM
 			if f.findIManifestInSlice(appendTo.Files) != nil {


### PR DESCRIPTION
During a minversion update, iterative manifests older than the new
minversion were leaked into the new MoM. Also, format bumps perform
minversion updates, so iterative manifests from an old format could
leak into new formats. This change prevents forwarding iterative
manifests with versions older than the minversion into the new MoM.

Fixes #523

Signed-off-by: John Akre <john.w.akre@intel.com>