### PR TITLE
swupd: Retain previously deleted file entries

### DIFF
--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -439,9 +439,12 @@ func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, minVersion uint32) 
 		added = append(added, nf)
 	}
 
-	// anything remaining in oldManifest is newly deleted in the new manifest
+	// anything remaining in oldManifest is deleted in the new manifest
 	for _, of := range oldManifest.Files[ox:omFilesLen] {
-		if of.Status == StatusDeleted || of.Status == StatusGhosted {
+		if !of.Present() {
+			if of.Status == StatusDeleted && m.Header.Format == oldManifest.Header.Format {
+				m.Files = append(m.Files, of)
+			}
 			continue
 		}
 		m.newDeleted(of)


### PR DESCRIPTION
Fixes #684 

Changes proposed in this pull request:
* Prevent newly generated manifests from dropping previously deleted file entries when the new manifest has less file entries than the previous manifest.
* Add test case to verify that previously deleted file entries are retained.