### PR TITLE
Mca bugfixes

### DIFF
--- a/bat/tests/build-validate/run.bats
+++ b/bat/tests/build-validate/run.bats
@@ -18,7 +18,8 @@ setup() {
 
   # Strip required bundles to minimum package set.
   mixer init --no-default-bundles
-  mixer bundle add os-core os-core-update
+  mixer bundle create no-pkgs
+  mixer bundle add os-core os-core-update no-pkgs
   echo "filesystem" > $LOCAL_BUNDLE_DIR/os-core
   echo "clr-bundles" > $LOCAL_BUNDLE_DIR/os-core-update
 

--- a/bat/tests/build-validate/run.bats
+++ b/bat/tests/build-validate/run.bats
@@ -117,7 +117,7 @@ setup() {
 
   run sudo mixer build validate --from 10 --to 20 --native
 
-  [[ $status -eq 0 ]]
+  [[ $status -ne 0 ]]
 
   # Check for inserted file failures
   [[ $output =~ "ERROR: /fakeAdd is added in manifest 'os-core', but not in a package" ]]
@@ -135,7 +135,7 @@ setup() {
   
   run sudo mixer build validate --from 20 --to 30 --native
 
-  [[ $status -eq 0 ]]
+  [[ $status -ne 0 ]]
   [[ $output =~ "ERROR: /usr/share/defaults/swupd/format is not modified in manifest 'os-core-update'" ]]
 }
 
@@ -146,7 +146,7 @@ setup() {
 
   run sudo mixer build validate --from 30 --to 40 --native
 
-  [[ $status -eq 0 ]]
+  [[ $status -ne 0 ]]
   [[ $output =~ "WARNING: If this is a +10 to +20 comparison, os-core/os-core-update have file exception errors" ]]
 }
 

--- a/builder/build_validate.go
+++ b/builder/build_validate.go
@@ -987,7 +987,7 @@ func printMcaResults(results *mcaDiffResults, fromInfo, toInfo map[string]*mcaBu
 			}
 			fmt.Printf(err)
 		}
-		return nil
+		return fmt.Errorf("Manifest errors were identified")
 	}
 
 	fmt.Printf("** Summary: No errors detected in manifests\n\n")

--- a/builder/build_validate.go
+++ b/builder/build_validate.go
@@ -277,6 +277,12 @@ func (b *Builder) mcaPkgInfo(mInfo map[string]*swupd.Manifest, version, download
 	bundleWorker := func() {
 		for m := range mCh {
 			var pkgList = []string{}
+
+			// Skip bundles with no packages
+			if len(mInfo[m.name].BundleInfo.AllPackages) == 0 {
+				continue
+			}
+
 			for pkg := range mInfo[m.name].BundleInfo.AllPackages {
 				pkgList = append(pkgList, pkg)
 			}


### PR DESCRIPTION
I found additional special case errors for MCA:

1. When a bundle has no packages, MCA should not call dnf without any packages in its argument list.

2. /usr/lib/os-release can be modified by both Mixer and the filesystem package. When Mixer and the filesystem package modified this file, MCA would generate an invalid special case error. This PR reworks how MCA handles /usr/lib/os-release so that an error is not generated when both Mixer and the filesystem package modify the file.