### PR TITLE
Add `mixer repo set` command

### DIFF
--- a/bat/tests/mixer-repo-commands/Makefile
+++ b/bat/tests/mixer-repo-commands/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/mixer-repo-commands/description.txt
+++ b/bat/tests/mixer-repo-commands/description.txt
@@ -1,0 +1,4 @@
+mixer-repo-commands
+====================
+This test validates mixer's ability to add new repos and set values in the
+.yum-mix.conf file.

--- a/bat/tests/mixer-repo-commands/run.bats
+++ b/bat/tests/mixer-repo-commands/run.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  global_setup
+}
+
+@test "Set repo values" {
+  mixer-init-stripped-down 25740 10
+
+  # Set value for new key
+  run mixer repo set local testkey 2
+  val=$(sed -n 's/^testkey.*= //p' .yum-mix.conf)
+
+  [[ "$status" -eq 0 ]]
+  [[ "$val" -eq 2 ]]
+
+  # Change value of existing key
+  run mixer repo set local testkey 3
+  val=$(sed -n 's/^testkey.*= //p' .yum-mix.conf)
+
+  [[ "$status" -eq 0 ]]
+  [[ "$val" -eq 3 ]]
+
+  # Attempt to set repo that doesn't exist
+  run mixer repo set invalidRepo testkey 3
+  [[ "$status" -ne 0 ]]
+}
+
+@test "Add repo" {
+  mixer-init-stripped-down 25740 10
+
+  # Add new repo
+  run mixer repo add newRepo newUrl
+
+  [[ "$status" -eq 0 ]]
+  grep -P "^\[newRepo\]" .yum-mix.conf
+  grep -P "^name=newRepo" .yum-mix.conf
+  grep -P "^baseurl=newUrl" .yum-mix.conf
+
+  # Attempt to add existing repo
+  run mixer repo add newRepo newUrl
+  [[ "$status" -ne 0 ]]
+}
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/builder/repo_control.go
+++ b/builder/repo_control.go
@@ -197,6 +197,33 @@ func (b *Builder) SetURLRepo(name, url string) error {
 	return DNFConf.SaveTo(b.Config.Builder.DNFConf)
 }
 
+// SetRepoVal sets a value for the provided repo and key
+func (b *Builder) SetRepoVal(reponame, key, val string) error {
+	if err := b.NewDNFConfIfNeeded(); err != nil {
+		return err
+	}
+
+	DNFConf, err := ini.Load(b.Config.Builder.DNFConf)
+	if err != nil {
+		return err
+	}
+
+	s, err := DNFConf.GetSection(reponame)
+	if err != nil {
+		return err
+	}
+
+	k, err := s.GetKey(key)
+	if err != nil {
+		if k, err = DNFConf.Section(reponame).NewKey(key, val); err != nil {
+			return err
+		}
+	}
+
+	k.SetValue(val)
+	return DNFConf.SaveTo(b.Config.Builder.DNFConf)
+}
+
 // SetExcludesRepo sets the ecludes for the repo <name> to [pkgs...]
 func (b *Builder) SetExcludesRepo(reponame, pkgs string) error {
 	if err := b.NewDNFConfIfNeeded(); err != nil {

--- a/mixer/cmd/repos.go
+++ b/mixer/cmd/repos.go
@@ -78,6 +78,15 @@ supported.`,
 	Run:  runExcludesRepo,
 }
 
+var setValRepoCmd = &cobra.Command{
+	Use:   "set <repo> <key> <value>",
+	Short: "Set the value for the specified key and repository",
+	Long: `Set the value for the specified key and repository in the .yum-mix.conf file.
+The dnf.conf man page can be used to search for acceptable keys and their descriptions.`,
+	Args: cobra.ExactArgs(3),
+	Run:  runSetValRepo,
+}
+
 var repoCmds = []*cobra.Command{
 	addRepoCmd,
 	removeRepoCmd,
@@ -85,6 +94,7 @@ var repoCmds = []*cobra.Command{
 	initRepoCmd,
 	setURLRepoCmd,
 	setExcludesRepoCmd,
+	setValRepoCmd,
 }
 
 func init() {
@@ -169,4 +179,17 @@ func runSetURLRepo(cmd *cobra.Command, args []string) {
 		fail(err)
 	}
 	fmt.Printf("Set %s baseurl to %s.\n", args[0], args[1])
+}
+
+func runSetValRepo(cmd *cobra.Command, args []string) {
+	b, err := builder.NewFromConfig(configFile)
+	if err != nil {
+		fail(err)
+	}
+
+	err = b.SetRepoVal(args[0], args[1], args[2])
+	if err != nil {
+		fail(err)
+	}
+	fmt.Printf("Set %s %s to %s.\n", args[0], args[1], args[2])
 }


### PR DESCRIPTION
A generic command for setting values in the .yum-mix.conf file would be useful. Currently, `mixer repo` only has ad-hoc commands to set specific values in the config file.