### PR TITLE
Fix to fail Early if rpm not found

### DIFF
--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -662,6 +662,9 @@ func installBundleToFull(packagerCmd []string, baseDir string, bundle *bundle, d
 		rpmFull := filepath.Join(localPath, rpm)
 		if _, err = os.Stat(rpmFull); os.IsNotExist(err) {
 			rpmFull = filepath.Join(rpmPath, rpm)
+			if _, err = os.Stat(rpmFull); os.IsNotExist(err) {
+				return fmt.Errorf("rpm not found: %s ", rpmFull)
+			}
 		}
 		rpmMap[rpm] = true
 		select {


### PR DESCRIPTION
Fix to fail Early if rpm not found

if rpm is not found in the cache dir of clear-*, we can fail early
instead of failing during extraction.

Signed-off-by: Ashlesha Atrey <ashlesha.atrey@intel.com>