### PR TITLE
builder: fix spurious print in stopWatch

### DIFF
--- a/builder/stopwatch.go
+++ b/builder/stopwatch.go
@@ -24,7 +24,7 @@ func (sw *stopWatch) Start(name string) {
 	logger := log.New(sw.w, "", log.Ldate|log.Ltime)
 	if sw.w != nil {
 		if len(sw.entries) > 0 {
-			logger.Println(sw.w, "")
+			logger.Println()
 		}
 		logger.Printf("=> %s\n", name)
 	}


### PR DESCRIPTION
Likely a typo when converting to the logger interface. Stops printing
a memory address of the writer given to the stopWatch and just print a
newline.