### PR TITLE
swupd-extract: Use correct purpose on manifest signature verification

### DIFF
--- a/swupd-extract/main.go
+++ b/swupd-extract/main.go
@@ -485,7 +485,7 @@ func verifySignature(content, sig, cert string) error {
 		"-inform", "der",
 		"-content", content,
 		"-CAfile", cert,
-		"-purpose", "crlsign",
+		"-purpose", "any",
 	)
 	var buf bytes.Buffer
 	cmd.Stdout = &buf


### PR DESCRIPTION
We are using purpose any for signature verification on swupd and mixin. Updating
swupd-extract to use the same.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>