### PR TITLE
Added test case for generating delta packs with missing files

### DIFF
--- a/bat/tests/build-multiple-delta-packs/Makefile
+++ b/bat/tests/build-multiple-delta-packs/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/build-multiple-delta-packs/description.txt
+++ b/bat/tests/build-multiple-delta-packs/description.txt
@@ -1,0 +1,4 @@
+build-multiple-delta-packs
+=====================
+This test case tests and runs 'mixer build delta-packs' command multiple times for different
+versions with some delta files missing when generating content with 'mixer build all'.

--- a/bat/tests/build-multiple-delta-packs/run.bats
+++ b/bat/tests/build-multiple-delta-packs/run.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  global_setup
+}
+
+@test "build delta-packs after build all for different versions" {
+  current_ver=$(get-current-version)
+  mixer-init-stripped-down "$current_ver" 10
+  mixer-build-all
+  sudo mixer versions update
+  mixer-build-all
+  mixer-build-delta-packs 10
+  sudo rm -rf ./update/image/10/full/usr/lib/os-release
+  sudo mixer versions update
+  mixer-build-all
+  mixer-build-delta-packs 10
+  test $(ls ./update/www/30/delta/ | wc -l) -eq 1
+  test $(ls ./update/www/10/delta/ | wc -l) -eq 0
+  test $(ls ./update/www/20/delta/ | wc -l) -eq 1
+  }
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
Added testcase for generating deltapacks with missing files for
different versions. If file is missing, delta pack for that
bundle should be ignored as delta pack generation is optional.

Signed-off-by: Ashlesha Atrey <ashlesha.atrey@intel.com>