### PR TITLE
Setting multiple repos in mixer

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -66,6 +66,7 @@ type Builder struct {
 	// Parsed versions.
 	MixVerUint32      uint32
 	UpstreamVerUint32 uint32
+	repos             map[string]repoInfo
 }
 
 // UpdateParameters contains the configuration parameters for building an update

--- a/builder/bundleset.go
+++ b/builder/bundleset.go
@@ -31,7 +31,7 @@ type bundle struct {
 	Files map[string]bool
 
 	/* hidden property, not to be included in file usr/share/clear/allbundles */
-	AllRpmPackages map[string]bool `json:"-"`
+	AllRpms map[string]packageMetadata `json:"-"`
 }
 
 type bundleSet map[string]*bundle

--- a/mixer/cmd/repos.go
+++ b/mixer/cmd/repos.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/clearlinux/mixer-tools/builder"
@@ -113,12 +114,18 @@ func runAddRepo(cmd *cobra.Command, args []string) {
 	if err != nil {
 		fail(err)
 	}
-
-	err = b.AddRepo(args[0], args[1])
+	u, err := url.Parse(args[1])
 	if err != nil {
 		fail(err)
 	}
-	fmt.Printf("Added %s repo at %s url.\n", args[0], args[1])
+	if u.Scheme == "" {
+		u.Scheme = "file"
+	}
+	err = b.AddRepo(args[0], u.String())
+	if err != nil {
+		fail(err)
+	}
+	fmt.Printf("Added %s repo at %s url.\n", args[0], u.String())
 }
 
 func runRemoveRepo(cmd *cobra.Command, args []string) {
@@ -164,9 +171,18 @@ func runSetURLRepo(cmd *cobra.Command, args []string) {
 		fail(err)
 	}
 
-	err = b.SetURLRepo(args[0], args[1])
+	u, err := url.Parse(args[1])
 	if err != nil {
 		fail(err)
 	}
-	fmt.Printf("Set %s baseurl to %s.\n", args[0], args[1])
+	if u.Scheme == "" {
+		u.Scheme = "file"
+	}
+
+	err = b.SetURLRepo(args[0], u.String())
+	if err != nil {
+		fail(err)
+	}
+
+	fmt.Printf("Set %s baseurl to %s.\n", args[0], u.String())
 }


### PR DESCRIPTION
Currently mixer allows users to set multiple repos using 'mixer repo set' commands and name them anyhow.
But the code within the mixer is tightly coupled to having only two repos - "clear" and "local".
This inconsistency is fixed.
fixes #654

Signed-off-by: Ashlesha Atrey <ashlesha.atrey@intel.com>