### PR TITLE
Stop processing bundles if missing dependencies

### DIFF
--- a/builder/build_validate.go
+++ b/builder/build_validate.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/clearlinux/mixer-tools/helpers"
 	"github.com/clearlinux/mixer-tools/swupd"
+	"github.com/pkg/errors"
 )
 
 type bundleStatus int
@@ -324,8 +325,10 @@ func (b *Builder) mcaPkgInfo(manifests []*swupd.Manifest, version, downloadRetri
 		}
 
 		// Collect metadata to resolve installed RPM file names
-		pInfo[m.Name].allPkgs = pkgInfoFromNoopInstall(out.String())
-
+		pInfo[m.Name].allPkgs, err = pkgInfoFromNoopInstall(out.String())
+		if err != nil {
+			return nil, errors.Wrapf(err, m.Name)
+		}
 		for _, p := range pInfo[m.Name].allPkgs {
 			if pkgFileCache[p.name] == nil {
 				pkgFileCache[p.name], err = b.resolvePkgFiles(p, version)
@@ -414,12 +417,14 @@ func (b *Builder) resolvePkgFiles(pkg *pkgInfo, version int) ([]*fileInfo, error
 }
 
 // pkgInfoFromNoopInstall parses DNF install output to collect and store package metadata
-func pkgInfoFromNoopInstall(installOut string) map[string]*pkgInfo {
+func pkgInfoFromNoopInstall(installOut string) (map[string]*pkgInfo, error) {
 	pInfo := make(map[string]*pkgInfo)
 
 	// Parse DNF install output
-	pkgs := parseNoopInstall(installOut)
-
+	pkgs, err := parseNoopInstall(installOut)
+	if err != nil {
+		return nil, err
+	}
 	for _, p := range pkgs {
 		pInfo[p.name] = &pkgInfo{
 			name:    p.name,
@@ -427,7 +432,7 @@ func pkgInfoFromNoopInstall(installOut string) map[string]*pkgInfo {
 			version: p.version,
 		}
 	}
-	return pInfo
+	return pInfo, nil
 }
 
 // getManFiles collects the manifest's file list

--- a/builder/bundleset.go
+++ b/builder/bundleset.go
@@ -389,3 +389,14 @@ func parseBundle(contents []byte) (*bundle, error) {
 
 	return &b, nil
 }
+
+func isEmptyBundle(bundle *bundle) bool {
+	if len(bundle.DirectIncludes) == 0 &&
+		len(bundle.OptionalIncludes) == 0 &&
+		len(bundle.DirectPackages) == 0 &&
+		len(bundle.AllPackages) == 0 &&
+		len(bundle.Files) == 0 {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
For current version of mixer, if dependencies are not resolved, it
continues with installing other bundles.The correct behavior should be to fail at this point .
While resolving packages, if dependencies are not resolved then we stop the processing 
and return error.

fixes #663

Signed-off-by: Ashlesha Atrey <ashlesha.atrey@intel.com>