### PR TITLE
travis: Set travis timeout to 60min

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_install:
     - docker build -t testdock .
 
 script:
-    - docker run testdock
+    - travis_wait 60 docker run testdock


### PR DESCRIPTION
The bat tests in travis fail due to timeout when there is no output for
10 minutes. This change adds the `travis_wait` command which will prevent
the timeout by writing to the build log every minute for 60 minutes.

Signed-off-by: John Akre <john.w.akre@intel.com>