### PR TITLE
repo: Fix message while removing repo

### DIFF
--- a/builder/repo_control.go
+++ b/builder/repo_control.go
@@ -287,11 +287,18 @@ func (b *Builder) RemoveRepo(name string) error {
 
 	_, err = DNFConf.GetSection(name)
 	if err != nil {
-		fmt.Printf("Repo %s does not exist.\n", name)
+		return errors.Errorf("unable to remove repo %s, does not exist.", name)
 	}
 
 	DNFConf.DeleteSection(name)
-	return DNFConf.SaveTo(b.Config.Builder.DNFConf)
+
+	err = DNFConf.SaveTo(b.Config.Builder.DNFConf)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Removing repo %s\n", name)
+	return nil
 }
 
 // ListRepos lists all configured repositories in the DNF configuration file.

--- a/mixer/cmd/repos.go
+++ b/mixer/cmd/repos.go
@@ -131,7 +131,6 @@ func runRemoveRepo(cmd *cobra.Command, args []string) {
 	if err != nil {
 		fail(err)
 	}
-	fmt.Printf("Removed %s repo.\n", args[0])
 }
 
 func runListRepos(cmd *cobra.Command, args []string) {

--- a/mixin/repo.go
+++ b/mixin/repo.go
@@ -151,7 +151,6 @@ func runRemoveRepo(cmd *cobra.Command, args []string) {
 	if err != nil {
 		fail(err)
 	}
-	fmt.Printf("Removed %s repo.\n", args[0])
 }
 
 func runListRepos(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Currently, `mixer repo remove` displays incorrect messages if repo does not exist.
This fix displays the correct message.

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>