### PR TITLE
Use cdn to download content on mixer

### DIFF
--- a/bat/lib/mixerlib.bash
+++ b/bat/lib/mixerlib.bash
@@ -140,7 +140,7 @@ plugins=0
 [clear]
 name=Clear
 failovermethod=priority
-baseurl=https://download.clearlinux.org/releases/\$releasever/clear/x86_64/os/
+baseurl=https://cdn.download.clearlinux.org/releases/\$releasever/clear/x86_64/os/
 enabled=1
 gpgcheck=0
 EOF

--- a/mixer/cmd/init.go
+++ b/mixer/cmd/init.go
@@ -81,7 +81,7 @@ func init() {
 	initCmd.Flags().StringVar(&initFlags.clearVer, "clear-version", "latest", "Supply the Clear version to compose the mix from")
 	initCmd.Flags().StringVar(&initFlags.clearVer, "upstream-version", "latest", "Alias to --clear-version")
 	initCmd.Flags().IntVar(&initFlags.mixver, "mix-version", 10, "Supply the Mix version to build")
-	initCmd.Flags().StringVar(&initFlags.upstreamURL, "upstream-url", "https://download.clearlinux.org", "Supply an upstream URL to use for mixing")
+	initCmd.Flags().StringVar(&initFlags.upstreamURL, "upstream-url", "https://cdn.download.clearlinux.org", "Supply an upstream URL to use for mixing")
 	initCmd.Flags().BoolVar(&initFlags.git, "git", false, "Track mixer's internal work dir with git")
 	initCmd.Flags().StringVar(&initFlags.format, "format", "", "Supply the format version for the mix")
 

--- a/mixin/build.go
+++ b/mixin/build.go
@@ -191,7 +191,7 @@ func buildMix(prepNeeded bool) error {
 			filepath.Join(oldMix, "Manifest.MoM"))
 	}
 
-	upstreamMoM := fmt.Sprintf("https://download.clearlinux.org/update/%d/Manifest.MoM", ver)
+	upstreamMoM := fmt.Sprintf("https://cdn.download.clearlinux.org/update/%d/Manifest.MoM", ver)
 	err = helpers.DownloadFile(upstreamMoM, "Manifest.MoM")
 	if err != nil {
 		_ = os.Remove(mixFlagFile)

--- a/mixin/helpers.go
+++ b/mixin/helpers.go
@@ -118,7 +118,7 @@ func setUpMixDir(upstreamVer, mixVer int) error {
 		return err
 	}
 	err = ioutil.WriteFile(filepath.Join(mixWS, "upstreamurl"),
-		[]byte("https://download.clearlinux.org"), 0644)
+		[]byte("https://cdn.download.clearlinux.org"), 0644)
 	if err != nil {
 		return err
 	}

--- a/mixin/package.go
+++ b/mixin/package.go
@@ -105,7 +105,7 @@ func addPackage(pkg string, build bool, bundleName string) (string, error) {
 		return "", err
 	}
 	err = b.InitMix(fmt.Sprintf("%d", ver), fmt.Sprintf("%d", mixVer),
-		false, false, true, "https://download.clearlinux.org", false)
+		false, false, true, "https://cdn.download.clearlinux.org", false)
 	if err != nil {
 		return "", err
 	}

--- a/swupd-extract/main.go
+++ b/swupd-extract/main.go
@@ -66,7 +66,7 @@ Flags:
 const (
 	clearLinuxLatestURL         = "https://download.clearlinux.org/latest"
 	clearLinuxBaseContent       = "https://cdn.download.clearlinux.org/update"
-	clearLinuxCertificateURL    = "https://download.clearlinux.org/current/Swupd_Root.pem"
+	clearLinuxCertificateURL    = "https://cdn.download.clearlinux.org/current/Swupd_Root.pem"
 	clearLinuxCertificateSHA256 = "ff06fc76ec5148040acb4fcb2bc8105cc72f1963b55de0daf3a4ed664c6fe72c"
 )
 


### PR DESCRIPTION
Use cdn instead of download.clearlinux.org as the standard upstream URL,
because it's more reliable. Other usages of download.clearlinux.org were
also changed with the exception of version number downloads. Downloading
version numbers from download.clearlinux.org is still preferred because
we don't need to be concerned with caching.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>