### PR TITLE
cmd: skip format bump check

### DIFF
--- a/afb.sh
+++ b/afb.sh
@@ -97,7 +97,7 @@ mixer build update --native
 ###############################################################################
 
 # update mixer to build version 30, which in our case is the +20
-mixer versions update --mix-version 30
+mixer versions update --mix-version 30 --skip-format-check
 # update mixer.state to new format
 sed -i 's/\(FORMAT\).*/\1 = "2"/' mixer.state
 # Fully remove deleted bundles from groups.ini and mixbundles list. This will
@@ -115,4 +115,4 @@ done
 cp -al update/image/20 update/image/30
 # build an update as a minversion, this is the first build where the manifests
 # identify as the new format
-mixer build update --native --min-version 30
+mixer build update --native --min-version 30 --skip-format-check

--- a/bat/tests/manual-upstream-format-bump-flow/Makefile
+++ b/bat/tests/manual-upstream-format-bump-flow/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/manual-upstream-format-bump-flow/description.txt
+++ b/bat/tests/manual-upstream-format-bump-flow/description.txt
@@ -1,0 +1,4 @@
+manual-upstream-format-bump-flow
+=======================
+This test uses the manual format bump process to cross an upstream format
+bump boundary.

--- a/bat/tests/manual-upstream-format-bump-flow/run.bats
+++ b/bat/tests/manual-upstream-format-bump-flow/run.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  global_setup
+}
+
+@test "Manually cross an upstream format boundary" {
+  mixer-init-stripped-down 27190 10
+  sed -i 's/\(FORMAT\).*/\1 = "1"/' mixer.state
+
+  # create bundle to be deleted
+  create-empty-local-bundle "foo"
+  # mark as deleted
+  sed -i "s/\(# \[STATUS\]:\).*/\1 Deprecated/" local-bundles/foo
+  # add foo bundle to mix
+  mixer-bundle-add "foo"
+
+  ###############################################################################
+  # +0
+  #
+  # This is the last normal build in the original format. When doing a format
+  # bump this build already exists. Building it now because the test needs a
+  # normal starting version.
+  ###############################################################################
+
+  # build bundles and updates regularly
+  mixer-build-bundles > $LOGDIR/build_bundles10.log
+  mixer-build-update > $LOGDIR/build_update10.log
+
+  ###############################################################################
+  # +10
+  #
+  # This is the last build in the original format. At this point add ONLY the
+  # content relevant to the format bump to the mash to be used. Relevant content
+  # should be the only change.
+  #
+  # mixer will create manifests and update content based on the format it is
+  # building for. The format is set in the mixer.state file.
+  ###############################################################################
+
+  # update mixer to build version 20, which in our case is the +10
+  mixer-versions-update 20 27200
+  # build bundles normally. At this point the bundles to be deleted should still
+  # be part of the mixbundles list and the groups.ini
+  mixer-build-bundles > $LOGDIR/build_bundles20.log
+  # remove all deleted bundles' content by replacing bundle-info files with empty
+  # directories. This causes mixer to fall back to reading content for those
+  # bundles from a chroot. The chroots for these bundles will be empty.
+  for i in $(grep -lir "\[STATUS\]: Deprecated" local-bundles/); do
+    b=$(basename $i)
+    sudo rm -f update/image/20/$b-info; sudo mkdir update/image/20/$b
+  done
+  # Replace the +10 version in /usr/lib/os-release with +20 version and write the
+  # new format to the format file on disk.  This is so clients will already be on
+  # the new format when they update to the +10 because the content is the same as
+  # the +20.
+  sudo sed -i 's/\(VERSION_ID=\).*/\130/' update/image/20/full/usr/lib/os-release
+  echo 2 | sudo tee update/image/20/full/usr/share/defaults/swupd/format
+  # build update based on the modified bundle information. This is *not* a
+  # minversion and these manifests must be built with the mixer from the original
+  # format (if manifest format changes).
+  mixer-build-update > $LOGDIR/build_update20.log
+
+  # validate the +10 build
+  # MoM is the correct format
+  grep -P "MANIFEST\t1" update/www/20/Manifest.MoM
+  # bundle to be deleted still exists in the +10
+  grep -P "20\tfoo" update/www/20/Manifest.MoM
+  # deprecated bundle contains only one deleted file
+  grep -P "00000000000\t20\t/usr/share/clear/bundles/foo" update/www/20/Manifest.foo
+
+  ###############################################################################
+  # +20
+  #
+  # This is the first build in the new format. The content is the same as the +10
+  # but the manifests might be created differently if a new manifest template is
+  # defined for the new format.
+  ###############################################################################
+
+  # update mixer to build version 30, which in our case is the +20
+  mixer $MIXARGS versions update --mix-version 30 --upstream-version 27210 --skip-format-check
+  # update mixer.state to new format
+  sudo sed -i 's/\(FORMAT\).*/\1 = "2"/' mixer.state
+  # Fully remove deleted bundles from groups.ini and mixbundles list. This will
+  # cause the deprecated bundles to be removed from the MoM entirely. This will
+  # not break users who had these bundles because the removed content in the +10
+  # caused the bundles to be dropped from client systems at that point.
+  for i in $(grep -lir "\[STATUS\]: Deprecated" upstream-bundles/ local-bundles/); do
+    b=$(basename $i)
+    sudo mixer $MIXARGS bundle remove $b --native=true; sudo sed -i "/\[$b\]/d;/group=$b/d" update/groups.ini;
+  done
+  # link the +10 bundles to the +20 so we are building the update with the same
+  # underlying content. The only things that might change are the manifests
+  # (potentially the pack and full-file formats as well, though this is very
+  # rare).
+  sudo cp -al update/image/20 update/image/30
+  # build an update as a minversion, this is the first build where the manifests
+  # identify as the new format
+  sudo -E mixer $MIXARGS build update --config $BATS_TEST_DIRNAME/builder.conf --native=true --min-version 30 --skip-format-check
+
+  # validate the +20 build
+  grep -P "MANIFEST\t2" update/www/30/Manifest.MoM
+  grep -v "foo" update/www/30/Manifest.MoM
+  test ! -f update/www/30/Manifest.foo
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/builder/metadata.go
+++ b/builder/metadata.go
@@ -281,7 +281,7 @@ Latest upstream in format: (not available in offline mode)
 // UpdateVersions will validate then update both mix and upstream versions. If
 // upstream version is 0, then the latest upstream version in the current
 // upstream format will be taken instead.
-func (b *Builder) UpdateVersions(nextMix, nextUpstream uint32) error {
+func (b *Builder) UpdateVersions(nextMix, nextUpstream uint32, skipFormatCheck bool) error {
 	var format string
 	var latest uint32
 	var err error
@@ -359,8 +359,10 @@ New upstream: %d (format: %s)
 	b.UpstreamVerUint32 = nextUpstream
 	b.UpstreamVer = nextUpstreamStr
 
-	if _, err := b.CheckBumpNeeded(false); err != nil {
-		return err
+	if !skipFormatCheck {
+		if _, err := b.CheckBumpNeeded(false); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -50,6 +50,7 @@ type buildCmdFlags struct {
 	skipPacks       bool
 	to              int
 	from            int
+	skipFormatCheck bool
 
 	numFullfileWorkers int
 	numDeltaWorkers    int
@@ -701,6 +702,7 @@ func init() {
 	buildCmd.PersistentFlags().IntVar(&buildFlags.numDeltaWorkers, "delta-workers", 0, "Number of parallel workers when creating deltas, 0 means number of CPUs")
 	buildCmd.PersistentFlags().IntVar(&buildFlags.numBundleWorkers, "bundle-workers", 0, "Number of parallel workers when building bundles, 0 means number of CPUs")
 	buildCmd.PersistentFlags().IntVar(&buildFlags.downloadRetries, "retries", retriesDefault, "Number of retry attempts to download RPMs")
+	buildCmd.PersistentFlags().BoolVar(&buildFlags.skipFormatCheck, "skip-format-check", false, "Skip format bump check")
 
 	RootCmd.AddCommand(buildCmd)
 
@@ -774,7 +776,7 @@ func printFormatMismatch(b *builder.Builder) error {
 
 func checkFormatBump(b *builder.Builder) error {
 	// Skip check if offline
-	if builder.Offline {
+	if builder.Offline || buildFlags.skipFormatCheck {
 		return nil
 	}
 

--- a/mixer/cmd/versions.go
+++ b/mixer/cmd/versions.go
@@ -57,6 +57,7 @@ var versionsUpdateFlags struct {
 	mixVersion      uint32
 	upstreamVersion string // Accepts "latest".
 	increment       uint32
+	skipFormatCheck bool
 }
 
 func init() {
@@ -67,6 +68,7 @@ func init() {
 	versionsUpdateCmd.Flags().StringVar(&versionsUpdateFlags.upstreamVersion, "upstream-version", "", "Next upstream version (either version number or 'latest')")
 	versionsUpdateCmd.Flags().StringVar(&versionsUpdateFlags.upstreamVersion, "clear-version", "", "Alias to --upstream-version")
 	versionsUpdateCmd.Flags().Uint32Var(&versionsUpdateFlags.increment, "increment", 10, "Amount to increment current mix version")
+	versionsUpdateCmd.Flags().BoolVar(&versionsUpdateFlags.skipFormatCheck, "skip-format-check", false, "Skip format bump check")
 }
 
 func runVersions(cmd *cobra.Command, args []string) {
@@ -106,7 +108,7 @@ func runVersionsUpdate(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	err = b.UpdateVersions(nextMix, nextUpstream)
+	err = b.UpdateVersions(nextMix, nextUpstream, versionsUpdateFlags.skipFormatCheck)
 	if err != nil {
 		fail(err)
 	}


### PR DESCRIPTION
When doing manual format bumps, the upstream version for +20 needs to be
updated to the upstream version in the new format, but since the format
differs, the build will fail.
This PR adds a new flag to `mixer versions update` and to `mixer build`
subcommands that allows the check this check to be skipped.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>