### PR TITLE
Iterative/Delta: Don't generate Iterative and Delta manifests anymore

### DIFF
--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -235,6 +235,10 @@ func addUnchangedManifests(appendTo *Manifest, appendFrom *Manifest, bundles []s
 
 		bundleName := f.Name
 		if f.Type == TypeIManifest {
+			if !shouldAddIManifestForFormat(appendTo) {
+				continue
+			}
+
 			// Don't add iterative manifests across minversion updates
 			if f.Version < appendTo.Header.MinVersion {
 				continue

--- a/swupd/format_switch.go
+++ b/swupd/format_switch.go
@@ -93,9 +93,9 @@ func setManifestStatusForFormat(format uint, bundleStatus string, statusFlag *St
 	}
 }
 
-// Delta manifests were introduced in format 26 and should not be created in older formats
+// Delta manifests were introduced in format 26 and removed in format 29
 func writeDeltaManifestForFormat(tw *tar.Writer, outputDir string, dManifest *Manifest, toVersion uint32) error {
-	if dManifest == nil || dManifest.Header.Format <= 25 {
+	if dManifest == nil || dManifest.Header.Format <= 25 || dManifest.Header.Format >= 29 {
 		return nil
 	}
 

--- a/swupd/format_switch.go
+++ b/swupd/format_switch.go
@@ -102,9 +102,18 @@ func writeDeltaManifestForFormat(tw *tar.Writer, outputDir string, dManifest *Ma
 	return writeDeltaManifest(tw, outputDir, dManifest, toVersion)
 }
 
+// Iterative manifests is being deprecated in format 29
+func shouldAddIManifestForFormat(manifest *Manifest) bool {
+	if manifest == nil || manifest.Header.Format >= 29 {
+		return false
+	}
+
+    return true
+}
+
 // Iterative manifests were introduced in format 26 and will cause issues with older formats
 func (m *Manifest) writeIterativeManifestsForFormat(newManifests []*Manifest, out string) ([]*Manifest, error) {
-	if m.Header.Format <= 25 {
+	if m.Header.Format <= 25 || m.Header.Format >= 29 {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Stop generating delta/iterative manifests is format 29.

I wasn't sure on how to approach tests, so I didn't change anything yet:
 - Should I remove all tests that check for Iterative/Delta manifests?
or
 - Should I run them if format < 29?

And do I need any tests for the transition?