### PR TITLE
swupd: Remove directories from contentsize calculation

### DIFF
--- a/bat/tests/contentsize-check/Makefile
+++ b/bat/tests/contentsize-check/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/contentsize-check/description.txt
+++ b/bat/tests/contentsize-check/description.txt
@@ -1,0 +1,5 @@
+contentsize-check
+================
+This test calculates the content size of the files in the chroot for each bundle
+and compares them against the contentsize field in the corresponding manifest.
+The directory size is omitted for the content size calculation.

--- a/bat/tests/contentsize-check/run.bats
+++ b/bat/tests/contentsize-check/run.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  global_setup
+
+  current_ver=$(get-current-version)
+  mixer-init-stripped-down "$current_ver" 10
+  mixer-build-all
+}
+
+@test "Compare calculated contentsize with actual" {
+  manifestPrefix=update/www/10/Manifest.
+  manifests=$(sed -n 's/^[M,I]\..*\t//p' "${manifestPrefix}"MoM)
+
+  while read -r manifest; do
+    chroot=update/image/10/full/
+
+    # Only files and links are included in the contentsize. Directories
+    # can be installed with variable sizes, so they are omitted from the
+    # contentsize calculation.
+    files=$(sed -n 's/^[F,L].*\t//p' "${manifestPrefix}${manifest}")
+
+    # Add the content sizes of the files and links
+    total=0
+    while read -r f; do
+      if [ -z "$f" ]; then
+        continue
+      fi
+      size=$(stat -c "%s" "${chroot}${f}")
+      total=$((total + size))
+    done <<< "$files"
+
+    manifestSize=$(sed -n 's/^contentsize:\t//p' "${manifestPrefix}${manifest}")
+
+    # Compare the calculated contentsize against the manifest's contentsize
+    test "$total" -eq "$manifestSize" 
+  done <<< "$manifests"
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -629,7 +629,12 @@ func (m *Manifest) subtractManifestFromManifest(m2 *Manifest) {
 				// this is expensive because we care about order at this point
 				m.Files = append(m.Files[:i], m.Files[i+1:]...)
 				m.Header.FileCount--
-				m.Header.ContentSize -= uint64(f1.Info.Size())
+
+				// Directories can be installed with inconsistent sizes, so the
+				// directory size is not included in the contentsize header field.
+				if f1.Type != TypeDirectory {
+					m.Header.ContentSize -= uint64(f1.Info.Size())
+				}
 			}
 
 			// only need to advance the m2.Files index since i now points to the next
@@ -910,7 +915,9 @@ func fileContentInManifest(f *File, m *Manifest) bool {
 // AppendFile appends a file to the manifest and updates the ContentSize
 func (m *Manifest) AppendFile(file *File) {
 	m.Files = append(m.Files, file)
-	if file.Info != nil {
+	// Directories can be installed with inconsistent sizes, so the
+	// directory size is not included in the contentsize header field.
+	if file.Info != nil && file.Type != TypeDirectory {
 		m.Header.ContentSize += uint64(file.Info.Size())
 	}
 }


### PR DESCRIPTION
Directories can be installed with inconsistent sizes. To make mixes
reproducible, the size of directories is omitted from the contentsize
calculation.

Fixes #568 

Signed-off-by: John Akre <john.w.akre@intel.com>