### PR TITLE
MCA Statistics Reporting Updates

### DIFF
--- a/bat/tests/build-validate/run.bats
+++ b/bat/tests/build-validate/run.bats
@@ -60,9 +60,9 @@ setup() {
   [[ "$output" =~ "Deleted bundles: 0" ]]
 
   # testbundle2 is added. testbundle1 and os-core are modified
-  [[ "$output" =~ "|testbundle1" ]]
-  [[ "$output" =~ "|testbundle2" ]]
-  [[ "$output" =~ "|os-core" ]]
+  [[ "$output" =~ "| testbundle1" ]]
+  [[ "$output" =~ "| testbundle2" ]]
+  [[ "$output" =~ "| os-core" ]]
 }
 
 @test "MCA compare to +10" {
@@ -77,8 +77,8 @@ setup() {
 
   # When updating to the +10, the special case files in os-core and
   # os-core-update should be modified
-  [[ "$output" =~ "|os-core" ]]
-  [[ "$output" =~ "|os-core-update" ]]
+  [[ "$output" =~ "| os-core" ]]
+  [[ "$output" =~ "| os-core-update" ]]
 }
 
 @test "MCA compare +10 to +20" {

--- a/builder/build_validate.go
+++ b/builder/build_validate.go
@@ -26,7 +26,7 @@ const (
 
 // Contains all results from MCA diff and lists of added/deleted/modified bundles
 type mcaDiffResults struct {
-	bundleDiff map[string]*mcaBundleDiff
+	bundleDiff []*mcaBundleDiff
 
 	addList []string
 	delList []string
@@ -537,9 +537,7 @@ func (info *mcaBundleInfo) getSubPkgFiles(bundle string, mInfo map[string]*swupd
 // diffMcaInfo calculates the manifest file, package, and resolved package file
 // differences between two versions and captures metadata required by printMcaResults.
 func diffMcaInfo(fromInfo, toInfo map[string]*mcaBundleInfo) (*mcaDiffResults, error) {
-	results := &mcaDiffResults{
-		bundleDiff: make(map[string]*mcaBundleDiff),
-	}
+	results := &mcaDiffResults{}
 
 	// Bundles in toInfo are either added, modified, or unchanged
 	for bName := range toInfo {
@@ -581,7 +579,7 @@ func diffMcaInfo(fromInfo, toInfo map[string]*mcaBundleInfo) (*mcaDiffResults, e
 			results.addList = append(results.addList, bName)
 		}
 
-		results.bundleDiff[bName] = bundleDiff
+		results.bundleDiff = append(results.bundleDiff, bundleDiff)
 	}
 
 	for bName := range fromInfo {
@@ -593,7 +591,7 @@ func diffMcaInfo(fromInfo, toInfo map[string]*mcaBundleInfo) (*mcaDiffResults, e
 			}
 
 			results.delList = append(results.delList, bName)
-			results.bundleDiff[bName] = bundleDiff
+			results.bundleDiff = append(results.bundleDiff, bundleDiff)
 		}
 	}
 	return results, nil
@@ -1054,6 +1052,10 @@ func printMcaResults(results *mcaDiffResults, fromInfo, toInfo map[string]*mcaBu
 	if _, err = fmt.Fprintf(w, "+---------------------------------------------------------------+\n"); err != nil {
 		return err
 	}
+
+	sort.Slice(results.bundleDiff, func(i, j int) bool {
+		return results.bundleDiff[i].name < results.bundleDiff[j].name
+	})
 
 	// Print statistics for each bundle
 	for _, b := range results.bundleDiff {

--- a/builder/build_validate.go
+++ b/builder/build_validate.go
@@ -1046,7 +1046,7 @@ func printMcaResults(results *mcaDiffResults, fromInfo, toInfo map[string]*mcaBu
 	if _, err = fmt.Fprintf(w, "\n+---------------------------------------------------------------+\n"); err != nil {
 		return err
 	}
-	if _, err = fmt.Fprintf(w, "|BUNDLE\t CHANGES\n"); err != nil {
+	if _, err = fmt.Fprintf(w, "| BUNDLE\t CHANGES\n"); err != nil {
 		return err
 	}
 	if _, err = fmt.Fprintf(w, "+---------------------------------------------------------------+\n"); err != nil {
@@ -1063,7 +1063,7 @@ func printMcaResults(results *mcaDiffResults, fromInfo, toInfo map[string]*mcaBu
 		if (b.status == unchanged || b.status == removed) && b.minversion == false {
 			continue
 		}
-		if _, err = fmt.Fprintf(w, "|%s\t Summary:\n", b.name); err != nil {
+		if _, err = fmt.Fprintf(w, "| %s\t Summary:\n", b.name); err != nil {
 			return err
 		}
 
@@ -1110,7 +1110,7 @@ func printMcaResults(results *mcaDiffResults, fromInfo, toInfo map[string]*mcaBu
 
 		// Print added and deleted packages for bundle
 		if len(b.pkgDiffs.addList) > 0 {
-			if _, err = fmt.Fprintf(w, "|\t Packages added\n"); err != nil {
+			if _, err = fmt.Fprintf(w, "|\t Packages added:\n"); err != nil {
 				return err
 			}
 			sort.Strings(b.pkgDiffs.addList)
@@ -1122,7 +1122,7 @@ func printMcaResults(results *mcaDiffResults, fromInfo, toInfo map[string]*mcaBu
 			}
 		}
 		if len(b.pkgDiffs.delList) > 0 {
-			if _, err = fmt.Fprintf(w, "|\t Packages deleted\n"); err != nil {
+			if _, err = fmt.Fprintf(w, "|\t Packages deleted:\n"); err != nil {
 				return err
 			}
 			sort.Strings(b.pkgDiffs.delList)


### PR DESCRIPTION
This PR makes the following changes:

1. Sort bundles when printing statistics
2. Add colons to added/deleted packages when printing bundle statistics.
3. Add space between '|' character and bundle name