### PR TITLE
Mixer documentation

### DIFF
--- a/docs/mixer.1
+++ b/docs/mixer.1
@@ -50,7 +50,10 @@ configure remote RPM repositories.
 The output of \fBmixer\fP is a set of manifests readable by \fBswupd\fP as well as
 all the OS content \fBswupd\fP needs to perform its update operations. The OS
 content includes all the files in an update as well as zero\- and delta\-packs for
-improved update performance. See \fBswupd\fP(1) for more details.
+improved update performance. The content that \fBmixer\fP produces is tied to a
+specific format so that \fBswupd\fP is guaranteed to understand it if the client
+is using the right version of \fBswupd\fP\&. See \fBswupd\fP(1) and \fBos\-format\fP(7)
+for more details.
 .SH OPTIONS
 .sp
 The following options are applicable to most subcommands, and can be
@@ -102,9 +105,8 @@ itself. See \fBmixer.build\fP(1) for more details.
 .INDENT 0.0
 .INDENT 3.5
 Perform various configuration actions on local and upstream bundles. The
-user can add or remove bundles from their mix, edit local and upstream
-bundles, create new bundle definitions, or validate local bundle definition
-files. See \fBmixer.bundle\fP(1) for more details.
+user can add or remove bundles from their mix, create new bundle definitions,
+or validate local bundle definition files. See \fBmixer.bundle\fP(1) for more details.
 .UNINDENT
 .UNINDENT
 .sp
@@ -187,6 +189,8 @@ On success, 0 is returned. A non\-zero return code indicates a failure.
 \fBmixer.versions\fP(1)
 .IP \(bu 2
 \fBswupd\fP(1)
+.IP \(bu 2
+\fBos\-format\fP(7)
 .IP \(bu 2
 \fI\%https://github.com/clearlinux/mixer\-tools\fP
 .IP \(bu 2

--- a/docs/mixer.build.1
+++ b/docs/mixer.build.1
@@ -62,6 +62,11 @@ flag defaults the number of workers to the number of CPUs on the system.
 Number of parallel workers when creating fullfiles, passing 0 or omitting this
 flag defaults the number of workers to the number of CPUs on the system.
 .IP \(bu 2
+\fB\-\-skip\-format\-check\fP
+.sp
+Skip check for compatible upstream format when building on top of a new
+upstream.
+.IP \(bu 2
 \fB\-h, \-\-help\fP
 .sp
 Display \fBbuild\fP help information and exit.
@@ -183,7 +188,7 @@ Generate packs from the specified \fIversion\fP\&.
 .IP \(bu 2
 \fB\-h, \-\-help\fP
 .sp
-Display \fBbuild bundles\fP help information and exit.
+Display \fBbuild delta\-packs\fP help information and exit.
 .IP \(bu 2
 \fB\-\-previous\-versions {number}\fP
 .sp
@@ -221,7 +226,7 @@ Generate packs from the specified \fIversion\fP\&.
 .IP \(bu 2
 \fB\-h, \-\-help\fP
 .sp
-Display \fBbuild bundles\fP help information and exit.
+Display \fBbuild delta\-manifests\fP help information and exit.
 .IP \(bu 2
 \fB\-\-previous\-versions {number}\fP
 .sp
@@ -253,7 +258,7 @@ Supply the format \fInumber\fP used for the mix.
 .IP \(bu 2
 \fB\-h, \-\-help\fP
 .sp
-Display \fBbuild bundles\fP help information and exit.
+Display \fBbuild image\fP help information and exit.
 .IP \(bu 2
 \fB\-\-template {path}\fP
 .sp
@@ -288,7 +293,7 @@ Supply the format \fInumber\fP used for the mix.
 .IP \(bu 2
 \fB\-h, \-\-help\fP
 .sp
-Display \fBbuild bundles\fP help information and exit.
+Display \fBbuild update\fP help information and exit.
 .IP \(bu 2
 \fB\-\-increment\fP
 .sp
@@ -332,19 +337,19 @@ reported as errors. When no errors occur, package update statistics are displaye
 .IP \(bu 2
 \fB\-\-from {version}\fP
 .sp
-Compare manifests from a specific version\&.
+Compare manifests \fBfrom\fP a specific version
 .IP \(bu 2
 \fB\-\-to {version}\fP
 .sp
-Compare manifests to a specific version\&.
+Compare manifests \fBto\fP a specific version
 .IP \(bu 2
-\fB\-\-from-repo-url {repo}={URL}\fP
+\fB\-\-from\-repo\-url {repo}={URL}\fP
 .sp
-Overrides the baseurl value for the provided repo in the DNF config file for the from version\&.
+Overrides the baseurl value for the provided repo in the DNF config file for the \fBfrom\fP version
 .IP \(bu 2
-\fB\-\-to-repo-url {repo}={URL}\fP
+\fB\-\-to\-repo\-url {repo}={URL}\fP
 .sp
-Overrides the baseurl value for the provided repo in the DNF config file for the to version\&.
+Overrides the baseurl value for the provided repo in the DNF config file for the \fBto\fP version
 .IP \(bu 2
 \fB\-h, \-\-help\fP
 .sp

--- a/docs/mixer.build.1.rst
+++ b/docs/mixer.build.1.rst
@@ -152,7 +152,7 @@ SUBCOMMANDS
 
     - ``-h, --help``
 
-      Display ``build bundles`` help information and exit.
+      Display ``build delta-packs`` help information and exit.
 
     - ``--previous-versions {number}``
 
@@ -185,7 +185,7 @@ SUBCOMMANDS
 
     - ``-h, --help``
 
-      Display ``build bundles`` help information and exit.
+      Display ``build delta-manifests`` help information and exit.
 
     - ``--previous-versions {number}``
 
@@ -212,7 +212,7 @@ SUBCOMMANDS
 
     - ``-h, --help``
 
-      Display ``build bundles`` help information and exit.
+      Display ``build image`` help information and exit.
 
     - ``--template {path}``
 
@@ -240,7 +240,7 @@ SUBCOMMANDS
 
     - ``-h, --help``
 
-      Display ``build bundles`` help information and exit.
+      Display ``build update`` help information and exit.
 
     - ``--increment``
 

--- a/docs/mixer.bundle.1
+++ b/docs/mixer.bundle.1
@@ -76,15 +76,14 @@ Display \fBbundle add\fP help information and exit.
 .UNINDENT
 .UNINDENT
 .sp
-\fBedit\fP
+\fBcreate\fP
 .INDENT 0.0
 .INDENT 3.5
-Creates local and upstream bundle definition files.
+Create new bundles or copy existing bundles.
 This command will locate the bundle by first looking in local\-bundles,
-and then in upstream\-bundles. If the bundle is only found upstream, the
-bundle file will be copied to your local\-bundles directory.
-If the bundle is not found anywhere, a blank template is created
-with the correct name.
+and then in upstream\-bundles. If the bundle is only found upstream,
+the bundle file will be copied to your local\-bundles directory. If the bundle is
+not found anywhere, a blank template will be created with the correct name.
 .sp
 Passing \(aq\-\-add\(aq will also add the bundle(s) to your mix. Please note that
 bundles are added after all bundles are created, and thus will not be added
@@ -113,11 +112,6 @@ version control.
 \fB\-h, \-\-help\fP
 .sp
 Display \fBbundle create\fP help information and exit.
-.IP \(bu 2
-\fB\-\-suppress\-editor\fP
-.sp
-Suppress launching editor and only copy to local\-bundles or create a
-template for the bundle.
 .UNINDENT
 .UNINDENT
 .UNINDENT

--- a/docs/mixer.init.1
+++ b/docs/mixer.init.1
@@ -53,7 +53,7 @@ Initialize the mix with all upstream bundles automatically included.
 .IP \(bu 2
 \fB\-\-clear\-version {version}\fP
 .sp
-Supply the Clear version to compose the mix from (default is "latest")
+Upstream version used to compose the mix. It must be either an integer or \(aqlatest\(aq (default "latest")
 .IP \(bu 2
 \fB\-\-config {path}\fP
 .sp

--- a/docs/mixer.versions.1
+++ b/docs/mixer.versions.1
@@ -86,6 +86,10 @@ Set a specific mix \fIversion\fP\&.
 .sp
 Set a specific next upstream version (either version number or the default
 "latest" string).
+.IP \(bu 2
+\fB\-\-skip\-format\-check\fP
+.sp
+Skip check for compatible upstream format when changing upstream version.
 .sp
 This command will not update to an upstream version of a different format
 ("format bumps"). At the moment this needs to be handled manually.


### PR DESCRIPTION
Fix a few inaccuracies in `mixer.build` manual.

The second commit in this PR is the result of running `for i in `ls *.rst`; do rst2man $i > ${i%.rst}; done`, I wasn't sure if I was supposed to do it or not. Let me know if this needs to be reverted.