### PR TITLE
MCA refactor pkg queries

### DIFF
--- a/builder/build_validate.go
+++ b/builder/build_validate.go
@@ -115,8 +115,13 @@ func (b *Builder) CheckManifestCorrectness(fromVer, toVer, downloadRetries int, 
 	if fromVer >= toVer {
 		return fmt.Errorf("From version must be less than to version")
 	}
-
-	fmt.Printf("WARNING: Local RPMs will override upstream RPMs for both the from and to versions.\n")
+	
+	// Suppress Stdout so that it doesn't clutter the results
+	stdOut := os.Stdout
+	os.Stdout,_ = os.Open(os.DevNull)
+	defer func() {
+		os.Stdout = stdOut
+	}()
 
 	// Load initial repo map
 	if err := b.ListRepos(); err != nil {
@@ -153,6 +158,9 @@ func (b *Builder) CheckManifestCorrectness(fromVer, toVer, downloadRetries int, 
 	if err != nil {
 		return err
 	}
+
+	// Re-enable Stdout for the results
+	os.Stdout = stdOut
 
 	// Display errors and package/file statistics
 	err = printMcaResults(results, fromInfo, toInfo, fromVer, toVer, errorList, warningList)


### PR DESCRIPTION
Changes proposed in this pull request:

* MCA: Instead of querying packages downloaded by `dnf install`, the packages are resolved and queried with `rpm`. When the packages are in repos on the local system, the query operation is much faster.
* MCA: Added support to resolve packages that do not follow NVRA name format.
* MCA: Suppress verbose Mixer output
* Return more package metadata during `resolvePackages`

Based on local MCA testing, with all bundles and package repositories on the local system the execution time improved from 106min 11sec -> 15min 11sec.
