### PR TITLE
WIP: Implemented --ignore-missing flag in mixer build

### DIFF
--- a/builder/deltapacks.go
+++ b/builder/deltapacks.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func createDeltaPacks(fromMoM *swupd.Manifest, toMoM *swupd.Manifest, printReport bool, outputDir, bundleDir string, numWorkers int) error {
+func createDeltaPacks(fromMoM *swupd.Manifest, toMoM *swupd.Manifest, printReport bool, outputDir, bundleDir string, numWorkers int, ignoreMissing bool) error {
 	timer := &stopWatch{w: os.Stdout}
 	defer timer.WriteSummary(os.Stdout)
 	timer.Start("CREATE DELTA PACKS")
@@ -75,7 +75,7 @@ func createDeltaPacks(fromMoM *swupd.Manifest, toMoM *swupd.Manifest, printRepor
 			defer wg.Done()
 			for b := range bundleQueue {
 				fmt.Printf("  Creating delta pack for bundle %q from %d to %d\n", b.Name, b.FromVersion, b.ToVersion)
-				info, err := swupd.CreatePack(b.Name, b.FromVersion, b.ToVersion, outputDir, bundleDir, numWorkers)
+				info, err := swupd.CreatePack(b.Name, b.FromVersion, b.ToVersion, outputDir, bundleDir, numWorkers, ignoreMissing)
 				if err != nil {
 					log.Printf("ERROR: Pack %q from %d to %d FAILED to be created: %s\n", b.Name, b.FromVersion, b.ToVersion, err)
 					// Do not exit on errors, we have logging for all other failures and deltas are optional

--- a/builder/update.go
+++ b/builder/update.go
@@ -212,7 +212,7 @@ func (b *Builder) buildUpdateContent(params UpdateParameters, timer *stopWatch) 
 			fmt.Printf("Creating zero pack for %s to version %d\n", name, version)
 
 			var info *swupd.PackInfo
-			info, err = swupd.CreatePack(name, 0, version, outputDir, bundleDir, 0)
+			info, err = swupd.CreatePack(name, 0, version, outputDir, bundleDir, 0, b.IgnoreMissing)
 			if err != nil {
 				return errors.Wrapf(err, "couldn't make pack for bundle %q", name)
 			}

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -57,6 +57,7 @@ type buildCmdFlags struct {
 	numFullfileWorkers int
 	numDeltaWorkers    int
 	numBundleWorkers   int
+	ignoreMissing      bool
 }
 
 var buildFlags buildCmdFlags
@@ -250,6 +251,7 @@ var buildFormatOldCmd = &cobra.Command{
 		}
 
 		setWorkers(b)
+		b.IgnoreMissing = buildFlags.ignoreMissing
 
 		lastVer, err := b.GetLastBuildVersion()
 		if err != nil {
@@ -363,6 +365,7 @@ var buildFormatNewCmd = &cobra.Command{
 		}
 
 		setWorkers(b)
+		b.IgnoreMissing = buildFlags.ignoreMissing
 
 		if err = b.ModifyBundles(b.RemoveBundlesGroupINI); err != nil {
 			fail(err)
@@ -410,6 +413,7 @@ var buildUpdateCmd = &cobra.Command{
 			fail(err)
 		}
 		setWorkers(b)
+		b.IgnoreMissing = buildFlags.ignoreMissing
 		params := builder.UpdateParameters{
 			MinVersion:    buildFlags.minVersion,
 			Format:        buildFlags.format,
@@ -448,6 +452,7 @@ var buildAllCmd = &cobra.Command{
 			fail(err)
 		}
 		setWorkers(b)
+		b.IgnoreMissing = buildFlags.ignoreMissing
 		rpms, err := helpers.ListVisibleFiles(b.Config.Mixer.LocalRPMDir)
 		if err == nil {
 			err = b.AddRPMList(rpms)
@@ -604,6 +609,8 @@ func runBuildDeltaPacks(cmd *cobra.Command, args []string) error {
 		fail(err)
 	}
 	setWorkers(b)
+	b.IgnoreMissing = buildFlags.ignoreMissing
+
 	if fromChanged {
 		err = b.BuildDeltaPacks(buildDeltaPacksFlags.from, buildDeltaPacksFlags.to, buildDeltaPacksFlags.report)
 	} else {
@@ -627,6 +634,8 @@ func runBuildDeltaManifests(cmd *cobra.Command, args []string) error {
 		fail(err)
 	}
 	setWorkers(b)
+	b.IgnoreMissing = buildFlags.ignoreMissing
+
 	if fromChanged {
 		err = b.BuildDeltaManifests(buildDeltaManifestsFlags.from, buildDeltaManifestsFlags.to)
 	} else {
@@ -705,6 +714,7 @@ func init() {
 	buildCmd.PersistentFlags().IntVar(&buildFlags.numBundleWorkers, "bundle-workers", 0, "Number of parallel workers when building bundles, 0 means number of CPUs")
 	buildCmd.PersistentFlags().IntVar(&buildFlags.downloadRetries, "retries", retriesDefault, "Number of retry attempts to download RPMs")
 	buildCmd.PersistentFlags().BoolVar(&buildFlags.skipFormatCheck, "skip-format-check", false, "Skip format bump check")
+	buildCmd.PersistentFlags().BoolVar(&buildFlags.ignoreMissing, "ignore-missing", false, "Ignore missing files while generating deltas, continue generating deltas for existing files")
 
 	RootCmd.AddCommand(buildCmd)
 

--- a/swupd/cmd/create-pack/main.go
+++ b/swupd/cmd/create-pack/main.go
@@ -124,7 +124,7 @@ func main() {
 
 		fmt.Printf("Packing %s from %d to %d...\n", b.Name, b.FromVersion, b.ToVersion)
 
-		info, err := swupd.CreatePack(b.Name, b.FromVersion, b.ToVersion, filepath.Join(stateDir, "www"), chrootDir, 0)
+		info, err := swupd.CreatePack(b.Name, b.FromVersion, b.ToVersion, filepath.Join(stateDir, "www"), chrootDir, 0, false)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -264,7 +264,7 @@ func mustCreateAllDeltas(t *testing.T, manifest, statedir string, from, to uint3
 		_ = logFile.Close()
 	}()
 
-	deltas, err := CreateDeltasForManifest(manifest, statedir, from, to, 0, bsdiffLog)
+	deltas, err := CreateDeltasForManifest(manifest, statedir, from, to, 0, bsdiffLog, false)
 	if err != nil {
 		t.Fatalf("couldn't create deltas for %s: %s", manifest, err)
 	}
@@ -291,7 +291,7 @@ func tryCreateAllDeltas(t *testing.T, manifest, statedir string, from, to uint32
 		_ = logFile.Close()
 	}()
 
-	_, err = CreateDeltasForManifest(manifest, statedir, from, to, 0, bsdiffLog)
+	_, err = CreateDeltasForManifest(manifest, statedir, from, to, 0, bsdiffLog, false)
 	if err != nil {
 		t.Fatalf("couldn't create deltas for %s: %s", manifest, err)
 	}

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -508,7 +508,7 @@ func (m *Manifest) newDeleted(df *File) {
 
 // linkDeltaPeersForPack sets the DeltaPeer of the files in newManifest that have the corresponding files
 // in oldManifest.
-func linkDeltaPeersForPack(c *config, oldManifest, newManifest *Manifest) error {
+func linkDeltaPeersForPack(c *config, oldManifest, newManifest *Manifest, ignoreMissingFlag bool) error {
 	newIndex := 0
 	oldIndex := 0
 	added := []*File{}
@@ -568,6 +568,9 @@ func linkDeltaPeersForPack(c *config, oldManifest, newManifest *Manifest) error 
 			newPath := filepath.Join(c.imageBase, fmt.Sprint(nf.Version), "full", nf.Name)
 			fi, err := os.Stat(newPath)
 			if err != nil {
+				if ignoreMissingFlag {
+					continue
+				}
 				return errors.Wrapf(err, "error accessing %s to decide whether it can have a delta or not", newPath)
 			}
 			if fi.Size() < minimumSizeToMakeDeltaInBytes {
@@ -580,7 +583,7 @@ func linkDeltaPeersForPack(c *config, oldManifest, newManifest *Manifest) error 
 	}
 
 	// Run rename detection on old and new manifests
-	return renameDetection(newManifest, added, removed, *c)
+	return renameDetection(newManifest, added, removed, *c, ignoreMissingFlag)
 }
 
 func includesChanged(m1 *Manifest, m2 *Manifest) bool {

--- a/swupd/packs_test.go
+++ b/swupd/packs_test.go
@@ -255,7 +255,7 @@ func TestCreatePackZeroPacks(t *testing.T) {
 	ts.createManifests(20)
 
 	// Expect failure when creating packs without the fullfiles.
-	_, err := CreatePack("editors", 0, 20, ts.path("www"), "", 0)
+	_, err := CreatePack("editors", 0, 20, ts.path("www"), "", 0, false)
 	if err == nil {
 		t.Fatalf("unexpected success creating pack without chrootDir nor fullfiles available")
 	}
@@ -270,7 +270,7 @@ func TestCreatePackZeroPacks(t *testing.T) {
 
 	// Expect failure when creating packs for bundle shells, it won't find the new
 	// shell added in version 20.
-	_, err = CreatePack("shells", 0, 20, ts.path("www"), "", 0)
+	_, err = CreatePack("shells", 0, 20, ts.path("www"), "", 0, false)
 	if err == nil {
 		t.Fatalf("unexpected success creating pack without all fullfiles available")
 	}
@@ -476,7 +476,7 @@ func TestCreatePackWithIncompleteChrootDir(t *testing.T) {
 
 	// Creating a pack should fail, no way to get emacs contents from neither chroot
 	// or fullfile.
-	info, err := CreatePack("editors", 0, 10, fs.path("www"), fs.path("image"), 0)
+	info, err := CreatePack("editors", 0, 10, fs.path("www"), fs.path("image"), 0, false)
 	if err == nil {
 		t.Fatalf("unexpected success when creating pack with incomplete chroot")
 	}
@@ -618,12 +618,12 @@ func mustCreatePack(t *testing.T, name string, fromVersion, toVersion uint32, ou
 		_ = logFile.Close()
 	}()
 
-	err = CreateAllDeltas(outputDir, int(fromVersion), int(toVersion), 0, bsdiffLog)
+	err = CreateAllDeltas(outputDir, int(fromVersion), int(toVersion), 0, bsdiffLog, false)
 	if err != nil {
 		t.Fatalf("error creating pack for bundle %s: %s", name, err)
 	}
 	var info *PackInfo
-	info, err = CreatePack(name, fromVersion, toVersion, outputDir, chrootDir, 0)
+	info, err = CreatePack(name, fromVersion, toVersion, outputDir, chrootDir, 0, false)
 	if err != nil {
 		t.Fatalf("error creating pack for bundle %s: %s", name, err)
 	}
@@ -914,19 +914,19 @@ func TestWritePackErrorPaths(t *testing.T) {
 	}()
 	// valid fromManifest
 	fm := Manifest{Name: "test"}
-	if _, err = WritePack(f, &fm, nil, d, d, 1); err == nil {
+	if _, err = WritePack(f, &fm, nil, d, d, 1, false); err == nil {
 		t.Error("WritePack did not return error with nil toManifest")
 	}
 
 	tm := Manifest{}
-	if _, err = WritePack(f, &fm, &tm, d, d, 1); err == nil {
+	if _, err = WritePack(f, &fm, &tm, d, d, 1, false); err == nil {
 		t.Error("WritePack did not return error with unnamed toManifest")
 	}
 
 	tm.Name = "testto"
 	tm.Header.Version = 10
 	fm.Header.Version = 20
-	if _, err = WritePack(f, &fm, &tm, d, d, 1); err == nil {
+	if _, err = WritePack(f, &fm, &tm, d, d, 1, false); err == nil {
 		t.Error("WritePack did not return error with invalid version pairs")
 	}
 
@@ -936,7 +936,7 @@ func TestWritePackErrorPaths(t *testing.T) {
 	}
 
 	tm.Header.Version = 30
-	if _, err = WritePack(f, &fm, &tm, d, d, 1); err == nil {
+	if _, err = WritePack(f, &fm, &tm, d, d, 1, false); err == nil {
 		t.Error("WritePack did not return error with no config present")
 	}
 }
@@ -1023,7 +1023,7 @@ func TestCreatePackErrorPaths(t *testing.T) {
 		_ = os.RemoveAll(d)
 	}()
 
-	if _, err = CreatePack("test", 0, 10, d, d, 1); err == nil {
+	if _, err = CreatePack("test", 0, 10, d, d, 1, false); err == nil {
 		t.Error("CreatePack did not return error with failed manifest parsing")
 	}
 
@@ -1049,7 +1049,7 @@ func TestCreatePackErrorPaths(t *testing.T) {
 		t.Fatalf("could not write test to manifest: %s", err)
 	}
 
-	if _, err := CreatePack("testto", 10, 20, d, d, 1); err == nil {
+	if _, err := CreatePack("testto", 10, 20, d, d, 1, false); err == nil {
 		t.Error("CreatePack did not return error with failed from manifest parsing")
 	}
 }

--- a/swupd/rename_test.go
+++ b/swupd/rename_test.go
@@ -137,7 +137,7 @@ func TestRename(t *testing.T) {
 	for _, tc := range tests {
 		add := filelist(t, sn, tc.add)
 		remove := markdelete(filelist(t, sn, tc.remove))
-		err := renameDetection(&Manifest{}, add, remove, config{})
+		err := renameDetection(&Manifest{}, add, remove, config{}, false)
 		if err != nil {
 			t.Fatalf("Invalid testcase %v, renameDetection failed ", tc)
 		}


### PR DESCRIPTION
if ignore-missing flag is set, deltas are generated for existing files,
ignoring the ones which are not present

Signed-off-by: Ashlesha Atrey <ashlesha.atrey@intel.com>