### PR TITLE
swupd-inspector: ignore "iterative manifests" when visiting all files

### DIFF
--- a/swupd-inspector/get.go
+++ b/swupd-inspector/get.go
@@ -109,6 +109,9 @@ func runGet(cacheDir, url, arg string) {
 func visitAllFiles(state *client.State, mom *swupd.Manifest, visitFunc func(bundle, file *swupd.File) bool) error {
 	var stop bool
 	for _, bundleF := range mom.Files {
+		if bundleF.Type != swupd.TypeManifest {
+			continue
+		}
 		bundle, err := state.GetBundleManifest(fmt.Sprint(bundleF.Version), bundleF.Name, "")
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes log and get.  In these we want to loop at the actual Manifests,
to peek at the entire file list of each.