### PR TITLE
Added zstd compression support for fullfile creation

### DIFF
--- a/swupd/fullfiles.go
+++ b/swupd/fullfiles.go
@@ -37,6 +37,7 @@ var fullfileCompressors = []struct {
 	{"external-bzip2", externalCompressFunc("bzip2")},
 	{"external-gzip", externalCompressFunc("gzip")},
 	{"external-xz", externalCompressFunc("xz")},
+	{"external-zstd", externalCompressFunc("zstd")},
 }
 
 // FullfilesInfo holds statistics about a fullfile generation.


### PR DESCRIPTION
Currently, fullfile creation supports gzip, bzip2, and xz compression types.
Adding zstd support, since it tends to produce smaller files in general and decompression speed is excellent.