### PR TITLE
builder: create a www/latest_version file

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -364,13 +364,17 @@ func (b *Builder) BuildUpdate(params UpdateParameters) error {
 		}
 	}
 
-	// Publish. Update the latest version both in the format (used by update itself) and in LAST_VER
-	// (used to create newer manifests).
+	// Publish. Update the latest version file in various locations.
 	if !params.Publish {
 		return nil
 	}
 
 	fmt.Printf("Setting latest version to %s\n", b.MixVer)
+
+	err = ioutil.WriteFile(filepath.Join(b.Config.Builder.ServerStateDir, "www", "version", "latest_version"), []byte(b.MixVer), 0644)
+	if err != nil {
+		return errors.Wrapf(err, "couldn't update the latest_version file")
+	}
 
 	err = ioutil.WriteFile(filepath.Join(formatDir, "latest"), []byte(b.MixVer), 0644)
 	if err != nil {


### PR DESCRIPTION
If publishing an update, also update the www/latest_version.  This is
useful for various consumers of swupd data: swupd-client can easily
discover the latest version (and not only the latest version in a
given format); swupd-inspector and swupd-extract will be able to
automatically figure the latest version of a mix given the update URL.

If --no-publish is used, the file will not be updated like the other
related files.  Clear Linux itself uses that so it can decide later on
whether to publish or not an update to the end users.

Related to #467.  With latest_version is possible to peek at
www/<latest_version>/format and figure its format.