### PR TITLE
MCA: Support repo/baseurl overrides for from and to versions

### DIFF
--- a/bat/tests/build-validate/run.bats
+++ b/bat/tests/build-validate/run.bats
@@ -150,4 +150,12 @@ setup() {
   [[ $output =~ "WARNING: If this is a +10 to +20 comparison, os-core/os-core-update have file exception errors" ]]
 }
 
+@test "MCA override DNF conf to invalid URL" {
+  # Override upstream repo to invalid URL to confirm DNF conf overrides succeed
+  run sudo sh -c "mixer build validate --from 10 --to 20 --native --from-repo-url clear=foo"
+
+  [[ "$status" -ne 0 ]]
+  [[ "$output" =~ "RPM download attempt 4 failed. Maximum of 4 attempts." ]]
+}
+
 # vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -462,6 +462,7 @@ func genUpdateBundleSpecialFiles(chrootDir string, b *Builder) error {
 
 func downloadRpms(packagerCmd, rpmList []string, baseDir string, maxRetries int) (*bytes.Buffer, error) {
 	var downloadErr error
+	var out *bytes.Buffer
 
 	if maxRetries < 0 {
 		return nil, errors.Errorf("maxRetries value < 0 for RPM downloads")
@@ -471,7 +472,7 @@ func downloadRpms(packagerCmd, rpmList []string, baseDir string, maxRetries int)
 	args = append(args, rpmList...)
 
 	for attempts := 0; attempts <= maxRetries; attempts++ {
-		out, downloadErr := helpers.RunCommandOutputEnv(args[0], args[1:], []string{"LC_ALL=en_US.UTF-8"})
+		out, downloadErr = helpers.RunCommandOutputEnv(args[0], args[1:], []string{"LC_ALL=en_US.UTF-8"})
 		if downloadErr == nil {
 			return out, downloadErr
 		}

--- a/docs/mixer.build.1
+++ b/docs/mixer.build.1
@@ -321,6 +321,37 @@ Supply the \fIpath\fP to the file system where the \fBswupd\fP binaries live.
 .UNINDENT
 .UNINDENT
 .UNINDENT
+.sp
+\fBvalidate\fP
+.INDENT 0.0
+.INDENT 3.5
+Compare two versions to validate that manifest file changes align with corresponding
+package changes. Inconsistencies between manifest entries and package contents are
+reported as errors. When no errors occur, package update statistics are displayed.
+.INDENT 0.0
+.IP \(bu 2
+\fB\-\-from {version}\fP
+.sp
+Compare manifests from a specific version\&.
+.IP \(bu 2
+\fB\-\-to {version}\fP
+.sp
+Compare manifests to a specific version\&.
+.IP \(bu 2
+\fB\-\-from-repo-url {repo}={URL}\fP
+.sp
+Overrides the baseurl value for the provided repo in the DNF config file for the from version\&.
+.IP \(bu 2
+\fB\-\-to-repo-url {repo}={URL}\fP
+.sp
+Overrides the baseurl value for the provided repo in the DNF config file for the to version\&.
+.IP \(bu 2
+\fB\-h, \-\-help\fP
+.sp
+Display \fBbuild validate\fP help information and exit.
+.UNINDENT
+.UNINDENT
+.UNINDENT
 .SH EXIT STATUS
 .sp
 On success, 0 is returned. A non\-zero return code indicates a failure.

--- a/docs/mixer.build.1.rst
+++ b/docs/mixer.build.1.rst
@@ -267,6 +267,32 @@ SUBCOMMANDS
 
      Supply the `path` to the file system where the ``swupd`` binaries live.
 
+``validate``
+
+    Compare two versions to validate that manifest file changes align with corresponding
+    package changes. Inconsistencies between manifest entries and package contents are
+    reported as errors. When no errors occur, package update statistics are displayed.
+
+    - ``--from {version}``
+
+      Compare manifests ``from`` a specific version
+
+    - ``--to {version}``
+
+      Compare manifests ``to`` a specific version
+
+    - ``--from-repo-url {repo}={URL}``
+
+      Overrides the baseurl value for the provided repo in the DNF config file for the ``from`` version
+
+    - ``--to-repo-url {repo}={URL}``
+
+      Overrides the baseurl value for the provided repo in the DNF config file for the ``to`` version
+
+    - ``-h, --help``
+
+      Display ``build validate`` help information and exit.
+
 
 EXIT STATUS
 ===========

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -50,6 +50,8 @@ type buildCmdFlags struct {
 	skipPacks       bool
 	to              int
 	from            int
+	toRepoURLs      *map[string]string
+	fromRepoURLs    *map[string]string
 	skipFormatCheck bool
 
 	numFullfileWorkers int
@@ -496,7 +498,7 @@ var buildValidateCmd = &cobra.Command{
 		}
 		setWorkers(b)
 
-		err = b.CheckManifestCorrectness(buildFlags.from, buildFlags.to, buildFlags.downloadRetries)
+		err = b.CheckManifestCorrectness(buildFlags.from, buildFlags.to, buildFlags.downloadRetries, *buildFlags.fromRepoURLs, *buildFlags.toRepoURLs)
 		if err != nil {
 			fail(err)
 		}
@@ -718,6 +720,8 @@ func init() {
 
 	buildValidateCmd.Flags().IntVar(&buildFlags.to, "to", 0, "Compare manifests targeting a specific version")
 	buildValidateCmd.Flags().IntVar(&buildFlags.from, "from", 0, "Compare manifests from a specific version")
+	buildFlags.toRepoURLs = buildValidateCmd.Flags().StringToString("to-repo-url", nil, "Overrides the baseurl value for the provided repo in the DNF config file for the `to` version: <repo>=<URL>")
+	buildFlags.fromRepoURLs = buildValidateCmd.Flags().StringToString("from-repo-url", nil, "Overrides the baseurl value for the provided repo in the DNF config file for the `from` version: <repo>=<URL>")
 
 	buildImageCmd.Flags().StringVar(&buildFlags.format, "format", "", "Supply the format used for the Mix")
 	buildImageCmd.Flags().StringVar(&buildFlags.template, "template", "", "Path to template file to use")


### PR DESCRIPTION
Problem:

In some cases (downstream mix with custom content) the `from` and `to` mix versions require different repo settings in the dnf conf file to download packages correctly. This makes it difficult for MCA to consume a single config file when downloading packages for both mix versions.

Approach:

Add arguments that override repo/baseurl settings in a temporary dnf config file for that will be used only when downloading packages for the `from` or `to` mixes.

If this approach is acceptable, I will update with tests