### PR TITLE
Enable create Manifest deltas in mixer

### DIFF
--- a/bat/lib/mixerlib.bash
+++ b/bat/lib/mixerlib.bash
@@ -60,6 +60,10 @@ mixer-build-delta-packs() {
   sudo -E mixer $MIXARGS build delta-packs --config $BATS_TEST_DIRNAME/builder.conf --native=true --previous-versions $1
 }
 
+mixer-build-delta-manifests() {
+  sudo -E mixer $MIXARGS build delta-manifests --config $BATS_TEST_DIRNAME/builder.conf --native=true --previous-versions $1
+}
+
 mixer-build-format-bump-new() {
   sudo -E mixer $MIXARGS build format-bump new --new-format $1 --native=true
 }

--- a/bat/tests/build-delta-manifests/Makefile
+++ b/bat/tests/build-delta-manifests/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/build-delta-manifests/description.txt
+++ b/bat/tests/build-delta-manifests/description.txt
@@ -1,0 +1,4 @@
+build-delta-manifests
+=====================
+This test case tests the 'mixer build delta-manifests command when generating
+content with 'mixer build all'.

--- a/bat/tests/build-delta-manifests/run.bats
+++ b/bat/tests/build-delta-manifests/run.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  global_setup
+}
+
+@test "build delta-manifests after build all" {
+  current_ver=$(get-current-version)
+  mixer-init-stripped-down "$current_ver" 10
+  sudo -E mixer build all --native --increment
+  mixer-build-all
+  sudo -E mixer build delta-manifests --native --previous-versions=1
+
+  test $(< mixversion) -eq 20
+  test -e update/www/20/Manifest-os-core-delta-from-10
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/bat/tests/no-delta-manifests-over-format-bump/Makefile
+++ b/bat/tests/no-delta-manifests-over-format-bump/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/no-delta-manifests-over-format-bump/description.txt
+++ b/bat/tests/no-delta-manifests-over-format-bump/description.txt
@@ -1,0 +1,5 @@
+no-delta-manifests-over-format-bump
+===================================
+This test creates a format bump using a manual process (not auto-format-bump)
+and attempts to create delta manifests over that bump. No delta manifests
+should be created.

--- a/bat/tests/no-delta-manifests-over-format-bump/run.bats
+++ b/bat/tests/no-delta-manifests-over-format-bump/run.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  global_setup
+}
+
+# TODO: just call the auto-format-bump capability when available. Not using the old
+# auto-format-bump functionality because it will be changing very soon.
+
+@test "Attempt to create delta manifests over format bump" {
+  mixer-init-stripped-down $CLRVER 10
+  sed -i 's/\(FORMAT\).*/\1 = "1"/' mixer.state
+
+  ###############################################################################
+  # +0
+  ###############################################################################
+
+  # build bundles and updates regularly
+  mixer-build-bundles > $LOGDIR/build_bundles10.log
+  mixer-build-update > $LOGDIR/build_update10.log
+
+  ###############################################################################
+  # +10
+  ###############################################################################
+
+  # update mixer to build version 20, which in our case is the +10
+  mixer-mixversion-update 20
+  # build bundles normally. At this point the bundles to be deleted should still
+  # be part of the mixbundles list and the groups.ini
+  mixer-build-bundles > $LOGDIR/build_bundles20.log
+  # no deleted bundles
+
+  # Replace the +10 version in /usr/lib/os-release with +20 version and write the
+  # new format to the format file on disk.  This is so clients will already be on
+  # the new format when they update to the +10 because the content is the same as
+  # the +20.
+  sudo sed -i 's/\(VERSION_ID=\).*/\130/' update/image/20/full/usr/lib/os-release
+  echo 2 | sudo tee update/image/20/full/usr/share/defaults/swupd/format
+  # build update based on the modified bundle information. This is *not* a
+  # minversion and these manifests must be built with the mixer from the original
+  # format (if manifest format changes).
+  mixer-build-update > $LOGDIR/build_update20.log
+
+  # not validating the bump itself, we have another test for that
+
+  ###############################################################################
+  # +20
+  ###############################################################################
+
+  # update mixer to build version 30, which in our case is the +20
+  mixer-mixversion-update 30
+  # update mixer.state to new format
+  sudo sed -i 's/\(FORMAT\).*/\1 = "2"/' mixer.state
+  # no deleted bundles
+
+  # link the +10 bundles to the +20 so we are building the update with the same
+  # underlying content. The only things that might change are the manifests
+  # (potentially the pack and full-file formats as well, though this is very
+  # rare).
+  sudo cp -al update/image/20 update/image/30
+  # build an update as a minversion, this is the first build where the manifests
+  # identify as the new format
+  mixer-build-update-minversion 30
+
+  # not validating the bump itself, we have another test for that
+
+  ###############################################################################
+  # try to create delta manifests for the previous two versions
+  ###############################################################################
+
+  # wipe old image dirs so we make sure we can't create it, then make sure we
+  # "Found 0 previous versions" when building.
+  sudo rm -rf image/www/{10,20}
+  # redirect both stderr and stdout so we can check for the warning as well
+  mixer-build-delta-manifests 2 &> $LOGDIR/build_delta-manifests30.log
+  grep "Found 0 previous versions" $LOGDIR/build_delta-manifests30.log
+  # check mixer didn't create them anyways
+  [ ! -f update/www/30/Manifest-os-core-delta-from-10 ]
+  [ ! -f update/www/30/Manifest-os-core-delta-from-20 ]
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/docs/mixer.build.1
+++ b/docs/mixer.build.1
@@ -201,6 +201,39 @@ Generate packs targeting a specific \fIto\fP \fIversion\fP\&.
 .UNINDENT
 .UNINDENT
 .sp
+\fBdelta\-manifests\fP
+.INDENT 0.0
+.INDENT 3.5
+Build manifest deltas to optimize \fBswupd update\fPs between versions. When a
+\fBswupd\fP client update runs, it will first try to get a delta manifest file
+if it exists and apply that on the bundle manifest file for the version
+installed on their system (if it exists). This can save a large amount of
+content being downloaded in the case of few files changing in a manifest.
+Because the client can fall back to the full manifest file if a delta is not
+available, delta manifests are not necessary for a functional update. In
+addition to the global options \fBmixer build delta\-manifests\fP takes the
+following options.
+.INDENT 0.0
+.IP \(bu 2
+\fB\-\-from {version}\fP
+.sp
+Generate packs from the specified \fIversion\fP\&.
+.IP \(bu 2
+\fB\-h, \-\-help\fP
+.sp
+Display \fBbuild bundles\fP help information and exit.
+.IP \(bu 2
+\fB\-\-previous\-versions {number}\fP
+.sp
+Generate packs for \fInumber\fP of previous versions.
+.IP \(bu 2
+\fB\-\-to {version}\fP
+.sp
+Generate packs targeting a specific \fIto\fP \fIversion\fP\&.
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.sp
 \fBimage\fP
 .INDENT 0.0
 .INDENT 3.5

--- a/docs/mixer.build.1.rst
+++ b/docs/mixer.build.1.rst
@@ -162,6 +162,34 @@ SUBCOMMANDS
 
       Generate packs targeting a specific `to` `version`.
 
+``delta-manifests``
+
+    Build manifest deltas to optimize ``swupd update``\s between versions. When a
+    ``swupd`` client update runs, it will first try to get a delta manifest file
+    if it exists and apply that on the bundle manifest file for the version
+    installed on their system (if it exists). This can save a large amount of
+    content being downloaded in the case of few files changing in a manifest.
+    Because the client can fall back to the full manifest file if a delta is not
+    available, delta manifests are not necessary for a functional update. In
+    addition to the global options ``mixer build delta-manifests`` takes the
+    following options.
+
+    - ``--from {version}``
+
+      Generate packs from the specified `version`.
+
+    - ``-h, --help``
+
+      Display ``build bundles`` help information and exit.
+
+    - ``--previous-versions {number}``
+
+      Generate packs for `number` of previous versions.
+
+    - ``--to {version}``
+
+      Generate packs targeting a specific `to` `version`.
+
 ``image``
 
     Build an image from the mix content. In addition to the global options


### PR DESCRIPTION
swupd-server used to support building bsdiff based deltas of manifest
files. This change adds that ability back for bundle manifests with
the 'mixer build delta-manifests' command.