### PR TITLE
Extract Rpms using rpm2archive and tar instead of dnf

### DIFF
--- a/builder/bundleset.go
+++ b/builder/bundleset.go
@@ -29,6 +29,9 @@ type bundle struct {
 	AllPackages      map[string]bool
 
 	Files map[string]bool
+
+	/* hidden property, not to be included in file usr/share/clear/allbundles */
+	AllRpmPackages map[string]bool `json:"-"`
 }
 
 type bundleSet map[string]*bundle

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -779,6 +779,8 @@ func init() {
 	externalDeps[buildBundlesCmd] = []string{
 		"rpm",
 		"dnf",
+		"rpm2archive",
+		"tar",
 	}
 	externalDeps[buildUpdateCmd] = []string{
 		"openssl",


### PR DESCRIPTION
Extracting rpm using rpm2archive and tar is faster than dnf and will
improve performance significantly.
Fixes #631 

Signed-off-by: Ashlesha Atrey <ashlesha.atrey@intel.com>