### PR TITLE
MCA: Parse rpm output with \a characters

### DIFF
--- a/builder/build_validate.go
+++ b/builder/build_validate.go
@@ -348,7 +348,7 @@ func (b *Builder) mcaPkgInfo(manifests []*swupd.Manifest, version, downloadRetri
 
 // resolvePkgFiles queries a package for a list of file metadata.
 func (b *Builder) resolvePkgFiles(pkg *pkgInfo, version int) ([]*fileInfo, error) {
-	queryCmd := "[%{filenames}, %{filesizes}, %{filedigests}, %{filemodes:perms}, %{filelinktos}, %{fileusername}, %{filegroupname}\n]"
+	queryCmd := "[%{filenames}\a%{filesizes}\a%{filedigests}\a%{filemodes:perms}\a%{filelinktos}\a%{fileusername}\a%{filegroupname}\n]"
 	rpmCmd := []string{"rpm", "-qp", "--qf=" + queryCmd}
 
 	validationDir := filepath.Join(b.Config.Builder.ServerStateDir, "validation")
@@ -375,7 +375,7 @@ func (b *Builder) resolvePkgFiles(pkg *pkgInfo, version int) ([]*fileInfo, error
 			continue
 		}
 
-		fileMetadata := strings.Split(line, ", ")
+		fileMetadata := strings.Split(line, "\a")
 		path := fileMetadata[0]
 
 		// Paths that are banned from manifests are skipped by MCA

--- a/swupd/filesystem.go
+++ b/swupd/filesystem.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 )
 
-const illegalChars = ";&|*`/<>\\\"'"
+const illegalChars = ";&|*`/<>\\\"'\a"
 
 // FilenameBlacklisted checks for illegal characters in filename
 func FilenameBlacklisted(fname string) bool {


### PR DESCRIPTION
Previously, MCA parsed rpm output with commas which is a valid file
character. Now, rpm output is parsed with \a which are
blacklisted file characters for Mixer.

Signed-off-by: John Akre <john.w.akre@intel.com>