### PR TITLE
Delete index manifest

### DIFF
--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -515,18 +515,7 @@ func installBundleToFull(packagerCmd []string, buildVersionDir string, bundle *b
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(bundleDir, bundle.Name), nil, 0644)
-	if err != nil {
-		return nil
-	}
-
-	metaPath := filepath.Join(baseDir, "usr/share/clear/allbundles")
-	err = os.MkdirAll(metaPath, 0755)
-	if err != nil {
-		return err
-	}
-
-	return writeBundleInfoPretty(bundle, filepath.Join(metaPath, bundle.Name))
+	return ioutil.WriteFile(filepath.Join(bundleDir, bundle.Name), nil, 0644)
 }
 
 func clearDNFCache(packagerCmd []string) error {
@@ -592,15 +581,6 @@ func buildFullChroot(b *Builder, set *bundleSet, packagerCmd []string, buildVers
 	}
 
 	return nil
-}
-
-func writeBundleInfoPretty(bundle *bundle, path string) error {
-	b, err := json.MarshalIndent(*bundle, "", "\t")
-	if err != nil {
-		return err
-	}
-
-	return ioutil.WriteFile(path, b, 0644)
 }
 
 func writeBundleInfo(bundle *bundle, path string) error {

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -280,6 +280,23 @@ var buildFormatOldCmd = &cobra.Command{
 		oldFormat := b.State.Mix.Format
 		b.State.Mix.Format = buildFlags.newFormat
 
+		oldFormatInt, err := strconv.Atoi(oldFormat)
+		if err != nil {
+			fail(err)
+		}
+		newFormatInt, err := strconv.Atoi(b.State.Mix.Format)
+		if err != nil {
+			fail(err)
+		}
+
+		// Delete index manifest when passing format 28
+		if oldFormatInt <= 28 && newFormatInt > 28 {
+			bdir := filepath.Join(b.Config.Builder.ServerStateDir, "image", b.MixVer, "os-core-update-index")
+			if err := os.MkdirAll(bdir, 0755); err != nil {
+				fail(err)
+			}
+		}
+
 		// Build bundles normally. At this point the bundles to be deleted should still
 		// be part of the mixbundles list and the groups.ini
 		if err = buildBundles(b, buildFlags.noSigning, buildFlags.clean, buildFlags.downloadRetries); err != nil {

--- a/swupd/bundleinfo.go
+++ b/swupd/bundleinfo.go
@@ -180,3 +180,13 @@ func (m *Manifest) ReadIncludesFromBundleInfo(bundles []*Manifest) error {
 	m.Header.Optional = optional
 	return nil
 }
+
+// writeBundleInfoPretty creates files for index manifest bundle entries
+func writeBundleInfoPretty(bundle *BundleInfo, path string) error {
+	b, err := json.MarshalIndent(*bundle, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(path, b, 0644)
+}

--- a/swupd/delta_test.go
+++ b/swupd/delta_test.go
@@ -145,14 +145,15 @@ func TestNoDeltasForTypeChangesOrDereferencedSymlinks(t *testing.T) {
 	}
 
 	// Since pack has 3 deltas, no other delta is there. Double check other deltas
-	// were not created in the file system.
+	// were not created in the file system (with the exception of the index manifest).
 	fis, err := ioutil.ReadDir(ts.path("www/20/delta"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Check if all deltas and the delta manifest were created
-	if uint64(len(fis)) != info.DeltaCount {
+	// Check if all deltas and the delta manifest were created. An additional delta
+	// was created for the index manifest
+	if uint64(len(fis)) != info.DeltaCount+1 {
 		t.Fatalf("found %d files in %s but expected %d", len(fis), ts.path("www/20/delta"), info.DeltaCount)
 	}
 }

--- a/swupd/format_switch.go
+++ b/swupd/format_switch.go
@@ -16,6 +16,9 @@ package swupd
 
 import (
 	"archive/tar"
+	"fmt"
+	"os"
+	"path/filepath"
 	"text/template"
 )
 
@@ -109,6 +112,53 @@ func (m *Manifest) writeIterativeManifestsForFormat(newManifests []*Manifest, ou
 	}
 
 	return m.writeIterativeManifests(newManifests, out)
+}
+
+// The index manifest is not generated after format 28
+func writeIndexManifestForFormat(c *config, ui *UpdateInfo, bundles []*Manifest, format uint) (*Manifest, error) {
+	if format <= 28 {
+		bundleDir := filepath.Join(c.imageBase, fmt.Sprint(ui.version))
+		baseDir := filepath.Join(bundleDir, "full")
+		metaPath := filepath.Join(baseDir, "usr/share/clear/allbundles")
+
+		err := os.MkdirAll(metaPath, 0755)
+		if err != nil {
+			return nil, err
+		}
+
+		// Create index manifest bundle entries when a bundle chroot doesn't exist
+		if _, err = os.Stat(filepath.Join(bundleDir, "os-core-update-index")); os.IsNotExist(err) {
+			for _, b := range bundles {
+				// full and iterative manifests are not included in index manifest
+				if b.Name == "full" || b.Type == ManifestIterative {
+					continue
+				}
+
+				// Load bundle info files that haven't been loaded
+				if b.BundleInfo.Name == "" {
+					biPath := filepath.Join(bundleDir, b.Name+"-info")
+					if err = b.GetBundleInfo(c.stateDir, biPath); err != nil {
+						return nil, err
+					}
+				}
+
+				// Write index manifest content to full chroot
+				err = writeBundleInfoPretty(&b.BundleInfo, filepath.Join(metaPath, b.Name))
+				if err != nil {
+					return nil, err
+				}
+			}
+		} else if err != nil {
+			return nil, err
+		}
+
+		osIdx, err := writeIndexManifest(c, ui, bundles)
+		if err != nil {
+			return nil, err
+		}
+		return osIdx, nil
+	}
+	return nil, nil
 }
 
 // manifestTemplateForFormat returns the *template.Template for creating

--- a/swupd/format_switch_test.go
+++ b/swupd/format_switch_test.go
@@ -261,3 +261,48 @@ func TestFormats28to29Optional(t *testing.T) {
 	}
 	checkManifestContains(t, ts.Dir, "20", "test-bundle", expSubs...)
 }
+
+// Index manifest is deleted when its bundle chroot exists and is not
+// generated in formats greater than 28
+func TestFormats28to29IndexManifest(t *testing.T) {
+	ts := newTestSwupd(t, "format28to29indexManifest")
+	defer ts.cleanup()
+
+	// Format 28 generates index manifests
+	ts.Format = 28
+	ts.Bundles = []string{"test-bundle1"}
+	ts.createManifests(10)
+
+	subs := []string{
+		"10\t/usr/share/clear/bundles/os-core-update-index",
+		"10\t/usr/share/clear/allbundles",
+		"10\t/usr/share/clear/allbundles/os-core",
+		"10\t/usr/share/clear/allbundles/test-bundle1",
+	}
+
+	checkManifestContains(t, ts.Dir, "10", "os-core-update-index", subs...)
+	checkManifestContains(t, ts.Dir, "10", "MoM", "10\tos-core-update-index")
+
+	// The os-core-update-index is deleted when the os-core-update-index
+	// bundle chroot exists
+	ts.mkdir("image/20/os-core-update-index")
+
+	deletedPrefix := ".d..\t" + AllZeroHash + "\t20\t"
+	subs = []string{
+		deletedPrefix + "/usr/share/clear/bundles/os-core-update-index",
+		deletedPrefix + "/usr/share/clear/allbundles",
+		deletedPrefix + "/usr/share/clear/allbundles/os-core",
+		deletedPrefix + "/usr/share/clear/allbundles/test-bundle1",
+	}
+
+	ts.createManifests(20)
+	checkManifestContains(t, ts.Dir, "20", "os-core-update-index", subs...)
+	checkManifestContains(t, ts.Dir, "20", "MoM", "20\tos-core-update-index")
+
+	// Format 29 does not generate index manifests
+	ts.Format = 29
+	ts.createManifests(30)
+
+	checkManifestNotContains(t, ts.Dir, "30", "MoM", "os-core-update-index")
+	ts.checkNotExists("www/30/Manifest.os-core-update-index")
+}

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -239,6 +239,19 @@ func ParseManifestFile(path string) (*Manifest, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if strings.Compare(m.Name, "MoM") == 0 {
+		m.Type = ManifestMoM
+	} else if strings.Compare(m.Name, "full") == 0 {
+		m.Type = ManifestUnset
+	} else if strings.Contains(m.Name, ".I.") {
+		m.Type = ManifestIterative
+	} else if strings.Contains(m.Name, ".D.") {
+		m.Type = ManifestDelta
+	} else {
+		m.Type = ManifestBundle
+	}
+
 	return m, nil
 }
 


### PR DESCRIPTION
This PR deletes the index manifest when transitioning from format 28 -> 29. Since this manifest is directly injected into the mix, it cannot follow the typical bundle deletion workflow. As a result, there are some cases where the deletion will not be smooth:

1. Upstream mixes must create an empty bundle chroot during a format bump from 28 -> 29 for the os-core-update-index manifest to delete it.
2. Downstream mixes ahead of upstream Clear's format (format 28) will miss the index manifest deletion.
3. Downstream mixes that do not upgrade Mixer to include this change when advancing their mix to format 29 will miss the index manifest deletion.

If a mix does not successfully delete the index manifest, the following will happen:
1. The os-core-update-index manifest will be removed from the MoM.
2. The os-core-update-index manifest will be removed without deleting any of its files. Any systems that subscribed to this bundle will need to manually remove its files from their system or perform a `swupd verify --fix --picky`