### PR TITLE
Offline fix

### DIFF
--- a/builder/format.go
+++ b/builder/format.go
@@ -126,6 +126,11 @@ func (b *Builder) UnstageMixFromBump() error {
 // CheckBumpNeeded returns nil if it successfully deduces there is no format
 // bump boundary being crossed.
 func (b *Builder) CheckBumpNeeded(silent bool) (bool, error) {
+	// Skip bump checks in offline mode
+	if Offline {
+		return false, nil
+	}
+
 	version, err := b.getLastBuildUpstreamVersion()
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/builder/metadata.go
+++ b/builder/metadata.go
@@ -240,6 +240,11 @@ func (b *Builder) ModifyBundles(action func([]string) error) error {
 // PrintVersions prints the current mix and upstream versions, and the
 // latest version of upstream.
 func (b *Builder) PrintVersions() error {
+	if Offline {
+		b.printVersionsOffline()
+		return nil
+	}
+
 	format, first, latest, err := b.getUpstreamFormatRange(b.UpstreamVer)
 	if err != nil {
 		return err
@@ -256,6 +261,16 @@ Latest upstream in format: %d
 	return nil
 }
 
+func (b *Builder) printVersionsOffline() {
+	fmt.Printf(`
+Current mix:               %d
+Current upstream:          %d (format: %s)
+
+First upstream in format: (not available in offline mode)
+Latest upstream in format: (not available in offline mode)
+`, b.MixVerUint32, b.UpstreamVerUint32, b.State.Mix.Format)
+}
+
 // UpdateVersions will validate then update both mix and upstream versions. If
 // upstream version is 0, then the latest upstream version in the current
 // upstream format will be taken instead.
@@ -264,7 +279,7 @@ func (b *Builder) UpdateVersions(nextMix, nextUpstream uint32) error {
 	var latest uint32
 	var err error
 
-	checkUpstream := (nextUpstream != b.UpstreamVerUint32)
+	checkUpstream := (nextUpstream != b.UpstreamVerUint32) && !Offline
 	if checkUpstream {
 		format, _, latest, err = b.getUpstreamFormatRange(b.UpstreamVer)
 		if err != nil {

--- a/mixer/cmd/init.go
+++ b/mixer/cmd/init.go
@@ -32,6 +32,8 @@ var initCmd = &cobra.Command{
 				// Note: output matches Cobra's default pflag error syntax, as
 				// if initFlags.clearVer were an int all along.
 				return errors.Errorf("invalid argument \"%s\" for \"--clear-version\" flag: %s", initFlags.clearVer, err)
+			} else if builder.Offline {
+				return errors.Errorf("Offline mode requires clear version to be set manually. Please use --clear-version flag during init")
 			}
 		}
 


### PR DESCRIPTION
Those 3 patches fix code patches where `--offline` was ignored. They are required for downstream mixes to perform a manual format bump.