### PR TITLE
Manifests: Remove Iterative and Delta Manifests

### DIFF
--- a/builder/build_validate.go
+++ b/builder/build_validate.go
@@ -217,7 +217,7 @@ func (b *Builder) mcaManInfo(version int) ([]*swupd.Manifest, error) {
 	// Get bundle info for each MoM entry
 	for _, f := range mom.Files {
 		// os-core-update-index and iterative manifests are not checked by MCA
-		if f.Name == "os-core-update-index" || f.Type == swupd.TypeIManifest {
+		if f.Name == "os-core-update-index" {
 			continue
 		}
 

--- a/builder/update.go
+++ b/builder/update.go
@@ -173,9 +173,6 @@ func (b *Builder) buildUpdateContent(params UpdateParameters, timer *stopWatch) 
 		timer.Start("CREATE ZERO PACKS")
 		bundleDir := filepath.Join(b.Config.Builder.ServerStateDir, "image")
 		for _, bundle := range mom.Files {
-			if bundle.Type != swupd.TypeManifest {
-				continue
-			}
 			// TODO: Evaluate if it's worth using goroutines.
 			name := bundle.Name
 			version := bundle.Version

--- a/swupd-inspector/get.go
+++ b/swupd-inspector/get.go
@@ -109,9 +109,6 @@ func runGet(cacheDir, url, arg string) {
 func visitAllFiles(state *client.State, mom *swupd.Manifest, visitFunc func(bundle, file *swupd.File) bool) error {
 	var stop bool
 	for _, bundleF := range mom.Files {
-		if bundleF.Type != swupd.TypeManifest {
-			continue
-		}
 		bundle, err := state.GetBundleManifest(fmt.Sprint(bundleF.Version), bundleF.Name, "")
 		if err != nil {
 			return err

--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -81,7 +81,6 @@ func initBundles(ui UpdateInfo, c config, numWorkers int) ([]*Manifest, error) {
 					TimeStamp: ui.timeStamp,
 				},
 				Name: bundleName,
-				Type: ManifestBundle,
 			}
 
 			if bundleName == "full" {
@@ -410,7 +409,6 @@ func CreateManifests(version, previous, minVersion uint32, format uint, statedir
 			Previous:   previous,
 			TimeStamp:  timeStamp,
 		},
-		Type: ManifestMoM,
 	}
 	// if min-version wasn't explicitly set we need to carry the header forward
 	// from the old MoM

--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -448,7 +448,7 @@ func CreateManifests(version, previous, minVersion uint32, format uint, statedir
 	}
 
 	// Create Iterative manifests if there isn't a format bump or minVersion
-	if format == oldFormat && minVersion != version {
+	if format == oldFormat {
 		var iManifests []*Manifest
 		iManifests, err = newMoM.writeIterativeManifests(newManifests, verOutput)
 		if err != nil {

--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -457,7 +457,7 @@ func CreateManifests(version, previous, minVersion uint32, format uint, statedir
 	// Create Iterative manifests if there isn't a format bump or minVersion
 	if format == oldFormat && minVersion != version {
 		var iManifests []*Manifest
-		iManifests, err = newMoM.writeIterativeManifestsForFormat(newManifests, verOutput)
+		iManifests, err = newMoM.writeIterativeManifests(newManifests, verOutput)
 		if err != nil {
 			return nil, err
 		}

--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -235,11 +235,6 @@ func addUnchangedManifests(appendTo *Manifest, appendFrom *Manifest, bundles []s
 
 		bundleName := f.Name
 		if f.Type == TypeIManifest {
-			// Don't add iterative manifests across minversion updates
-			if f.Version < appendTo.Header.MinVersion {
-				continue
-			}
-
 			// Only the most recent iterative manifest for a bundle is valid,
 			// so omit stale iterative manifests from the to MoM
 			if f.findIManifestInSlice(appendTo.Files) != nil {

--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -76,27 +76,6 @@ func TestCreateManifestsBasic(t *testing.T) {
 	checkManifestContains(t, ts.Dir, "20", "test-bundle", expSubs...)
 	checkManifestNotContains(t, ts.Dir, "20", "test-bundle", "10\t/foo")
 	checkManifestNotContains(t, ts.Dir, "20", "MoM", "20\tManifest.full")
-
-	expSubs = []string{
-		"MANIFEST\t1",
-		"version:\t20",
-		"previous:\t10",
-		"filecount:\t1",
-		"20\t/usr/lib/os-release",
-	}
-	checkManifestContains(t, ts.Dir, "20", "os-core.I.10", expSubs...)
-	checkManifestFileCount(ts, "20", "os-core.I.10", 1, 0)
-
-	expSubs = []string{
-		"MANIFEST\t1",
-		"version:\t20",
-		"previous:\t10",
-		"filecount:\t1",
-		"includes:\tos-core",
-		"20\t/foo",
-	}
-	checkManifestContains(t, ts.Dir, "20", "test-bundle.I.10", expSubs...)
-	checkManifestFileCount(ts, "20", "test-bundle.I.10", 1, 0)
 }
 
 func TestCreateManifestsDeleteNoVerBump(t *testing.T) {
@@ -113,16 +92,6 @@ func TestCreateManifestsDeleteNoVerBump(t *testing.T) {
 	ts.createManifests(20)
 
 	fileInManifest(t, ts.parseManifest(20, "full"), 10, "/foo")
-
-	expSubs := []string{
-		"MANIFEST\t1",
-		"version:\t20",
-		"previous:\t10",
-		"filecount:\t1",
-		"20\t/foo",
-	}
-	checkManifestContains(t, ts.Dir, "20", "test-bundle2.I.10", expSubs...)
-	checkManifestFileCount(ts, "20", "test-bundle2.I.10", 1, 1)
 }
 
 func TestCreateManifestIllegalChar(t *testing.T) {
@@ -199,19 +168,6 @@ func TestCreateManifestGhosted(t *testing.T) {
 	if f3.Status != StatusGhosted {
 		t.Errorf("%s present in 20 full but expected to be ghosted", f3.Name)
 	}
-
-	manifestFile := filepath.Join(ts.Dir, "www/30/Manifest.test-bundle.I.20")
-	m30I, err := ParseManifestFile(manifestFile)
-	if err != nil {
-		t.Errorf("Couldn't parse Iterative manifest with ghost file: %s", err)
-	}
-	fileNotInManifest(t, m30I, "/usr/lib/kernel/bar")
-	f3I := fileInManifest(t, m30I, 30, "/usr/lib/kernel/baz")
-	if f3I.Status != StatusGhosted {
-		t.Errorf("%s present in 20 full but expected to be ghosted", f3.Name)
-	}
-	checkManifestFileCount(ts, "30", "test-bundle.I.20", 1, 0)
-
 }
 
 func TestCreateManifestIncludesDeduplicate(t *testing.T) {
@@ -284,7 +240,6 @@ func TestCreateManifestsMoM(t *testing.T) {
 		"10\ttest-bundle4",
 	}
 	checkManifestContains(t, ts.Dir, "10", "MoM", subs...)
-	checkManifestFileCount(ts, "10", "MoM", 6, 0)
 
 	ts.addFile(20, "test-bundle1", "/foo", "foo")
 	ts.addFile(20, "test-bundle2", "/bar", "bar")
@@ -294,17 +249,11 @@ func TestCreateManifestsMoM(t *testing.T) {
 	// no update to test-bundle4
 	subs = []string{
 		"20\ttest-bundle1",
-		"20\ttest-bundle1.I.10",
 		"20\ttest-bundle2",
-		"20\ttest-bundle2.I.10",
 		"20\ttest-bundle3",
-		"20\ttest-bundle3.I.10",
 		"10\ttest-bundle4",
-		"20\tos-core-update-index",
-		"20\tos-core-update-index.I.10",
 	}
 	checkManifestContains(t, ts.Dir, "20", "MoM", subs...)
-	checkManifestFileCount(ts, "20", "MoM", 11, 0)
 
 	ts.addFile(30, "test-bundle1", "/foo", "foo20")
 	ts.addFile(30, "test-bundle2", "/bar", "bar20")
@@ -314,17 +263,11 @@ func TestCreateManifestsMoM(t *testing.T) {
 	// again no update to test-bundle4
 	subs = []string{
 		"30\ttest-bundle1",
-		"30\ttest-bundle1.I.20",
 		"30\ttest-bundle2",
-		"30\ttest-bundle2.I.20",
 		"30\ttest-bundle3",
-		"30\ttest-bundle3.I.20",
 		"10\ttest-bundle4",
-		"30\tos-core-update-index",
-		"30\tos-core-update-index.I.20",
 	}
 	checkManifestContains(t, ts.Dir, "30", "MoM", subs...)
-	checkManifestFileCount(ts, "30", "MoM", 11, 0)
 
 	ts.addFile(40, "test-bundle1", "/foo", "foo30")
 	ts.addFile(40, "test-bundle2", "/bar", "bar20")
@@ -333,38 +276,11 @@ func TestCreateManifestsMoM(t *testing.T) {
 	// update only to test-bundle1, test-bundle3 has another deleted file now too
 	subs = []string{
 		"40\ttest-bundle1",
-		"40\ttest-bundle1.I.30",
-		"30\ttest-bundle2",
-		"30\ttest-bundle2.I.20",
 		"40\ttest-bundle3",
-		"40\ttest-bundle3.I.30",
+		"30\ttest-bundle2",
 		"10\ttest-bundle4",
-		"40\tos-core-update-index",
-		"40\tos-core-update-index.I.30",
 	}
 	checkManifestContains(t, ts.Dir, "40", "MoM", subs...)
-	checkManifestFileCount(ts, "40", "MoM", 11, 0)
-
-	ts.addFile(50, "test-bundle1", "/foo", "foo30")
-	ts.addFile(50, "test-bundle2", "/bar", "bar50")
-	ts.addFile(50, "test-bundle4", "/bar4", "bar50")
-	ts.createManifests(50)
-
-	// update only to test-bundle2 and test-bundle4
-	subs = []string{
-		"40\ttest-bundle1",
-		"40\ttest-bundle1.I.30",
-		"50\ttest-bundle2",
-		"50\ttest-bundle2.I.30",
-		"40\ttest-bundle3",
-		"40\ttest-bundle3.I.30",
-		"50\ttest-bundle4",
-		"50\ttest-bundle4.I.10",
-		"50\tos-core-update-index",
-		"50\tos-core-update-index.I.40",
-	}
-	checkManifestContains(t, ts.Dir, "50", "MoM", subs...)
-	checkManifestFileCount(ts, "50", "MoM", 12, 0)
 }
 
 func TestCreateManifestMaximizeFull(t *testing.T) {
@@ -395,29 +311,8 @@ func TestCreateManifestResurrect(t *testing.T) {
 	ts.addFile(20, "test-bundle", "/foo1", "foo1")
 	ts.createManifests(20)
 
-	expSubs := []string{
-		"MANIFEST\t1",
-		"version:\t20",
-		"previous:\t10",
-		"filecount:\t1",
-		AllZeroHash + "\t20\t/foo",
-	}
-	checkManifestContains(t, ts.Dir, "20", "test-bundle.I.10", expSubs...)
-	checkManifestFileCount(ts, "20", "test-bundle.I.10", 1, 1)
-
 	ts.addFile(30, "test-bundle", "/foo", "foo1")
 	ts.createManifests(30)
-
-	expSubs = []string{
-		"MANIFEST\t1",
-		"version:\t30",
-		"previous:\t20",
-		"filecount:\t2",
-		"30\t/foo",
-		AllZeroHash + "\t30\t/foo1",
-	}
-	checkManifestContains(t, ts.Dir, "30", "test-bundle.I.20", expSubs...)
-	checkManifestFileCount(ts, "30", "test-bundle.I.20", 2, 1)
 
 	checkManifestContains(t, ts.Dir, "30", "test-bundle", AllZeroHash+"\t30\t/foo1\n")
 	fileInManifest(t, ts.parseManifest(30, "test-bundle"), 30, "/foo")

--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -498,61 +498,6 @@ func TestCreateManifestsMinVersion(t *testing.T) {
 	ts.checkExists("www/30/Manifest.test-bundle.I.20")
 }
 
-func TestIManifestMinVersionForwarding(t *testing.T) {
-	ts := newTestSwupd(t, "iManifestMinVersionForwarding")
-	defer ts.cleanup()
-	ts.Format = 26
-
-	// Create test-bundle1 iterative manifest at v20
-	ts.Bundles = []string{"test-bundle1"}
-	ts.createManifests(10)
-	ts.addFile(20, "test-bundle1", "/bar", "bar")
-	ts.createManifests(20)
-	ts.checkExists("www/20/Manifest.test-bundle1.I.10")
-	ts.checkContains("www/20/Manifest.MoM", "test-bundle1.I.10")
-
-	// Create test-bundle2 iterative manifest at v40 with all files >= new minversion
-	ts.Bundles = append(ts.Bundles, "test-bundle2")
-	ts.addFile(30, "test-bundle1", "/bar", "bar")
-	ts.createManifests(30)
-	ts.addFile(40, "test-bundle1", "/bar", "bar")
-	ts.addFile(40, "test-bundle2", "/bar", "bar")
-	ts.createManifests(40)
-	ts.checkExists("www/40/Manifest.test-bundle2.I.30")
-	ts.checkContains("www/40/Manifest.MoM", "test-bundle2.I.30")
-	ts.checkContains("www/40/Manifest.MoM", "test-bundle1.I.10")
-
-	// Minversion != latest
-	ts.MinVersion = 30
-	ts.addFile(50, "test-bundle1", "/bar", "bar")
-	ts.addFile(50, "test-bundle2", "/bar", "bar")
-	ts.createManifests(50)
-
-	// Verify that iterative manifests affected by the minversion (test-bundle1.I.10)
-	// are replaced and iterative manifests unaffected by the minversion (test-bundle2.I.30)
-	// are forwarded into the new MoM.
-	ts.checkNotContains("www/50/Manifest.MoM", "test-bundle1.I.10")
-	ts.checkContains("www/50/Manifest.MoM", "test-bundle1.I.20")
-	ts.checkContains("www/50/Manifest.MoM", "test-bundle2.I.30")
-	ts.checkExists("www/50/Manifest.test-bundle1.I.20")
-	ts.checkNotExists("www/50/Manifest.test-bundle2.I.30")
-
-	// Minversion == latest
-	ts.MinVersion = 60
-	ts.addFile(60, "test-bundle1", "/bar", "bar")
-	ts.addFile(60, "test-bundle2", "/bar", "bar")
-	ts.createManifests(60)
-
-	// When the minversion == latest, iterative manifests should not be generated or
-	// forwarded to the new MoM.
-	ts.checkNotContains("www/60/Manifest.MoM", "test-bundle1.I.20")
-	ts.checkNotContains("www/60/Manifest.MoM", "test-bundle1.I.50")
-	ts.checkNotContains("www/60/Manifest.MoM", "test-bundle2.I.30")
-	ts.checkNotContains("www/60/Manifest.MoM", "test-bundle2.I.40")
-	ts.checkNotExists("www/60/Manifest.test-bundle1.I.50")
-	ts.checkNotExists("www/60/Manifest.test-bundle2.I.40")
-}
-
 func TestCreateManifestsMVDeletes(t *testing.T) {
 	ts := newTestSwupd(t, "minVersionDeletes")
 	defer ts.cleanup()

--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -39,14 +39,11 @@ func TestCreateManifestsBasic(t *testing.T) {
 
 	ts.Bundles = []string{"test-bundle"}
 
-	// Iterative manifests are not supported in formats < 26
-	ts.Format = 26
-
 	ts.addFile(10, "test-bundle", "/foo", "content")
 	ts.createManifests(10)
 
 	expSubs := []string{
-		"MANIFEST\t26",
+		"MANIFEST\t1",
 		"version:\t10",
 		"previous:\t0",
 		"filecount:\t2",
@@ -69,7 +66,7 @@ func TestCreateManifestsBasic(t *testing.T) {
 	ts.createManifests(20)
 
 	expSubs = []string{
-		"MANIFEST\t26",
+		"MANIFEST\t1",
 		"version:\t20",
 		"previous:\t10",
 		"filecount:\t2",
@@ -81,7 +78,7 @@ func TestCreateManifestsBasic(t *testing.T) {
 	checkManifestNotContains(t, ts.Dir, "20", "MoM", "20\tManifest.full")
 
 	expSubs = []string{
-		"MANIFEST\t26",
+		"MANIFEST\t1",
 		"version:\t20",
 		"previous:\t10",
 		"filecount:\t1",
@@ -91,7 +88,7 @@ func TestCreateManifestsBasic(t *testing.T) {
 	checkManifestFileCount(ts, "20", "os-core.I.10", 1, 0)
 
 	expSubs = []string{
-		"MANIFEST\t26",
+		"MANIFEST\t1",
 		"version:\t20",
 		"previous:\t10",
 		"filecount:\t1",
@@ -106,10 +103,6 @@ func TestCreateManifestsDeleteNoVerBump(t *testing.T) {
 	ts := newTestSwupd(t, "delete-no-version-bump")
 	defer ts.cleanup()
 	ts.Bundles = []string{"test-bundle1", "test-bundle2"}
-
-	// Iterative manifests are not supported in formats < 26
-	ts.Format = 26
-
 	ts.addFile(10, "test-bundle1", "/foo", "content")
 	ts.addFile(10, "test-bundle2", "/foo", "content")
 	ts.createManifests(10)
@@ -122,7 +115,7 @@ func TestCreateManifestsDeleteNoVerBump(t *testing.T) {
 	fileInManifest(t, ts.parseManifest(20, "full"), 10, "/foo")
 
 	expSubs := []string{
-		"MANIFEST\t26",
+		"MANIFEST\t1",
 		"version:\t20",
 		"previous:\t10",
 		"filecount:\t1",
@@ -172,10 +165,6 @@ func TestCreateManifestGhosted(t *testing.T) {
 	ts := newTestSwupd(t, "ghosted")
 	defer ts.cleanup()
 	ts.Bundles = []string{"test-bundle"}
-
-	// Iterative manifests are not supported in formats < 26
-	ts.Format = 26
-
 	ts.addFile(10, "test-bundle", "/usr/lib/kernel/bar", "bar")
 	ts.createManifests(10)
 
@@ -285,10 +274,6 @@ func TestCreateManifestsMoM(t *testing.T) {
 	ts := newTestSwupd(t, "MoM")
 	defer ts.cleanup()
 	ts.Bundles = []string{"test-bundle1", "test-bundle2", "test-bundle3", "test-bundle4"}
-
-	// Iterative manifests are not supported in formats < 26
-	ts.Format = 26
-
 	ts.createManifests(10)
 
 	// initial update, all manifests should be present at this version
@@ -403,10 +388,6 @@ func TestCreateManifestResurrect(t *testing.T) {
 	ts := newTestSwupd(t, "resurrect-file")
 	defer ts.cleanup()
 	ts.Bundles = []string{"test-bundle"}
-
-	// Iterative manifests are not supported in formats < 26
-	ts.Format = 26
-
 	ts.addFile(10, "test-bundle", "/foo", "foo")
 	ts.addFile(10, "test-bundle", "/foo1", "foo1")
 	ts.createManifests(10)
@@ -415,7 +396,7 @@ func TestCreateManifestResurrect(t *testing.T) {
 	ts.createManifests(20)
 
 	expSubs := []string{
-		"MANIFEST\t26",
+		"MANIFEST\t1",
 		"version:\t20",
 		"previous:\t10",
 		"filecount:\t1",
@@ -428,7 +409,7 @@ func TestCreateManifestResurrect(t *testing.T) {
 	ts.createManifests(30)
 
 	expSubs = []string{
-		"MANIFEST\t26",
+		"MANIFEST\t1",
 		"version:\t30",
 		"previous:\t20",
 		"filecount:\t2",

--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -477,12 +477,6 @@ func TestCreateManifestsMinVersion(t *testing.T) {
 	// we can even check that there are NO files left at version 10
 	ts.checkNotContains("www/20/Manifest.full", "\t10\t")
 
-	// we shouldn't create Iteraive Manifests in a minversion
-	ts.checkNotContains("www/20/Manifest.MoM", "os-core.I.10")
-	ts.checkNotContains("www/20/Manifest.MoM", "test-bundle.I.10")
-	ts.checkNotExists("www/20/Manifest.os-core.I.10")
-	ts.checkNotExists("www/20/Manifest.test-bundle.I.10")
-
 	ts.addFile(30, "test-bundle", "/foo", "changed")
 	// make sure we carry the minversion forward in the MoM if MinVersion isn't set
 	ts.MinVersion = 0
@@ -491,11 +485,6 @@ func TestCreateManifestsMinVersion(t *testing.T) {
 	ts.checkContains("www/30/Manifest.MoM", "minversion:\t20\n")
 	// make sure we aren't writing "minversion" to anything other than the MoM
 	ts.checkNotContains("www/30/Manifest.test-bundle", "minversion")
-	// make sure we created iterative Manifests for this version
-	ts.checkContains("www/30/Manifest.MoM", "os-core.I.20")
-	ts.checkContains("www/30/Manifest.MoM", "test-bundle.I.20")
-	ts.checkExists("www/30/Manifest.os-core.I.20")
-	ts.checkExists("www/30/Manifest.test-bundle.I.20")
 }
 
 func TestCreateManifestsMVDeletes(t *testing.T) {

--- a/swupd/delta_test.go
+++ b/swupd/delta_test.go
@@ -136,22 +136,12 @@ func TestNoDeltasForTypeChangesOrDereferencedSymlinks(t *testing.T) {
 		ts.checkExists(fmt.Sprintf("www/20/delta/10-20-%s-%s", hashA, hashB))
 	}
 
-	// Check Delta Manifest
-	{
-		m := checkDeltaManifest(ts, 10, 20, "os-core", 3)
-		fileInManifest(t, m, 10, "/file1")
-		fileInManifest(t, m, 10, "/file2")
-		fileInManifest(t, m, 10, "/file3")
-	}
-
 	// Since pack has 3 deltas, no other delta is there. Double check other deltas
 	// were not created in the file system.
 	fis, err := ioutil.ReadDir(ts.path("www/20/delta"))
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// Check if all deltas and the delta manifest were created
 	if uint64(len(fis)) != info.DeltaCount {
 		t.Fatalf("found %d files in %s but expected %d", len(fis), ts.path("www/20/delta"), info.DeltaCount)
 	}

--- a/swupd/files.go
+++ b/swupd/files.go
@@ -30,6 +30,7 @@ const (
 	TypeDirectory
 	TypeLink
 	TypeManifest
+	// TODO: IManifests are deprecated. Remove them on format 30
 	TypeIManifest
 )
 

--- a/swupd/files.go
+++ b/swupd/files.go
@@ -17,7 +17,6 @@ package swupd
 import (
 	"fmt"
 	"os"
-	"strings"
 )
 
 // TypeFlag describes the file type of a manifest entry.
@@ -269,18 +268,6 @@ func (f *File) GetFlagString() (string, error) {
 func (f *File) findFileNameInSlice(fs []*File) *File {
 	for _, file := range fs {
 		if file.Name == f.Name {
-			return file
-		}
-	}
-
-	return nil
-}
-
-func (f *File) findIManifestInSlice(fs []*File) *File {
-	// get bundle name without IManifest version
-	prefix := strings.SplitAfter(f.Name, ".I.")[0]
-	for _, file := range fs {
-		if strings.HasPrefix(file.Name, prefix) {
 			return file
 		}
 	}

--- a/swupd/format_switch.go
+++ b/swupd/format_switch.go
@@ -15,7 +15,6 @@
 package swupd
 
 import (
-	"archive/tar"
 	"text/template"
 )
 
@@ -91,15 +90,6 @@ func setManifestStatusForFormat(format uint, bundleStatus string, statusFlag *St
 			*statusFlag = StatusExperimental
 		}
 	}
-}
-
-// Delta manifests were introduced in format 26 and should not be created in older formats
-func writeDeltaManifestForFormat(tw *tar.Writer, outputDir string, dManifest *Manifest, toVersion uint32) error {
-	if dManifest == nil || dManifest.Header.Format <= 25 {
-		return nil
-	}
-
-	return writeDeltaManifest(tw, outputDir, dManifest, toVersion)
 }
 
 // Iterative manifests were introduced in format 26 and will cause issues with older formats

--- a/swupd/format_switch.go
+++ b/swupd/format_switch.go
@@ -92,15 +92,6 @@ func setManifestStatusForFormat(format uint, bundleStatus string, statusFlag *St
 	}
 }
 
-// Iterative manifests were introduced in format 26 and will cause issues with older formats
-func (m *Manifest) writeIterativeManifestsForFormat(newManifests []*Manifest, out string) ([]*Manifest, error) {
-	if m.Header.Format <= 25 {
-		return nil, nil
-	}
-
-	return m.writeIterativeManifests(newManifests, out)
-}
-
 // manifestTemplateForFormat returns the *template.Template for creating
 // manifests for the provided format f
 func manifestTemplateForFormat(f uint) (t *template.Template) {

--- a/swupd/format_switch_test.go
+++ b/swupd/format_switch_test.go
@@ -71,42 +71,6 @@ func TestFormats25to26Minversion(t *testing.T) {
 	checkManifestContains(t, ts.Dir, "30", "MoM", "minversion:\t20")
 }
 
-// Iterative manifest support added in format 26
-func TestFormats25to26IterativeManifest(t *testing.T) {
-	ts := newTestSwupd(t, "format25to26iterativeManifest")
-	defer ts.cleanup()
-
-	ts.Bundles = []string{"test-bundle"}
-
-	// Format 25 should not have iterative manifest support
-	ts.Format = 25
-	ts.addFile(10, "test-bundle", "/foo", "content")
-	ts.createManifests(10)
-
-	ts.addFile(20, "test-bundle", "/foo", "new content")
-	ts.createManifests(20)
-	checkManifestContains(t, ts.Dir, "20", "MoM", "MANIFEST\t25")
-
-	// Iterative manifests should not have entries in the MoM or be generated
-	checkManifestNotContains(t, ts.Dir, "20", "MoM", "I...\t")
-	ts.checkNotExists("www/20/Manifest.test-bundle.I.10")
-	ts.checkNotExists("www/20/Manifest.os-core.I.10")
-
-	// Update to format26
-	ts.Format = 26
-	ts.addFile(30, "test-bundle", "/foo", "even newer content")
-	ts.createManifests(30)
-
-	ts.addFile(40, "test-bundle", "/foo", "more new content")
-	ts.createManifests(40)
-	checkManifestContains(t, ts.Dir, "40", "MoM", "MANIFEST\t26")
-
-	// Updates in format 26 should support iterative manifests
-	checkManifestContains(t, ts.Dir, "40", "MoM", "\ttest-bundle.I.30", "\tos-core.I.30")
-	ts.checkExists("www/40/Manifest.test-bundle.I.30")
-	ts.checkExists("www/40/Manifest.os-core.I.30")
-}
-
 // Delta manifest support added in format 26
 func TestFormats25to26DeltaManifest(t *testing.T) {
 	ts := newTestSwupd(t, "format25to26deltaManifest")

--- a/swupd/format_switch_test.go
+++ b/swupd/format_switch_test.go
@@ -142,12 +142,6 @@ func TestFormats25to26DeltaManifest(t *testing.T) {
 	ts.addFile(40, "test-bundle", "/foo", contents+"D")
 	ts.createManifests(40)
 	checkManifestContains(t, ts.Dir, "40", "MoM", "MANIFEST\t26")
-
-	// Delta manifests should be created in format 26
-	ts.mustHashFile("image/30/full/foo")
-	ts.mustHashFile("image/40/full/foo")
-	ts.createPack("test-bundle", 30, 40, ts.path("image"))
-	checkDeltaManifest(ts, 30, 40, "test-bundle", 1)
 }
 
 func TestFormat25BadContentSize(t *testing.T) {

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -180,26 +180,6 @@ func mustCreateManifests(t *testing.T, ver, previousVer, minVer uint32, format u
 	return mom
 }
 
-func checkManifestFileCount(ts *testSwupd, version, manifest string, files, deleted int) {
-
-	manifestFile := filepath.Join(ts.Dir, "www", version, "Manifest."+manifest)
-	m, err := ParseManifestFile(manifestFile)
-	if err != nil {
-		ts.t.Fatalf("Couldn't parse manifest %s: %s", manifestFile, err)
-	}
-	if len(m.Files) != files {
-		ts.t.Fatalf(
-			"Number of files in Manifest %s: %d is different from the expected: %d.",
-			manifestFile, len(m.Files), files)
-	}
-
-	if len(m.DeletedFiles) != deleted {
-		ts.t.Fatalf(
-			"Number of deleted files in Manifest %s: %d is different from the expected: %d.",
-			manifestFile, len(m.DeletedFiles), deleted)
-	}
-}
-
 func checkManifestContains(t *testing.T, testDir, ver, name string, subs ...string) {
 	t.Helper()
 	manFpath := filepath.Join(testDir, "www", ver, "Manifest."+name)

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -200,8 +200,9 @@ func checkManifestFileCount(ts *testSwupd, version, manifest string, files, dele
 	}
 }
 
-func checkManifestContainsFile(t *testing.T, manFpath string, subs ...string) {
+func checkManifestContains(t *testing.T, testDir, ver, name string, subs ...string) {
 	t.Helper()
+	manFpath := filepath.Join(testDir, "www", ver, "Manifest."+name)
 	b, err := ioutil.ReadFile(manFpath)
 	if err != nil {
 		t.Error(err)
@@ -210,15 +211,9 @@ func checkManifestContainsFile(t *testing.T, manFpath string, subs ...string) {
 
 	for _, sub := range subs {
 		if !bytes.Contains(b, []byte(sub)) {
-			t.Errorf("%s did not contain expected '%s'", manFpath, sub)
+			t.Errorf("%s/Manifest.%s did not contain expected '%s'", ver, name, sub)
 		}
 	}
-}
-
-func checkManifestContains(t *testing.T, testDir, ver, name string, subs ...string) {
-	t.Helper()
-	manFpath := filepath.Join(testDir, "www", ver, "Manifest."+name)
-	checkManifestContainsFile(t, manFpath, subs...)
 }
 
 func checkManifestNotContains(t *testing.T, testDir, ver, name string, subs ...string) {
@@ -304,29 +299,11 @@ func checkFileInManifest(t *testing.T, m *Manifest, version uint32, name string)
 			if f.Version == version {
 				return
 			}
-			t.Errorf("in manifest %s version %d: file %s has version %d but expected %d",
-				m.Name, m.Header.Version, f.Name, f.Version, version)
+			t.Errorf("in manifest %s version %d: file %s has version %d but expected %d", m.Name, m.Header.Version, f.Name, f.Version, version)
 			return
 		}
 	}
 	t.Errorf("couldn't find file %s in manifest %s version %d", name, m.Name, m.Header.Version)
-}
-
-func fileInManifestHash(t *testing.T, m *Manifest, version uint32, name string, hash string) *File {
-	t.Helper()
-	for _, f := range m.Files {
-		if f.Name == name {
-			if f.Version != version {
-				t.Fatalf("in manifest %s version %d: file %s has version %d but expected %d", m.Name, m.Header.Version, f.Name, f.Version, version)
-			}
-			if f.Hash.String() != hash {
-				t.Fatalf("in manifest %s version %d: file %s has hash %s but expected %s", m.Name, m.Header.Version, f.Name, f.Hash.String(), hash)
-			}
-			return f
-		}
-	}
-	t.Fatalf("couldn't find file %s in manifest %s version %d", name, m.Name, m.Header.Version)
-	return nil
 }
 
 func fileInManifest(t *testing.T, m *Manifest, version uint32, name string) *File {

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -308,30 +308,6 @@ func (m *Manifest) WriteManifest(w io.Writer) error {
 	return nil
 }
 
-// createIterativeManifest returns a new manifest with only Files and DeletedFiles
-// updated in versions greater than fromVersion
-func (m *Manifest) createIterativeManifest(fromVersion uint32) *Manifest {
-	fm := &Manifest{
-		Header:     m.Header,
-		Name:       fmt.Sprintf("%s.I.%d", m.Name, m.Header.Previous),
-		BundleInfo: m.BundleInfo,
-	}
-	fm.Header.ContentSize = 0
-
-	for _, f := range m.Files {
-		if f.Version > fromVersion {
-			fm.AppendFile(f)
-			if f.Status == StatusDeleted {
-				fm.DeletedFiles = append(fm.DeletedFiles, f)
-			}
-		}
-	}
-
-	fm.Header.FileCount = uint32(len(fm.Files))
-	fm.sortFilesVersionName()
-	return fm
-}
-
 // WriteManifestFile writes manifest m to a new file at path.
 func (m *Manifest) WriteManifestFile(path string) error {
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -43,19 +43,6 @@ const IndexBundle = "os-core-update-index"
 // this should be done when configuration is in a more stable state
 const indexAllBundleDir = "/usr/share/clear/allbundles"
 
-// ManifestType specifies whether the manifest is a MoM, bundle, iterative, or
-// delta manifest.
-type ManifestType uint8
-
-// Valid values for ManifestType.
-const (
-	ManifestUnset ManifestType = iota
-	ManifestMoM
-	ManifestBundle
-	ManifestIterative
-	ManifestDelta
-)
-
 // ManifestHeader contains metadata for the manifest
 type ManifestHeader struct {
 	Format      uint
@@ -76,7 +63,6 @@ type Manifest struct {
 	Files        []*File
 	DeletedFiles []*File
 	BundleInfo   BundleInfo
-	Type         ManifestType
 }
 
 // MoM is a manifest that holds references to bundle manifests.
@@ -202,9 +188,7 @@ func (m *Manifest) CheckHeaderIsValid() error {
 	if m.Header.Version == 0 {
 		return errors.New("manifest has version zero, version must be positive")
 	}
-
-	// Iterative manifests updated to include new bundles can have 0 files.
-	if m.Header.FileCount == 0 && m.Type != ManifestIterative {
+	if m.Header.FileCount == 0 {
 		return errors.New("manifest has a zero file count")
 	}
 
@@ -331,7 +315,6 @@ func (m *Manifest) createIterativeManifest(fromVersion uint32) *Manifest {
 		Header:     m.Header,
 		Name:       fmt.Sprintf("%s.I.%d", m.Name, m.Header.Previous),
 		BundleInfo: m.BundleInfo,
-		Type:       ManifestIterative,
 	}
 	fm.Header.ContentSize = 0
 

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -168,6 +168,12 @@ func readManifestFileEntry(fields []string, m *Manifest) error {
 		return fmt.Errorf("invalid flags: %v", err)
 	}
 
+	// IManifests are deprecated. Ignore them
+	// TODO: Remove code on format 30
+	if file.Type == TypeIManifest {
+		return nil
+	}
+
 	// add file to manifest
 	m.Files = append(m.Files, file)
 

--- a/swupd/packs.go
+++ b/swupd/packs.go
@@ -485,9 +485,7 @@ func FindBundlesToPack(from *Manifest, to *Manifest) (map[string]*BundleToPack, 
 
 	bundles := make(map[string]*BundleToPack, len(to.Files))
 	for _, b := range to.Files {
-		if b.Type == TypeManifest {
-			bundles[b.Name] = &BundleToPack{b.Name, 0, b.Version}
-		}
+		bundles[b.Name] = &BundleToPack{b.Name, 0, b.Version}
 	}
 
 	// If this is not a zero pack, we might be able to skip some bundles.

--- a/swupd/packs_test.go
+++ b/swupd/packs_test.go
@@ -22,7 +22,6 @@ func TestFindBundlesToPack(t *testing.T) {
 		From       M
 		ToV        uint32
 		To         M
-		ToIMan     M
 		Expected   []BundleToPack
 		ShouldFail bool
 	}{
@@ -106,19 +105,6 @@ func TestFindBundlesToPack(t *testing.T) {
 
 			Expected: []BundleToPack{{"os-core", 100, 200}, {"c-basic", 0, 200}},
 		},
-
-		{
-			Name: "Don't pack Iterative manifests",
-
-			FromV: 10,
-			From:  M{"os-core": 10},
-
-			ToV:    20,
-			To:     M{"os-core": 20},
-			ToIMan: M{"os-core.I.10": 20},
-
-			Expected: []BundleToPack{{"os-core", 10, 20}},
-		},
 	}
 
 	addBundle := func(m *Manifest, name string, version uint32) {
@@ -128,15 +114,6 @@ func TestFindBundlesToPack(t *testing.T) {
 			Version: version,
 		}
 		m.Files = append(m.Files, bundle)
-	}
-
-	addIterativeManifest := func(m *Manifest, name string, version uint32) {
-		man := &File{
-			Name:    name,
-			Type:    TypeIManifest,
-			Version: version,
-		}
-		m.Files = append(m.Files, man)
 	}
 
 	sortBundles := func(bundles []BundleToPack) {
@@ -165,9 +142,6 @@ func TestFindBundlesToPack(t *testing.T) {
 		toM.Header.Version = tt.ToV
 		for name, v := range tt.To {
 			addBundle(toM, name, v)
-		}
-		for name, v := range tt.ToIMan {
-			addIterativeManifest(toM, name, v)
 		}
 
 		bundleMap, err := FindBundlesToPack(fromM, toM)
@@ -912,13 +886,13 @@ func TestFindBundlesToPackErrorPaths(t *testing.T) {
 	toMan := &Manifest{
 		Name: "testto",
 		Files: []*File{
-			{Name: "test1", Version: 20, Type: TypeManifest},
+			{Name: "test1", Version: 20},
 		},
 	}
 	fromMan := &Manifest{
 		Name: "testfrom",
 		Files: []*File{
-			{Name: "test1", Version: 30, Type: TypeManifest}, // invalid version greater than toMan version
+			{Name: "test1", Version: 30}, // invalid version greater than toMan version
 		},
 	}
 

--- a/swupd/packs_test.go
+++ b/swupd/packs_test.go
@@ -284,42 +284,6 @@ func TestCreatePackZeroPacks(t *testing.T) {
 	mustValidateZeroPack(t, ts.path("www/20/Manifest.shells"), ts.path("www/20/pack-shells-from-0.tar"))
 }
 
-func checkDeltaManifest(ts *testSwupd, from, to int, bundle string, fileCount int) *Manifest {
-	manifest := fmt.Sprintf("www/%d/Manifest.%s.D.%d", to, bundle, from)
-	ts.checkExists(manifest)
-
-	expSubs := []string{
-		fmt.Sprintf("MANIFEST\t%d", ts.Format),
-		fmt.Sprintf("version:\t%d", from),
-		fmt.Sprintf("filecount:\t%d", fileCount),
-	}
-
-	manifestFile := filepath.Join(ts.Dir, manifest)
-	checkManifestContainsFile(ts.t, manifestFile, expSubs...)
-
-	m, err := ParseManifestFile(manifestFile)
-	if err != nil {
-		ts.t.Fatalf("couldn't parse delta manifest %s: %s", manifestFile, err)
-	}
-
-	if len(m.Files) != fileCount {
-		ts.t.Fatalf("Number of files in delta manifest %s is %d. The expected was %d",
-			manifestFile, len(m.Files), fileCount)
-	}
-
-	if len(m.DeletedFiles) != 0 {
-		ts.t.Fatalf("Delta Manifests %s have %d deleted files and Delta Manifest shouldn't have any.",
-			manifestFile, len(m.DeletedFiles))
-	}
-
-	if len(m.Header.Includes) != 0 {
-		ts.t.Fatalf("Delta Manifests %s have %d includes and Delta Manifest shouldn't have any.",
-			manifestFile, len(m.Header.Includes))
-	}
-
-	return m
-}
-
 func TestCreatePackNonConsecutiveDeltas(t *testing.T) {
 	ts := newTestSwupd(t, "create-pack-ncd")
 	defer ts.cleanup()
@@ -363,13 +327,6 @@ func TestCreatePackNonConsecutiveDeltas(t *testing.T) {
 	checkFileInPack(t, ts.path("www/20/pack-contents-from-10.tar"),
 		fmt.Sprintf("delta/10-20-%s-%s", hashC, hashC1))
 
-	// Check Delta Manifest 10->20
-	{
-		m := checkDeltaManifest(ts, 10, 20, "contents", 2)
-		fileInManifestHash(t, m, 10, "/A", hashA)
-		fileInManifestHash(t, m, 10, "/C", hashC)
-	}
-
 	info = ts.createPack("contents", 20, 30, ts.path("image"))
 	mustHaveDeltaCount(t, info, 3)
 	checkFileInPack(t, ts.path("www/30/pack-contents-from-20.tar"),
@@ -380,27 +337,12 @@ func TestCreatePackNonConsecutiveDeltas(t *testing.T) {
 	checkFileInPack(t, ts.path("www/30/pack-contents-from-20.tar"),
 		fmt.Sprintf("delta/20-30-%s-%s", hashC1, hashC2))
 
-	// Check Delta Manifest 20->30
-	{
-		m := checkDeltaManifest(ts, 20, 30, "contents", 3)
-		fileInManifestHash(t, m, 20, "/A1", hashA1)
-		fileInManifestHash(t, m, 10, "/B", hashB)
-		fileInManifestHash(t, m, 20, "/C1", hashC1)
-	}
-
 	info = ts.createPack("contents", 10, 30, ts.path("image"))
 	mustHaveDeltaCount(t, info, 2)
 	checkFileInPack(t, ts.path("www/30/pack-contents-from-10.tar"),
 		fmt.Sprintf("delta/10-30-%s-%s", hashB, hashB1))
 	checkFileInPack(t, ts.path("www/30/pack-contents-from-10.tar"),
 		fmt.Sprintf("delta/10-30-%s-%s", hashC, hashC2))
-
-	// Check Delta Manifest 10->30
-	{
-		m := checkDeltaManifest(ts, 10, 30, "contents", 2)
-		fileInManifestHash(t, m, 10, "/B", hashB)
-		fileInManifestHash(t, m, 10, "/C", hashC)
-	}
 }
 
 func TestCreatePackWithDelta(t *testing.T) {
@@ -699,20 +641,15 @@ func TestTwoDeltasForTheSameTarget(t *testing.T) {
 	info := ts.createPack("os-core", 10, 20, ts.path("image"))
 	mustHaveNoWarnings(t, info)
 	mustHaveDeltaCount(t, info, 2)
-
-	hashA := ts.mustHashFile("image/10/full/fileA")
-	hashA2 := ts.mustHashFile("image/20/full/fileA")
-	ts.checkExists(fmt.Sprintf("www/20/delta/10-20-%s-%s", hashA, hashA2))
-
-	hashB := ts.mustHashFile("image/10/full/fileB")
-	hashB2 := ts.mustHashFile("image/20/full/fileB")
-	ts.checkExists(fmt.Sprintf("www/20/delta/10-20-%s-%s", hashB, hashB2))
-
-	// Check Delta Manifest 10->20
 	{
-		m := checkDeltaManifest(ts, 10, 20, "os-core", 2)
-		fileInManifestHash(t, m, 10, "/fileA", hashA)
-		fileInManifestHash(t, m, 10, "/fileB", hashB)
+		hashA := ts.mustHashFile("image/10/full/fileA")
+		hashB := ts.mustHashFile("image/20/full/fileA")
+		ts.checkExists(fmt.Sprintf("www/20/delta/10-20-%s-%s", hashA, hashB))
+	}
+	{
+		hashA := ts.mustHashFile("image/10/full/fileB")
+		hashB := ts.mustHashFile("image/20/full/fileB")
+		ts.checkExists(fmt.Sprintf("www/20/delta/10-20-%s-%s", hashA, hashB))
 	}
 }
 
@@ -756,33 +693,15 @@ func TestPackRenames(t *testing.T) {
 	mustHaveDeltaCount(t, info, 1)
 	checkFileInPack(t, ts.path("www/20/pack-os-core-from-10.tar"), fmt.Sprintf("delta/10-20-%s-%s", hashIn10, hashIn20))
 
-	// Check Delta Manifest 10->20
-	{
-		m := checkDeltaManifest(ts, 10, 20, "os-core", 1)
-		fileInManifestHash(t, m, 10, "/file1", hashIn10)
-	}
-
 	// Pack from 20->30 will contain a delta due to content change (and rename).
 	info = ts.createPack("os-core", 20, 30, ts.path("image"))
 	mustHaveDeltaCount(t, info, 1)
 	checkFileInPack(t, ts.path("www/30/pack-os-core-from-20.tar"), fmt.Sprintf("delta/20-30-%s-%s", hashIn20, hashIn30))
 
-	// Check Delta Manifest 20->30
-	{
-		m := checkDeltaManifest(ts, 20, 30, "os-core", 1)
-		fileInManifestHash(t, m, 20, "/file1", hashIn20)
-	}
-
 	// Pack from 10->30 will contain a delta due to content change (and rename).
 	info = ts.createPack("os-core", 10, 30, ts.path("image"))
 	mustHaveDeltaCount(t, info, 1)
 	checkFileInPack(t, ts.path("www/30/pack-os-core-from-10.tar"), fmt.Sprintf("delta/10-30-%s-%s", hashIn10, hashIn30))
-
-	// Check Delta Manifest 10->30
-	{
-		m := checkDeltaManifest(ts, 10, 30, "os-core", 1)
-		fileInManifestHash(t, m, 10, "/file1", hashIn10)
-	}
 
 	// Pack from 10->40 will contain a delta due to content change (and rename).
 	info = ts.createPack("os-core", 10, 40, ts.path("image"))
@@ -790,12 +709,6 @@ func TestPackRenames(t *testing.T) {
 
 	// Note that the delta refers to the version of the file, which is still 30.
 	checkFileInPack(t, ts.path("www/40/pack-os-core-from-10.tar"), fmt.Sprintf("delta/10-30-%s-%s", hashIn10, hashIn30))
-
-	// Check Delta Manifest 10->40
-	{
-		m := checkDeltaManifest(ts, 10, 40, "os-core", 1)
-		fileInManifestHash(t, m, 10, "/file1", hashIn10)
-	}
 }
 
 // TestPackNoDeltas will test cases where there are no delta files

--- a/swupd/swupd_test.go
+++ b/swupd/swupd_test.go
@@ -187,13 +187,6 @@ func TestFullRunDelta(t *testing.T) {
 	mustHaveFullfileCount(t, info, 0)
 	mustHaveDeltaCount(t, info, 1) // largefile.
 
-	// Check Delta Manifest 10->20
-	{
-		m := checkDeltaManifest(ts, 10, 20, "test-bundle", 1)
-		hash := ts.mustHashFile("image/10/full/largefile")
-		fileInManifestHash(t, m, 10, "/largefile", hash)
-	}
-
 	// NOTE: original test checked whether the packs had the manifests inside. This is
 	// not done by new swupd since it seems the client doesn't take advantage of them.
 }


### PR DESCRIPTION
Reverting all patches that added Iterative and Delta manifests in mixer.
Only Iterative Manifest leftover is the ability to parse MoM with Iterative manifests. This is necessary because when we build an update we need to parse previous manifest, that may have an Iterative Manifest.
Also added code to prevent mixer to carry Iterative manifests to a new MoM when an update is built.