### PR TITLE
MCA Bug Fixes

### DIFF
--- a/builder/build_validate.go
+++ b/builder/build_validate.go
@@ -383,6 +383,11 @@ func (b *Builder) resolvePkgFiles(pkg *pkgInfo, version int) ([]*fileInfo, error
 			continue
 		}
 
+		// Files with blacklisted characters are skipped
+		if swupd.FilenameBlacklisted(filepath.Base(path)) {
+			continue
+		}
+
 		// Directories are omitted from MCA because they may be missed from rpm output.
 		mode := fileMetadata[3]
 		if mode[:1] == "d" {

--- a/builder/build_validate.go
+++ b/builder/build_validate.go
@@ -376,9 +376,10 @@ func (b *Builder) resolvePkgFiles(pkg *pkgInfo, version int) ([]*fileInfo, error
 		}
 
 		fileMetadata := strings.Split(line, ", ")
+		path := fileMetadata[0]
 
 		// Paths that are banned from manifests are skipped by MCA
-		if isBannedPath(fileMetadata[0]) {
+		if isBannedPath(path) {
 			continue
 		}
 
@@ -390,20 +391,10 @@ func (b *Builder) resolvePkgFiles(pkg *pkgInfo, version int) ([]*fileInfo, error
 
 		// Some Clear Linux packages install files with path components that are
 		// symlinks. MCA must resolve file paths to align with the manifests.
-		if strings.HasPrefix(fileMetadata[0], "/bin/") {
-			fileMetadata[0] = strings.Replace(fileMetadata[0], "/bin/", "/usr/bin/", 1)
-		} else if strings.HasPrefix(fileMetadata[0], "/sbin/") {
-			fileMetadata[0] = strings.Replace(fileMetadata[0], "/sbin/", "/usr/bin/", 1)
-		} else if strings.HasPrefix(fileMetadata[0], "/lib64/") {
-			fileMetadata[0] = strings.Replace(fileMetadata[0], "/lib64/", "/usr/lib64/", 1)
-		} else if strings.HasPrefix(fileMetadata[0], "/lib/") {
-			fileMetadata[0] = strings.Replace(fileMetadata[0], "/lib/", "/usr/lib/", 1)
-		} else if strings.HasPrefix(fileMetadata[0], "/usr/sbin/") {
-			fileMetadata[0] = strings.Replace(fileMetadata[0], "/usr/sbin/", "/usr/bin/", 1)
-		}
+		path = resolveFileName(path)
 
 		pkgFile := &fileInfo{
-			name:  fileMetadata[0],
+			name:  path,
 			size:  fileMetadata[1],
 			hash:  fileMetadata[2],
 			modes: fileMetadata[3],

--- a/swupd/bundleinfo.go
+++ b/swupd/bundleinfo.go
@@ -134,7 +134,8 @@ func appendUniqueManifest(ms []*Manifest, man *Manifest) []*Manifest {
 	return append(ms, man)
 }
 
-func (m *Manifest) readIncludesFromBundleInfo(bundles []*Manifest) error {
+// ReadIncludesFromBundleInfo sets the Header.Includes field for the given manifest.
+func (m *Manifest) ReadIncludesFromBundleInfo(bundles []*Manifest) error {
 	includes := []*Manifest{}
 	// os-core is added as an include for every bundle
 	// handle it manually so we don't have to rely on the includes list having it

--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -210,7 +210,7 @@ func processBundles(ui UpdateInfo, c config, numWorkers int) ([]*Manifest, error
 		}
 		if bundle.Name != "os-core" {
 			// read in bundle includes
-			if err = bundle.readIncludesFromBundleInfo(tmpManifests); err != nil {
+			if err = bundle.ReadIncludesFromBundleInfo(tmpManifests); err != nil {
 				return nil, err
 			}
 		}

--- a/swupd/filesystem.go
+++ b/swupd/filesystem.go
@@ -24,7 +24,8 @@ import (
 
 const illegalChars = ";&|*`/<>\\\"'"
 
-func filenameBlacklisted(fname string) bool {
+// FilenameBlacklisted checks for illegal characters in filename
+func FilenameBlacklisted(fname string) bool {
 	return strings.ContainsAny(fname, illegalChars)
 }
 
@@ -60,7 +61,7 @@ func recordFromFile(rootPath, path, removePrefix string, fi os.FileInfo) (*File,
 		return nil, nil
 	}
 
-	if filenameBlacklisted(filepath.Base(fname)) {
+	if FilenameBlacklisted(filepath.Base(fname)) {
 		return nil, fmt.Errorf("%s is a blacklisted file name", fname)
 	}
 

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -603,6 +603,29 @@ func (m *Manifest) hasUnsupportedTypeChanges() bool {
 	return false
 }
 
+// GetRecursiveIncludes returns a list of all recursively included bundles
+// for the given manifest.
+func (m *Manifest) GetRecursiveIncludes() []*Manifest {
+	manifests := []*Manifest{}
+	visited := make(map[string]bool)
+
+	for _, inc := range m.Header.Includes {
+		manifests = append(manifests, inc)
+		visited[inc.Name] = true
+	}
+
+	for i := 0; i < len(manifests); i++ {
+		for _, inc := range manifests[i].Header.Includes {
+			if visited[inc.Name] != true {
+				manifests = append(manifests, inc)
+				visited[inc.Name] = true
+			}
+		}
+	}
+
+	return manifests
+}
+
 // subtractManifestFromManifest removes all files present in m2 from m.
 // Expects m and m2 files lists to be sorted by name only
 func (m *Manifest) subtractManifestFromManifest(m2 *Manifest) {


### PR DESCRIPTION
This PR makes the following changes:

* Serialize MCA package downloads:
  * There was a race condition where packages could be queried by `rpm` before the download finished. Serializing this section does not significantly impact performance.
* Use recursive includes for file/pkg subtraction:
  * There were cases when MCA would miss files/pkgs that should have been subtracted. This issue is resolved by checking each of the bundles from the recursive includes list for files/pkgs to subtract. 
* Use `resolveFileName` function to manage symlinks used by Clear Linux packages.
  * Re-use existing function to remove duplicated code.
* Skip files with blacklisted characters:
  * Mixer does not create entries for files that have names with blacklisted characters (;&|*`/<>\"'). Now, MCA ignores blacklisted files that it resolves from packages. Previously, these were reported as errors by MCA.

