### PR TITLE
Remove redundant getUpstreamBundles() call

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -200,11 +200,6 @@ func (b *Builder) InitMix(upstreamVer string, mixVer string, allLocal bool, allU
 		return err
 	}
 
-	// Get upstream bundles
-	if err := b.getUpstreamBundles(upstreamVer, true); err != nil {
-		return err
-	}
-
 	if git {
 		if err := ioutil.WriteFile(".gitignore", []byte(mixDirGitIgnore), 0644); err != nil {
 			return errors.Wrap(err, "Failed to create .gitignore file")


### PR DESCRIPTION
InitMix() calls AddBundles() and getUpstreamBundles().
AddBundles() already calls getUpstreamBundles().
So remove the redundant function call in InitMix().

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>