### PR TITLE
Deprecate new-swupd and new-config flags

### DIFF
--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -110,13 +110,13 @@ func init() {
 	// TODO: Remove this once we migrate to new implementation.
 	unusedBoolFlag := false
 	RootCmd.PersistentFlags().BoolVar(&unusedBoolFlag, "new-swupd", false, "")
-	_ = RootCmd.Flags().MarkHidden("new-swupd")
-	_ = RootCmd.Flags().MarkDeprecated("new-swupd", "new functionality is now the standard behavior, this flag is obsolete and no longer used")
+	_ = RootCmd.PersistentFlags().MarkHidden("new-swupd")
+	_ = RootCmd.PersistentFlags().MarkDeprecated("new-swupd", "new functionality is now the standard behavior, this flag is obsolete and no longer used")
 
 	// TODO: Remove this once we drop the old config format
 	RootCmd.PersistentFlags().BoolVar(&unusedBoolFlag, "new-config", true, "")
-	_ = RootCmd.Flags().MarkHidden("new-config")
-	_ = RootCmd.Flags().MarkDeprecated("new-config", "The config file is now automatically converted and the new format is always used")
+	_ = RootCmd.PersistentFlags().MarkHidden("new-config")
+	_ = RootCmd.PersistentFlags().MarkDeprecated("new-config", "The config file is now automatically converted and the new format is always used")
 
 	RootCmd.PersistentFlags().BoolVar(&builder.Native, "native", false, "Run mixer command on native host instead of in a container")
 	RootCmd.PersistentFlags().BoolVar(&builder.Offline, "offline", false, "Skip caching upstream-bundles; work entirely with local-bundles")


### PR DESCRIPTION
Earlier the new-swupd and new-config flags were incorrectly marked for
deprecation. After correctly deprecating these flags, they are no longer
present in the help message and print a deprecation message when used.

Signed-off-by: John Akre <john.w.akre@intel.com>