### PR TITLE
config: Allow OS identification customization #560

### DIFF
--- a/bat/tests/config-conversion/configs/1.1_builder.conf
+++ b/bat/tests/config-conversion/configs/1.1_builder.conf
@@ -1,0 +1,24 @@
+#VERSION 1.1
+
+[Builder]
+  CERT = "/home/clr/mix/Swupd_Root.pem"
+  SERVER_STATE_DIR = "/home/clr/mix/update"
+  VERSIONS_PATH = "/home/clr/mix"
+  YUM_CONF = "/home/clr/mix/.yum-mix.conf"
+
+[Swupd]
+  BUNDLE = "os-core-update"
+  CONTENTURL = "<URL where the content will be hosted>"
+  VERSIONURL = "<URL where the version of the mix will be hosted>"
+
+[Server]
+  DEBUG_INFO_BANNED = "true"
+  DEBUG_INFO_LIB = "/usr/lib/debug"
+  DEBUG_INFO_SRC = "/usr/src/debug"
+
+[Mixer]
+  LOCAL_BUNDLE_DIR = "/home/clr/mix/local-bundles"
+  LOCAL_REPO_DIR = "/home/clr/mix/local-yum"
+  LOCAL_RPM_DIR = "/home/clr/mix/local-rpms"
+  DOCKER_IMAGE_PATH = "clearlinux/mixer"
+  OS_RELEASE_PATH = ""

--- a/bat/tests/customize-os-release/Makefile
+++ b/bat/tests/customize-os-release/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./builder.conf.bkp ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles builder-orig.conf
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/customize-os-release/description.txt
+++ b/bat/tests/customize-os-release/description.txt
@@ -1,0 +1,4 @@
+customize-os-release
+=================
+This test simulates os-release customization for mixer build. It initiates a
+mix, replaces the default config with modified config with customized os-release file path.

--- a/bat/tests/customize-os-release/files/my-builder.conf
+++ b/bat/tests/customize-os-release/files/my-builder.conf
@@ -1,0 +1,24 @@
+#VERSION 1.1
+
+[Builder]
+  CERT = "/home/clr/mix/Swupd_Root.pem"
+  SERVER_STATE_DIR = "/home/clr/mix/update"
+  VERSIONS_PATH = "/home/clr/mix"
+  YUM_CONF = "/home/clr/mix/.yum-mix.conf"
+
+[Swupd]
+  BUNDLE = "os-core-update"
+  CONTENTURL = "<URL where the content will be hosted>"
+  VERSIONURL = "<URL where the version of the mix will be hosted>"
+
+[Server]
+  DEBUG_INFO_BANNED = "true"
+  DEBUG_INFO_LIB = "/usr/lib/debug"
+  DEBUG_INFO_SRC = "/usr/src/debug"
+
+[Mixer]
+  LOCAL_BUNDLE_DIR = "/home/clr/mix/local-bundles"
+  LOCAL_REPO_DIR = "/home/clr/mix/local-yum"
+  LOCAL_RPM_DIR = "/home/clr/mix/local-rpms"
+  DOCKER_IMAGE_PATH = "clearlinux/mixer"
+  OS_RELEASE_PATH = "/home/clr/mix/files/my-os-release"

--- a/bat/tests/customize-os-release/files/my-os-release
+++ b/bat/tests/customize-os-release/files/my-os-release
@@ -1,0 +1,11 @@
+NAME="Clear Linux OS"
+VERSION=1
+ID=clear-linux-os-downstream
+ID_LIKE=clear-linux-os-downstream
+VERSION_ID=1
+PRETTY_NAME="Clear Linux OS (DownStream)"
+ANSI_COLOR="1;35"
+HOME_URL="https://clearlinux.org"
+SUPPORT_URL="https://clearlinux.org"
+BUG_REPORT_URL="mailto:dev@lists.clearlinux.org"
+PRIVACY_POLICY_URL="http://www.intel.com/privacy"

--- a/bat/tests/customize-os-release/run.bats
+++ b/bat/tests/customize-os-release/run.bats
@@ -11,8 +11,7 @@ setup() {
 
   mixer init > /dev/null
 
-  #Backup orig config and use modified config which has customized os-release file
-  mv builder.conf builder-orig.conf
+  #Use modified config which has customized os-release file
   cp files/my-builder.conf builder.conf
   sed -i "s:/home/clr/mix:$PWD:g" builder.conf
 

--- a/bat/tests/customize-os-release/run.bats
+++ b/bat/tests/customize-os-release/run.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  global_setup
+}
+
+@test "Customize os-release file" {
+
+  mixer init > /dev/null
+
+  #Backup orig config and use modified config which has customized os-release file
+  mv builder.conf builder-orig.conf
+  cp files/my-builder.conf builder.conf
+  sed -i "s:/home/clr/mix:$PWD:g" builder.conf
+
+  #Mixer build bundle
+  mixer-build-bundles > $LOGDIR/build_bundles.log
+
+  #Compare the diff between customized os-release file and output of mixer build
+  #bundle. The only difference should be VERSION_ID 
+  run bash -c "diff files/my-os-release update/image/10/full/usr/lib/os-release | wc -l "
+  [ "$output" -eq  4 ]
+
+  run bash -c "diff files/my-os-release update/image/10/full/usr/lib/os-release"
+  [[ ${lines[1]} =~ "VERSION_ID" ]]
+  [[ ${lines[3]} =~ "VERSION_ID" ]]
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -881,38 +880,14 @@ func createVersionsFile(baseDir string, packagerCmd []string) error {
 func fixOSRelease(b *Builder, filename, version string) error {
 
 	//Replace the default os-release file if customized os-release file found
-	path := b.Config.Mixer.OSReleasePath
-	if path != "" {
-
-		// Validate file path
-		_, err := os.Stat(path)
-		if err != nil {
-			return err
-		}
-
-		fSrc, err := os.OpenFile(path, os.O_RDONLY, 0666)
-		if err != nil {
-			return err
-		}
-
-		fDst, err := os.OpenFile(filename, os.O_RDWR, 0666)
-		if err != nil {
-			return err
-		}
-
-		//Overwrite the os-release file
-		_, err = io.Copy(fDst, fSrc)
-		if err != nil {
-			return err
-		}
-
-		//Close file descriptor to make sure the copy operation is completed.
-		_ = fSrc.Close()
-		_ = fDst.Close()
-
+	var err error
+	var f *os.File
+	if b.Config.Mixer.OSReleasePath != "" {
+		f, err = os.Open(b.Config.Mixer.OSReleasePath)
+	} else {
+		f, err = os.Open(filename)
 	}
 
-	f, err := os.Open(filename)
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -69,6 +69,7 @@ type mixerConf struct {
 	LocalRepoDir   string `required:"false" mount:"true" toml:"LOCAL_REPO_DIR"`
 	LocalRPMDir    string `required:"false" mount:"true" toml:"LOCAL_RPM_DIR"`
 	DockerImgPath  string `required:"false" toml:"DOCKER_IMAGE_PATH"`
+	OSReleasePath  string `required:"false" mount:"true" toml:"OS_RELEASE_PATH"`
 }
 
 // LoadDefaults sets sane values for the config properties

--- a/config/config_convert.go
+++ b/config/config_convert.go
@@ -29,7 +29,7 @@ import (
 )
 
 // CurrentConfigVersion holds the current version of the config file
-const CurrentConfigVersion = "1.0"
+const CurrentConfigVersion = "1.1"
 
 func (config *MixConfig) parseVersion(reader *bufio.Reader) (bool, error) {
 	verBytes, err := reader.ReadString('\n')


### PR DESCRIPTION
New [Os] section is added in builder.conf file to support
OS identification modification such as NAME, VERSION, ID,
ID_LIKE, PRETTY_NAME, ANSI_COLOR, HOME_URL, SUPPORT_URL,
BUG_REPORT_URL and PRIVACY_POLICY_URL for downstream Clear Linux
build.

This section NOT supporting VERSION_ID since it has been used by
Mixer for mixversion.

Example to modify os-release file:
Change the NAME, PRETTY_NAME and PRIVACY_POLICY_URL

[Os]
  NAME = "Clear-Linux-A"
  PRETTY_NAME = "A Clear Linux OS"
  PRIVACY_POLICY_URL = ""

Example to keep value based on default os-release file:

[Os]
  ANSI_COLOR = "<NoChange>"
  HOME_URL = "<NoChange>"
  SUPPORT_URL = "<NoChange>"
  BUG_REPORT_URL = "<NoChange>"

Signed-off-by: sweeaun <swee.aun.khor@intel.com>