### PR TITLE
builder: Retry RPM downloads for build bundles

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -235,7 +235,7 @@ func (b *Builder) InitMix(upstreamVer string, mixVer string, allLocal bool, allU
 // DNF configuration file, then resolving all files for each bundle using dnf
 // resolve and no-op installs. One full chroot is created from this step with
 // the file contents of all bundles.
-func (b *Builder) BuildBundles(template *x509.Certificate, privkey *rsa.PrivateKey, signflag, clean bool) error {
+func (b *Builder) BuildBundles(template *x509.Certificate, privkey *rsa.PrivateKey, signflag, clean bool, downloadRetries int) error {
 	// Fetch upstream bundle files if needed
 	if err := b.getUpstreamBundles(b.UpstreamVer, true); err != nil {
 		return err
@@ -300,7 +300,7 @@ func (b *Builder) BuildBundles(template *x509.Certificate, privkey *rsa.PrivateK
 	}
 
 	// TODO: Merge the rest of this function into buildBundles (or vice-versa).
-	err = b.buildBundles(set)
+	err = b.buildBundles(set, downloadRetries)
 	if err != nil {
 		return err
 	}

--- a/mixin/build.go
+++ b/mixin/build.go
@@ -33,6 +33,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Default number of RPM download retries
+const retriesDefault = 3
+
 var buildCmd = &cobra.Command{
 	Use:   "build",
 	Short: "Build a mix from local or remote mix content",
@@ -68,7 +71,7 @@ func buildBundles(b *builder.Builder) error {
 	}
 	// Always wipe /image and /www because mixver will only be incremented if the last
 	// build was valid, so the user may end up using bad data if it's not cleaned.
-	return errors.Wrap(b.BuildBundles(template, privkey, false, true), "Error building bundles")
+	return errors.Wrap(b.BuildBundles(template, privkey, false, true, retriesDefault), "Error building bundles")
 }
 
 func mergeMoMs(mixWS string, mixVer, lastVer int) error {


### PR DESCRIPTION
Download failures can occur when downloading large sets of RPMs from a
server with a poor connection. This change adds retry functionality to
attempt RPM downloads multiple times.

Fixes: #531

Signed-off-by: John Akre <john.w.akre@intel.com>