### PR TITLE
repo: Handle rpms in repo sub directories

### DIFF
--- a/bat/tests/create-mix-with-custom-content/Makefile
+++ b/bat/tests/create-mix-with-custom-content/Makefile
@@ -3,7 +3,7 @@
 check:
 	bats ./run.bats
 
-CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles ./custom-yum
 CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
 clean:
 	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/create-mix-with-custom-content/run.bats
+++ b/bat/tests/create-mix-with-custom-content/run.bats
@@ -21,4 +21,39 @@ setup() {
   mixer-build-update > $LOGDIR/build_update.log
 }
 
+@test "Create stripped down mix 10 with custom rpm from custom repo" {
+  mixer-init-stripped-down $CLRVER 10
+  localize_builder_conf
+
+  # create a custom repo directory which has a sub directory
+  mkdir -p $BATS_TEST_DIRNAME/custom-yum/sub-dir
+
+  # download the helloworld rpm, rename it to a non-autospec convention and place it within the repo sub directory
+  curl --retry 4 --retry-delay 10 --fail --silent --show-error --location --remote-name https://download.clearlinux.org/current/x86_64/os/Packages/helloworld-bin-4-147.x86_64.rpm
+  mv helloworld-bin-4-147.x86_64.rpm $BATS_TEST_DIRNAME/custom-yum/sub-dir/foo.rpm
+
+  # create the repo
+  createrepo_c $BATS_TEST_DIRNAME/custom-yum/
+
+  # add the custom repo to mixer with the baseurl not including the sub directory
+  mixer repo add custom file://$BATS_TEST_DIRNAME/custom-yum
+
+  # create and add a bundle for the downloaded package to the mix
+cat > local-bundles/foobar <<EOF
+# [TITLE]: foobar
+# [DESCRIPTION]: example
+# [STATUS]: Active
+# [CAPABILITIES]: example
+# [MAINTAINER]: example@example.com
+helloworld
+EOF
+  mixer bundle add foobar
+
+  # build the bundles
+  mixer-build-bundles > $LOGDIR/build_bundles.log
+
+  # check if the corresponding bin file for the package is created
+  test -e $BATS_TEST_DIRNAME/update/image/10/full/usr/bin/helloworld
+}
+
 # vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/mixer/cmd/repos.go
+++ b/mixer/cmd/repos.go
@@ -33,9 +33,10 @@ var repoCmd = &cobra.Command{
 var addRepoCmd = &cobra.Command{
 	Use:   "add <name> <url>",
 	Short: "Add repo to DNF conf file",
-	Long:  `Add repo <name> with <url> to the DNF conf file used by mixer. The <url> must be an absolute path.`,
-	Args:  cobra.ExactArgs(2),
-	Run:   runAddRepo,
+	Long: `Add repo <name> with <url> to the DNF conf file used by mixer. The <url> must be an absolute path.
+NOTE: For <url> with "file" scheme, ensure that the rpms are stored directly within the <url> path for better performance.`,
+	Args: cobra.ExactArgs(2),
+	Run:  runAddRepo,
 }
 
 var removeRepoCmd = &cobra.Command{
@@ -64,7 +65,8 @@ var setURLRepoCmd = &cobra.Command{
 	Use:   "set-url <name> <url>",
 	Short: "Set URL of repo in DNF conf file",
 	Long: `Set repo <name> with <url> to the DNF conf file used by mixer. The <url> must be an absolute path.
-If repo <name> does not exist, the repo will be added to the conf file.`,
+If repo <name> does not exist, the repo will be added to the conf file.
+NOTE: For <url> with "file" scheme, ensure that the rpms are stored directly within the <url> path for better performance.`,
 	Args: cobra.ExactArgs(2),
 	Run:  runSetURLRepo,
 }


### PR DESCRIPTION
Currently, for repos with "file" baseurl scheme, mixer expects the
rpms to be directly within the baseurl path.
But it is possible that rpms can be in sub directories within the repo baseurl.

In order to handle this, if an rpm is not found directly within the repo baseurl,
run repoquery to determine the actual location of the rpm.
This is expensive and it is recommended that rpms are stored directly
within the repo baseurl.

Includes a bat test.
Fixes #674

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>