### PR TITLE
Support "optional" bundles in manifests

### DIFF
--- a/builder/bundle_control.go
+++ b/builder/bundle_control.go
@@ -305,6 +305,13 @@ func (b *Builder) getFullBundleSet(bundles bundleSet) (bundleSet, error) {
 						return err
 					}
 				}
+
+				if len(bundle.OptionalIncludes) > 0 {
+					err := recurseBundleSet(bundle.OptionalIncludes)
+					if err != nil {
+						return err
+					}
+				}
 			}
 		}
 		return nil
@@ -348,6 +355,17 @@ func (b *Builder) getFullMixBundleSet() (bundleSet, error) {
 	set, err := b.getFullBundleSet(bundles)
 	if err != nil {
 		return nil, err
+	}
+	// Add the included and optional included bundles to the mix
+	for _, bundle := range set {
+		err := b.AddBundles(bundle.DirectIncludes, false, false, false)
+		if err != nil {
+			return nil, err
+		}
+		err = b.AddBundles(bundle.OptionalIncludes, false, false, false)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return set, nil
 }
@@ -746,6 +764,7 @@ const bundleTemplateFormat = `# [TITLE]: %s
 # [MAINTAINER]: 
 # 
 # List bundles one per line. Includes have format: include(bundle)
+# also-adds have format: also-add(bundle)
 `
 
 func createBundleFile(bundle string, path string) error {

--- a/swupd/bundleinfo.go
+++ b/swupd/bundleinfo.go
@@ -35,13 +35,14 @@ type BundleHeader struct {
 
 // BundleInfo describes the JSON object to be read from the *-info files
 type BundleInfo struct {
-	Name           string
-	Filename       string
-	Header         BundleHeader
-	DirectIncludes []string
-	DirectPackages map[string]bool
-	AllPackages    map[string]bool
-	Files          map[string]bool
+	Name             string
+	Filename         string
+	Header           BundleHeader
+	DirectIncludes   []string
+	OptionalIncludes []string
+	DirectPackages   map[string]bool
+	AllPackages      map[string]bool
+	Files            map[string]bool
 }
 
 // GetBundleInfo loads the BundleInfo member of m from the bundle-info file at
@@ -66,6 +67,9 @@ func (m *Manifest) GetBundleInfo(stateDir, path string) error {
 			return err
 		}
 		m.BundleInfo.DirectIncludes = includes
+		// TODO: this part of the code seems to be a legacy thing. Keep
+		// an eye on this to make sure m.BundleInfo.OptionalIncludes don't
+		// need to be added here too
 		return nil
 	}
 
@@ -136,6 +140,7 @@ func appendUniqueManifest(ms []*Manifest, man *Manifest) []*Manifest {
 
 func (m *Manifest) readIncludesFromBundleInfo(bundles []*Manifest) error {
 	includes := []*Manifest{}
+	optional := []*Manifest{}
 	// os-core is added as an include for every bundle
 	// handle it manually so we don't have to rely on the includes list having it
 	for _, b := range bundles {
@@ -163,6 +168,14 @@ func (m *Manifest) readIncludesFromBundleInfo(bundles []*Manifest) error {
 		}
 	}
 
+	for _, bn := range m.BundleInfo.OptionalIncludes {
+		for _, b := range bundles {
+			if bn == b.Name {
+				optional = appendUniqueManifest(optional, b)
+			}
+		}
+	}
 	m.Header.Includes = includes
+	m.Header.Optional = optional
 	return nil
 }

--- a/swupd/format_switch.go
+++ b/swupd/format_switch.go
@@ -40,8 +40,7 @@ includes:	{{.Name}}
 {{.GetFlagString}}	{{.Hash}}	{{.Version}}	{{.Name}}
 {{- end}}
 `,
-	// format 26 manifest template
-	// used for formats 26 and greater until a new format is required
+	// formats 26 to 28 manifest template
 	26: `
 {{- with .Header -}}
 MANIFEST	{{.Format}}
@@ -53,6 +52,28 @@ timestamp:	{{(.TimeStamp.Unix)}}
 contentsize:	{{.ContentSize -}}
 {{range .Includes}}
 includes:	{{.Name}}
+{{- end}}
+{{- end}}
+{{ range .Files}}
+{{.GetFlagString}}	{{.Hash}}	{{.Version}}	{{.Name}}
+{{- end}}
+`,
+	// format 29 manifest template
+	// used for formats 29 and greater until a new format is required
+	29: `
+{{- with .Header -}}
+MANIFEST	{{.Format}}
+version:	{{.Version}}
+previous:	{{.Previous}}
+{{ if ne .MinVersion 0 }}minversion:	{{.MinVersion}}
+{{ end }}filecount:	{{.FileCount}}
+timestamp:	{{(.TimeStamp.Unix)}}
+contentsize:	{{.ContentSize -}}
+{{range .Includes}}
+includes:	{{.Name}}
+{{- end -}}
+{{range .Optional}}
+also-add:	{{.Name}}
 {{- end}}
 {{- end}}
 {{ range .Files}}
@@ -97,12 +118,15 @@ func manifestTemplateForFormat(f uint) (t *template.Template) {
 	case f <= 25:
 		// initial format, everything 0-25 uses this format
 		t = template.Must(template.New("manifest").Parse(manTemplates[25]))
-	case f > 25:
-		// template for format 26
+	case f > 25 && f <= 28:
+		// template for formats 26 to 28
 		t = template.Must(template.New("manifest").Parse(manTemplates[26]))
+	case f > 28:
+		// template for formats 29 or higher
+		t = template.Must(template.New("manifest").Parse(manTemplates[29]))
 		// when a new format is required it must be added here and the 'case f
-		// > 25' must be modified to 'case f > 25 && f < <new_format>'. The
-		// <new_format> does not necessarily have to be 27 as format 27 may be
+		// > 28' must be modified to 'case f > 28 && f < <new_format>'. The
+		// <new_format> does not necessarily have to be 29 as format 29 may be
 		// created due to a content breaking change instead of a manifest
 		// format breaking change.
 	}

--- a/swupd/manifest_test.go
+++ b/swupd/manifest_test.go
@@ -144,6 +144,28 @@ func TestReadManifestHeaderIncludes(t *testing.T) {
 	}
 }
 
+func TestReadManifestHeaderOptional(t *testing.T) {
+	m := Manifest{}
+	if err := readManifestFileHeaderLine([]string{"also-add:", "test-bundle"}, &m); err != nil {
+		t.Error("failed to read also-add header")
+	}
+
+	var expected []*Manifest
+	expected = append(expected, &Manifest{Name: "test-bundle"})
+	if !reflect.DeepEqual(m.Header.Optional, expected) {
+		t.Errorf("manifest also-add set to %v when %v expected", m.Header.Optional, expected)
+	}
+
+	if err := readManifestFileHeaderLine([]string{"also-add:", "test-bundle2"}, &m); err != nil {
+		t.Error("failed to read second includes header")
+	}
+
+	expected = append(expected, &Manifest{Name: "test-bundle2"})
+	if !reflect.DeepEqual(m.Header.Optional, expected) {
+		t.Errorf("manifest also-add set to %v when %v expected", m.Header.Optional, expected)
+	}
+}
+
 func TestReadManifestFileEntry(t *testing.T) {
 	validHash := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
 	validManifestLines := [][]string{
@@ -210,10 +232,10 @@ func TestCheckInvalidManifestHeaders(t *testing.T) {
 		name   string
 		header ManifestHeader
 	}{
-		{"format not set", ManifestHeader{0, 100, 90, 0, 553, time.Unix(1000, 0), 100000, nil}},
-		{"version zero", ManifestHeader{10, 0, 90, 0, 553, time.Unix(1000, 0), 100000, nil}},
-		{"no files", ManifestHeader{10, 100, 90, 0, 0, time.Unix(1000, 0), 100000, nil}},
-		{"no timestamp", ManifestHeader{10, 100, 0, 90, 553, zeroTime, 100000, nil}},
+		{"format not set", ManifestHeader{0, 100, 90, 0, 553, time.Unix(1000, 0), 100000, nil, nil}},
+		{"version zero", ManifestHeader{10, 0, 90, 0, 553, time.Unix(1000, 0), 100000, nil, nil}},
+		{"no files", ManifestHeader{10, 100, 90, 0, 0, time.Unix(1000, 0), 100000, nil, nil}},
+		{"no timestamp", ManifestHeader{10, 100, 0, 90, 553, zeroTime, 100000, nil, nil}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
An optional bundle is similar to the required bundles (included
bundles) but have a couple of differences.

 - Optional bundles will be installed by default when the main
   bundle that includes them is installed.
 - Users will have the option to skip the installation of Optional
   bundles by using the flag --skip-optional/-o with bundle-add.
 - Optional bundles can be removed from the system even if the
   main bundle that installed them is still in the system.

From the perspective of Mixer a bundle will be considered as
optional whenever it is marked as optional in the bundle spec
file. E.g. optional(lib-openssl). And it should be added as such
in the bundle's manifest.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>