### PR TITLE
repo: Improve performance for multiple repo subdir

### DIFF
--- a/builder/repo_control.go
+++ b/builder/repo_control.go
@@ -36,7 +36,7 @@ type dnfRepoConf struct {
 }
 
 type repoInfo struct {
-	cacheDir  string
+	cacheDirs map[string]bool
 	urlScheme string
 	url       string
 }
@@ -355,11 +355,11 @@ func (b *Builder) ListRepos() error {
 
 		repo.urlScheme = pURL.Scheme
 		repo.url = pURL.String()
+		repo.cacheDirs = make(map[string]bool)
 		if pURL.Scheme == "file" {
-			pURL.Scheme = ""
-			repo.cacheDir = pURL.String()
+			repo.cacheDirs[pURL.String()] = true
 		} else {
-			repo.cacheDir = dnfDownloadDir
+			repo.cacheDirs[dnfDownloadDir] = true
 		}
 
 		b.repos[name] = repo


### PR DESCRIPTION
repo: Improve performance for multiple repo subdir

If an rpm is not found in the assumed cache dir of its repo, update the
repo cache dir list based on the location of the rpm.

This is an attempt to improve performance in case the rpms are not
stored directly within the repo baseurl.

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>