### PR TITLE
Introduces option for upstream bundles url

### DIFF
--- a/bat/tests/config-conversion/configs/1.2_builder.conf
+++ b/bat/tests/config-conversion/configs/1.2_builder.conf
@@ -11,6 +11,7 @@
   CONTENTURL = "<URL where the content will be hosted>"
   VERSIONURL = "<URL where the version of the mix will be hosted>"
   COMPRESSION = ["external-xz"]
+  UPSTREAM_BUNDLES_URL = "https://github.com/clearlinux/clr-bundles/archive/"
 
 [Server]
   DEBUG_INFO_BANNED = "true"

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -238,7 +238,7 @@ func (b *Builder) InitMix(upstreamVer string, mixVer string, allLocal bool, allU
 // the file contents of all bundles.
 func (b *Builder) BuildBundles(template *x509.Certificate, privkey *rsa.PrivateKey, signflag, clean bool, downloadRetries int) error {
 	// Fetch upstream bundle files if needed
-	if err := b.getUpstreamBundles(b.UpstreamVer, true); err != nil {
+	if err := b.getUpstreamBundles(); err != nil {
 		return err
 	}
 

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -196,6 +196,12 @@ func (b *Builder) InitMix(upstreamVer string, mixVer string, allLocal bool, allU
 	if !noDefaults {
 		bundles = []string{"os-core", "os-core-update", "bootloader", "kernel-native"}
 	}
+
+	// Clean up the upstream bundles folder and its contents
+	if err := os.RemoveAll(upstreamBundlesBaseDir); err != nil {
+		return errors.Wrap(err, "Failed to delete upstream-bundles dir.")
+	}
+
 	if err := b.AddBundles(bundles, allLocal, allUpstream, false); err != nil {
 		return err
 	}

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -42,7 +42,7 @@ func TestNewDNFConfOnInit(t *testing.T) {
 	}
 	Offline = true
 
-	err = b.InitMix("10", "10", false, false, true, "https://example.com", false)
+	err = b.InitMix("latest", "10", false, false, true, "https://cdn.download.clearlinux.org", false)
 	if err != nil {
 		t.Errorf("Failed to initialize mix: %s", err)
 	}

--- a/builder/bundle_control_test.go
+++ b/builder/bundle_control_test.go
@@ -49,7 +49,8 @@ func TestGetUpstreamBundlesPath(t *testing.T) {
 	b.Config.Builder.VersionPath = "test"
 	for _, tc := range testCases {
 		t.Run(tc.ver, func(t *testing.T) {
-			actual := b.getUpstreamBundlesPath(tc.ver)
+			b.UpstreamVer = tc.ver
+			actual := b.getUpstreamBundlesPath()
 			if actual != tc.exp {
 				t.Errorf("expected %s on input %s but got %s", tc.exp, tc.ver, actual)
 			}
@@ -98,7 +99,7 @@ func TestGetUpstreamPackagesPath(t *testing.T) {
 func TestGetUpstreamBundles(t *testing.T) {
 	b := New()
 	Offline = true
-	if b.getUpstreamBundles("", false) != nil {
+	if b.getUpstreamBundles() != nil {
 		t.Error("returned error when in offline mode")
 	}
 	// TODO: mock network
@@ -197,7 +198,7 @@ func mustCreateTempBundleDirs(t *testing.T, b *Builder, d string) {
 		t.Fatal(err)
 	}
 
-	if err = os.MkdirAll(b.getUpstreamBundlesPath(b.UpstreamVer), 0755); err != nil {
+	if err = os.MkdirAll(b.getUpstreamBundlesPath(), 0755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -241,7 +242,7 @@ func mustAddBundleToLocalPackages(t *testing.T, b *Builder, name string) {
 
 func mustAddBundleToUpstream(t *testing.T, b *Builder, name string) {
 	t.Helper()
-	mustAddBundleToPath(t, b.getUpstreamBundlesPath(b.UpstreamVer), name)
+	mustAddBundleToPath(t, b.getUpstreamBundlesPath(), name)
 }
 
 func mustAddBundleToUpstreamPackages(t *testing.T, b *Builder, name string) {

--- a/config/config.go
+++ b/config/config.go
@@ -54,10 +54,11 @@ type builderConf struct {
 }
 
 type swupdConf struct {
-	Bundle      string   `required:"false" toml:"BUNDLE"`
-	ContentURL  string   `required:"false" toml:"CONTENTURL"`
-	VersionURL  string   `required:"false" toml:"VERSIONURL"`
-	Compression []string `required:"false" toml:"COMPRESSION"`
+	Bundle             string   `required:"false" toml:"BUNDLE"`
+	ContentURL         string   `required:"false" toml:"CONTENTURL"`
+	VersionURL         string   `required:"false" toml:"VERSIONURL"`
+	Compression        []string `required:"false" toml:"COMPRESSION"`
+	UpstreamBundlesURL string   `required:"false" toml:"UPSTREAM_BUNDLES_URL"`
 }
 
 type serverConf struct {
@@ -99,6 +100,7 @@ func (config *MixConfig) LoadDefaultsForPath(path string) {
 	config.Swupd.ContentURL = "<URL where the content will be hosted>"
 	config.Swupd.VersionURL = "<URL where the version of the mix will be hosted>"
 	config.Swupd.Compression = []string{"external-xz"}
+	config.Swupd.UpstreamBundlesURL = "https://github.com/clearlinux/clr-bundles/archive/"
 
 	// [Server]
 	config.Server.DebugInfoBanned = "true"
@@ -199,7 +201,7 @@ func (config *MixConfig) SetProperty(propertyStr string, value string) error {
 }
 
 // LoadConfig loads a configuration file from a provided path or from local directory
-// is none is provided
+// if none is provided
 func (config *MixConfig) LoadConfig(filename string) error {
 	if err := config.InitConfigPath(filename); err != nil {
 		return err

--- a/mixer/cmd/init.go
+++ b/mixer/cmd/init.go
@@ -10,14 +10,15 @@ import (
 )
 
 type initCmdFlags struct {
-	allLocal    bool
-	allUpstream bool
-	noDefaults  bool
-	clearVer    string
-	mixver      int
-	upstreamURL string
-	git         bool
-	format      string
+	allLocal           bool
+	allUpstream        bool
+	noDefaults         bool
+	clearVer           string
+	mixVer             int
+	upstreamURL        string
+	upstreamBundlesURL string
+	git                bool
+	format             string
 }
 
 var initFlags initCmdFlags
@@ -47,6 +48,14 @@ var initCmd = &cobra.Command{
 			fail(err)
 		}
 
+		// Save upstreamBundlesURL value in the config file
+		if initFlags.upstreamBundlesURL != "" {
+			b.Config.Swupd.UpstreamBundlesURL = initFlags.upstreamBundlesURL
+		}
+		if err := b.Config.SaveConfig(); err != nil {
+			fail(err)
+		}
+
 		b.State.LoadDefaults(b.Config)
 		if initFlags.format != "" {
 			b.State.Mix.Format = initFlags.format
@@ -55,7 +64,7 @@ var initCmd = &cobra.Command{
 			fail(err)
 		}
 
-		err := b.InitMix(initFlags.clearVer, strconv.Itoa(initFlags.mixver), initFlags.allLocal, initFlags.allUpstream, initFlags.noDefaults, initFlags.upstreamURL, initFlags.git)
+		err := b.InitMix(initFlags.clearVer, strconv.Itoa(initFlags.mixVer), initFlags.allLocal, initFlags.allUpstream, initFlags.noDefaults, initFlags.upstreamURL, initFlags.git)
 		if err != nil {
 			fail(err)
 		}
@@ -78,8 +87,9 @@ func init() {
 	initCmd.Flags().BoolVar(&initFlags.noDefaults, "no-default-bundles", false, "Skip adding default bundles to the mix")
 	initCmd.Flags().StringVar(&initFlags.clearVer, "clear-version", "latest", "Upstream version used to compose the mix. It must be either an integer or 'latest'")
 	initCmd.Flags().StringVar(&initFlags.clearVer, "upstream-version", "latest", "Alias to --clear-version")
-	initCmd.Flags().IntVar(&initFlags.mixver, "mix-version", 10, "Supply the Mix version to build")
+	initCmd.Flags().IntVar(&initFlags.mixVer, "mix-version", 10, "Supply the Mix version to build")
 	initCmd.Flags().StringVar(&initFlags.upstreamURL, "upstream-url", "https://cdn.download.clearlinux.org", "Supply an upstream URL to use for mixing")
+	initCmd.Flags().StringVar(&initFlags.upstreamBundlesURL, "upstream-bundles-url", "", "Supply an upstream bundles URL to get bundle definitions")
 	initCmd.Flags().BoolVar(&initFlags.git, "git", false, "Track mixer's internal work dir with git")
 	initCmd.Flags().StringVar(&initFlags.format, "format", "", "Supply the format version for the mix")
 


### PR DESCRIPTION
Currently, the bundle defintions are downloaded from the default
clr-bundles repo https://github.com/clearlinux/clr-bundles/archive/.

The user can now specify a different upstream bundles url using a mixer init flag or mixer
config parameter.

E.g. mixer init --upstream-bundles-url=https://github.com/reaganlo/clr-bundles/archive/
E.g. mixer config set Swupd.UPSTREAM_BUNDLES_URL https://github.com/reaganlo/clr-bundles/archive/

Since there is a tight coupling between the --upstream-version and bundles
repo, the user should ensure that the bundles repo has the same structure as the
clr-bundles repo and the tar.gz files should be named after an upstream
version. i.e. If the mix is based on an upstream-version 31300, the bundles repo
should have a file 31300.tar.gz

Fixes clearlinux#614
Note: Setting this value using `mixer config set` will only update it in builder.conf.
It does not fetch the upstream bundles. A dedicated command for that purpose
will have to be implemented instead.

Also, fixes clearlinux#624
In getUpstreamBundles(),
- Remove the prune param as it is always true. 
- Remove the version param as it is available in the method.

In getUpstreamBundlesPath(),
- Remove the version param as it is available in the method.