### PR TITLE
Add clean flag to mixer build all command

### DIFF
--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -585,6 +585,8 @@ func init() {
 
 	RootCmd.AddCommand(buildCmd)
 
+	buildAllCmd.Flags().BoolVar(&buildFlags.clean, "clean", false, "Wipe the /image and /www dirs if they exist")
+
 	buildBundlesCmd.Flags().BoolVar(&buildFlags.clean, "clean", false, "Wipe the /image and /www dirs if they exist")
 	buildBundlesCmd.Flags().BoolVar(&buildFlags.noSigning, "no-signing", false, "Do not generate a certificate to sign the Manifest.MoM")
 


### PR DESCRIPTION
The clean flag for the mixer build all command was not exposed to users
to change from the default value. Now the clean flag can be set for the
mixer build all command.

Signed-off-by: John Akre <john.w.akre@intel.com>