### PR TITLE
config: Use server state dir when loading MixState

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -112,10 +112,10 @@ func NewFromConfig(conf string) (*Builder, error) {
 	if err := b.Config.LoadDefaults(); err != nil {
 		return nil, err
 	}
-	if err := b.State.Load(); err != nil {
+	if err := b.Config.LoadConfig(conf); err != nil {
 		return nil, err
 	}
-	if err := b.Config.LoadConfig(conf); err != nil {
+	if err := b.State.Load(b.Config); err != nil {
 		return nil, err
 	}
 	if err := b.ReadVersions(); err != nil {

--- a/config/config_convert.go
+++ b/config/config_convert.go
@@ -138,7 +138,7 @@ func (config *MixConfig) convertFormat() error {
 	}
 
 	var state MixState
-	state.LoadDefaults()
+	state.LoadDefaults(*config)
 
 	_, err = os.Stat(state.filename)
 	if err == nil {

--- a/config/state.go
+++ b/config/state.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -48,9 +49,9 @@ type MixState struct {
 const DefaultFormatPath = "/usr/share/defaults/swupd/format"
 
 // LoadDefaults initialize the state object with sane values
-func (state *MixState) LoadDefaults() {
+func (state *MixState) LoadDefaults(config MixConfig) {
 	state.loadDefaultFormat()
-	state.loadDefaultPreviousMixVer()
+	state.loadDefaultPreviousMixVer(config.Builder.ServerStateDir)
 
 	state.filename = "mixer.state"
 	state.version = CurrentStateVersion
@@ -77,9 +78,9 @@ func (state *MixState) loadDefaultFormat() {
 	state.formatSource = "Mixer internal value"
 }
 
-func (state *MixState) loadDefaultPreviousMixVer() {
+func (state *MixState) loadDefaultPreviousMixVer(stateDir string) {
 	/* The LAST_VER is the default for PREVIOUS_MIX_VERSION */
-	lastVer, err := ioutil.ReadFile("update/image/LAST_VER")
+	lastVer, err := ioutil.ReadFile(filepath.Join(stateDir, "image/LAST_VER"))
 	if err == nil && string(lastVer) != "" {
 		state.Mix.PreviousMixVer = strings.TrimSuffix(string(lastVer), "\n")
 		return
@@ -127,8 +128,8 @@ func (state *MixState) Save() error {
 }
 
 // Load the mixer.state file
-func (state *MixState) Load() error {
-	state.LoadDefaults()
+func (state *MixState) Load(config MixConfig) error {
+	state.LoadDefaults(config)
 
 	f, err := os.Open(state.filename)
 	if err != nil {

--- a/mixer/cmd/config.go
+++ b/mixer/cmd/config.go
@@ -50,15 +50,13 @@ var configConvertCmd = &cobra.Command{
 a backup file of the old config and will replace it with the converted one. Environment
 variables will not be expanded and the values will not be validated`,
 	Run: func(cmd *cobra.Command, args []string) {
-		/* If no state file exists, it must be created first to ensure the FORMAT value
-		is transferred from old configs before conversion */
-		var ms config.MixState
-		if err := ms.Load(); err != nil {
+		var mc config.MixConfig
+		if err := mc.Convert(configFile); err != nil {
 			fail(err)
 		}
 
-		var mc config.MixConfig
-		if err := mc.Convert(configFile); err != nil {
+		var ms config.MixState
+		if err := ms.Load(mc); err != nil {
 			fail(err)
 		}
 

--- a/mixer/cmd/init.go
+++ b/mixer/cmd/init.go
@@ -47,7 +47,7 @@ var initCmd = &cobra.Command{
 			fail(err)
 		}
 
-		b.State.LoadDefaults()
+		b.State.LoadDefaults(b.Config)
 		if initFlags.format != "" {
 			b.State.Mix.Format = initFlags.format
 		}


### PR DESCRIPTION
MixState needs to know the server state dir in order to find the value
for previous version since its path will not always be relative to the
execution folder.
With this patch, MixState is always loaded after MixConfig. Since the
conversion of older formats of MixConfig account for format transfer,
changing the order does not prevent the format value to be properly
moved to the state file.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>