### PR TITLE
Create zero packs in parallel

### DIFF
--- a/builder/deltapacks.go
+++ b/builder/deltapacks.go
@@ -63,19 +63,18 @@ func createDeltaPacks(fromMoM *swupd.Manifest, toMoM *swupd.Manifest, printRepor
 	if numWorkers < 1 {
 		numWorkers = runtime.NumCPU()
 	}
-	bundleWorkers := numWorkers
 
 	var bundleQueue = make(chan *swupd.BundleToPack)
 	var wg sync.WaitGroup
-	wg.Add(bundleWorkers)
+	wg.Add(numWorkers)
 
 	// Delta creation takes a lot of memory, so create a limited amount of goroutines.
-	for i := 0; i < bundleWorkers; i++ {
+	for i := 0; i < numWorkers; i++ {
 		go func() {
 			defer wg.Done()
 			for b := range bundleQueue {
 				fmt.Printf("  Creating delta pack for bundle %q from %d to %d\n", b.Name, b.FromVersion, b.ToVersion)
-				info, err := swupd.CreatePack(b.Name, b.FromVersion, b.ToVersion, outputDir, bundleDir, numWorkers)
+				info, err := swupd.CreatePack(b.Name, b.FromVersion, b.ToVersion, outputDir, bundleDir)
 				if err != nil {
 					log.Printf("ERROR: Pack %q from %d to %d FAILED to be created: %s\n", b.Name, b.FromVersion, b.ToVersion, err)
 					// Do not exit on errors, we have logging for all other failures and deltas are optional

--- a/builder/update.go
+++ b/builder/update.go
@@ -189,7 +189,7 @@ func (b *Builder) buildUpdateContent(params UpdateParameters, timer *stopWatch) 
 			fmt.Printf("Creating zero pack for %s to version %d\n", name, version)
 
 			var info *swupd.PackInfo
-			info, err = swupd.CreatePack(name, 0, version, outputDir, bundleDir, 0)
+			info, err = swupd.CreatePack(name, 0, version, outputDir, bundleDir)
 			if err != nil {
 				return errors.Wrapf(err, "couldn't make pack for bundle %q", name)
 			}

--- a/swupd/cmd/create-pack/main.go
+++ b/swupd/cmd/create-pack/main.go
@@ -124,7 +124,7 @@ func main() {
 
 		fmt.Printf("Packing %s from %d to %d...\n", b.Name, b.FromVersion, b.ToVersion)
 
-		info, err := swupd.CreatePack(b.Name, b.FromVersion, b.ToVersion, filepath.Join(stateDir, "www"), chrootDir, 0)
+		info, err := swupd.CreatePack(b.Name, b.FromVersion, b.ToVersion, filepath.Join(stateDir, "www"), chrootDir)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/swupd/packs.go
+++ b/swupd/packs.go
@@ -116,9 +116,8 @@ func CreateAllDeltas(outputDir string, fromVersion, toVersion, numWorkers int, b
 // WritePack writes the pack between two Manifests, or a zero pack if fromManifest is
 // nil. The toManifest should always be non nil. The outputDir is used to pick deltas and
 // fullfiles. If not empty, chrootDir is tried first as a fast alternative to
-// decompressing the fullfiles. Multiple workers are used to parallelize delta creation.
-// If number of workers is zero or less, 1 worker is used.
-func WritePack(w io.Writer, fromManifest, toManifest *Manifest, outputDir, chrootDir string, numWorkers int) (info *PackInfo, err error) {
+// decompressing the fullfiles.
+func WritePack(w io.Writer, fromManifest, toManifest *Manifest, outputDir, chrootDir string) (info *PackInfo, err error) {
 	if toManifest == nil {
 		return nil, fmt.Errorf("need a valid toManifest")
 	}
@@ -514,9 +513,7 @@ func FindBundlesToPack(from *Manifest, to *Manifest) (map[string]*BundleToPack, 
 // CreatePack creates the pack file for a specific bundle between two versions. The pack is written
 // in the TO version subdirectory of outputDir (e.g. a pack from 10 to 20 is written to "www/20").
 // Empty packs will lead to not creating the pack.
-// Multiple workers are used to parallelize delta creation. If number of workers is zero or
-// less, 1 worker is used.
-func CreatePack(name string, fromVersion, toVersion uint32, outputDir, chrootDir string, numWorkers int) (*PackInfo, error) {
+func CreatePack(name string, fromVersion, toVersion uint32, outputDir, chrootDir string) (*PackInfo, error) {
 	toDir := filepath.Join(outputDir, fmt.Sprint(toVersion))
 	toM, err := ParseManifestFile(filepath.Join(toDir, "Manifest."+name))
 	if err != nil {
@@ -536,7 +533,7 @@ func CreatePack(name string, fromVersion, toVersion uint32, outputDir, chrootDir
 	if err != nil {
 		return nil, err
 	}
-	info, err := WritePack(output, fromM, toM, outputDir, chrootDir, numWorkers)
+	info, err := WritePack(output, fromM, toM, outputDir, chrootDir)
 	if err != nil {
 		_ = output.Close()
 		_ = os.RemoveAll(packPath)

--- a/swupd/packs_test.go
+++ b/swupd/packs_test.go
@@ -229,7 +229,7 @@ func TestCreatePackZeroPacks(t *testing.T) {
 	ts.createManifests(20)
 
 	// Expect failure when creating packs without the fullfiles.
-	_, err := CreatePack("editors", 0, 20, ts.path("www"), "", 0)
+	_, err := CreatePack("editors", 0, 20, ts.path("www"), "")
 	if err == nil {
 		t.Fatalf("unexpected success creating pack without chrootDir nor fullfiles available")
 	}
@@ -244,7 +244,7 @@ func TestCreatePackZeroPacks(t *testing.T) {
 
 	// Expect failure when creating packs for bundle shells, it won't find the new
 	// shell added in version 20.
-	_, err = CreatePack("shells", 0, 20, ts.path("www"), "", 0)
+	_, err = CreatePack("shells", 0, 20, ts.path("www"), "")
 	if err == nil {
 		t.Fatalf("unexpected success creating pack without all fullfiles available")
 	}
@@ -392,7 +392,7 @@ func TestCreatePackWithIncompleteChrootDir(t *testing.T) {
 
 	// Creating a pack should fail, no way to get emacs contents from neither chroot
 	// or fullfile.
-	_, err := CreatePack("editors", 0, 10, fs.path("www"), fs.path("image"), 0)
+	_, err := CreatePack("editors", 0, 10, fs.path("www"), fs.path("image"))
 	if err == nil {
 		t.Fatalf("unexpected success when creating pack with incomplete chroot")
 	}
@@ -539,7 +539,7 @@ func mustCreatePack(t *testing.T, name string, fromVersion, toVersion uint32, ou
 		t.Fatalf("error creating pack for bundle %s: %s", name, err)
 	}
 	var info *PackInfo
-	info, err = CreatePack(name, fromVersion, toVersion, outputDir, chrootDir, 0)
+	info, err = CreatePack(name, fromVersion, toVersion, outputDir, chrootDir)
 	if err != nil {
 		t.Fatalf("error creating pack for bundle %s: %s", name, err)
 	}
@@ -801,19 +801,19 @@ func TestWritePackErrorPaths(t *testing.T) {
 	}()
 	// valid fromManifest
 	fm := Manifest{Name: "test"}
-	if _, err = WritePack(f, &fm, nil, d, d, 1); err == nil {
+	if _, err = WritePack(f, &fm, nil, d, d); err == nil {
 		t.Error("WritePack did not return error with nil toManifest")
 	}
 
 	tm := Manifest{}
-	if _, err = WritePack(f, &fm, &tm, d, d, 1); err == nil {
+	if _, err = WritePack(f, &fm, &tm, d, d); err == nil {
 		t.Error("WritePack did not return error with unnamed toManifest")
 	}
 
 	tm.Name = "testto"
 	tm.Header.Version = 10
 	fm.Header.Version = 20
-	if _, err = WritePack(f, &fm, &tm, d, d, 1); err == nil {
+	if _, err = WritePack(f, &fm, &tm, d, d); err == nil {
 		t.Error("WritePack did not return error with invalid version pairs")
 	}
 
@@ -823,7 +823,7 @@ func TestWritePackErrorPaths(t *testing.T) {
 	}
 
 	tm.Header.Version = 30
-	if _, err = WritePack(f, &fm, &tm, d, d, 1); err == nil {
+	if _, err = WritePack(f, &fm, &tm, d, d); err == nil {
 		t.Error("WritePack did not return error with no config present")
 	}
 }
@@ -910,7 +910,7 @@ func TestCreatePackErrorPaths(t *testing.T) {
 		_ = os.RemoveAll(d)
 	}()
 
-	if _, err = CreatePack("test", 0, 10, d, d, 1); err == nil {
+	if _, err = CreatePack("test", 0, 10, d, d); err == nil {
 		t.Error("CreatePack did not return error with failed manifest parsing")
 	}
 
@@ -936,7 +936,7 @@ func TestCreatePackErrorPaths(t *testing.T) {
 		t.Fatalf("could not write test to manifest: %s", err)
 	}
 
-	if _, err := CreatePack("testto", 10, 20, d, d, 1); err == nil {
+	if _, err := CreatePack("testto", 10, 20, d, d); err == nil {
 		t.Error("CreatePack did not return error with failed from manifest parsing")
 	}
 }


### PR DESCRIPTION
Create zero packs in parallel
Fixes #629

Decided not to reuse the parallel code of delta packs for zero packs because there were certain differences such as 1) For zero packs, stop processing in case of error. For delta packs continue processing even in case of error because delta packs are optional. 2) The report and print statements are different. etc.

Decided to reuse the delta-workers as the the numWorker for zero packs. This is because mixer is already overloaded with too many numWorker flags such as delta-workers, bundle-workers and fullfile-workers. Did not find the need to introduce another new one. Also, technically a zero pack is a delta pack.