### PR TITLE
Increment Clear repo default timeout

### DIFF
--- a/bat/lib/mixerlib.bash
+++ b/bat/lib/mixerlib.bash
@@ -143,6 +143,7 @@ failovermethod=priority
 baseurl=https://cdn.download.clearlinux.org/releases/\$releasever/clear/x86_64/os/
 enabled=1
 gpgcheck=0
+timeout=45
 EOF
 }
 

--- a/builder/repo_control.go
+++ b/builder/repo_control.go
@@ -69,6 +69,7 @@ failovermethod=priority
 baseurl={{.UpstreamURL}}/releases/$releasever/clear/x86_64/os/
 enabled=1
 gpgcheck=0
+timeout=45
 {{end}}{{if .Local}}
 [local]
 name=Local


### PR DESCRIPTION
Since the default Clear repo mirror changed to the cdn, dnf timeouts
occur more frequently. Increasing the timeout to 45 seconds from the
default timeout of 30 seconds.

Signed-off-by: John Akre <john.w.akre@intel.com>