### PR TITLE
Add set-priority to repo command

### DIFF
--- a/builder/repo_control.go
+++ b/builder/repo_control.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -218,6 +219,18 @@ func (b *Builder) SetURLRepo(repo, url string) error {
 // SetExcludesRepo sets the excludes for the repo <repo> to [pkgs...]
 func (b *Builder) SetExcludesRepo(repo, pkgs string) error {
 	return b.setRepoVal(repo, "excludepkgs", pkgs)
+}
+
+// SetPriorityRepo sets the priority for the repo
+func (b *Builder) SetPriorityRepo(repo, priority string) error {
+	p, err := strconv.Atoi(priority)
+	if err != nil {
+		return err
+	}
+	if p < 1 || p > 99 {
+		return errors.Errorf("repo priority %d must be between 1 and 99", p)
+	}
+	return b.setRepoVal(repo, "priority", priority)
 }
 
 // WriteRepoURLOverrides writes a copy of the DNF conf file

--- a/docs/mixer.repo.1
+++ b/docs/mixer.repo.1
@@ -58,6 +58,12 @@ Display subcommand help information and exit.
 .INDENT 3.5
 Add the repo named \fIname\fP at the \fIurl\fP url. In addition to the global
 options \fBmixer repo add\fP takes the following options.
+.INDENT 0.0
+.IP \(bu 2
+\fB\-\-priority\fP
+.sp
+Repo priority between 1 and 99, where 1 is highest. Defaults to 1.
+.UNINDENT
 .UNINDENT
 .UNINDENT
 .sp

--- a/docs/mixer.repo.1
+++ b/docs/mixer.repo.1
@@ -84,6 +84,13 @@ Remove the repo \fIname\fP from the DNF configuration file used by mixer.
 .UNINDENT
 .UNINDENT
 .sp
+\fBset\-priority {name} {priority}\fP
+.INDENT 0.0
+.INDENT 3.5
+Sets the priority for repo \fIname\fP to the provided \fIpriority\fP\&.
+.UNINDENT
+.UNINDENT
+.sp
 \fBset\-url {name} {url}\fP
 .INDENT 0.0
 .INDENT 3.5

--- a/docs/mixer.repo.1.rst
+++ b/docs/mixer.repo.1.rst
@@ -60,6 +60,10 @@ SUBCOMMANDS
 
     Remove the repo `name` from the DNF configuration file used by mixer.
 
+``set-priority {name} {priority}``
+
+    Sets the priority for repo `name` to the provided `priority`.
+
 ``set-url {name} {url}``
 
     Sets the URL for repo `name` to the provided `url`. If `name` does not exist

--- a/docs/mixer.repo.1.rst
+++ b/docs/mixer.repo.1.rst
@@ -46,6 +46,10 @@ SUBCOMMANDS
     Add the repo named `name` at the `url` url. In addition to the global
     options ``mixer repo add`` takes the following options.
 
+    - ``--priority``
+
+      Repo priority between 1 and 99, where 1 is highest. This flag defaults to 1.
+
 ``init``
 
     Initialize the DNF configuration file with the default `Clear` repository

--- a/mixer/cmd/repos.go
+++ b/mixer/cmd/repos.go
@@ -81,6 +81,15 @@ to use when building bundles by excluding the unwanted ones. Globbing is support
 	Run:  runExcludesRepo,
 }
 
+var setPriorityRepoCmd = &cobra.Command{
+	Use:   "set-priority <repo> <priority>",
+	Short: "Set priority of repo in DNF conf file",
+	Long: `Set repo <repo> with <priority> to the DNF conf file used by mixer. The <priority> must be a
+number between 1 and 99.`,
+	Args: cobra.ExactArgs(2),
+	Run:  runPriorityRepo,
+}
+
 var repoCmds = []*cobra.Command{
 	addRepoCmd,
 	removeRepoCmd,
@@ -88,6 +97,7 @@ var repoCmds = []*cobra.Command{
 	initRepoCmd,
 	setURLRepoCmd,
 	setExcludesRepoCmd,
+	setPriorityRepoCmd,
 }
 
 func init() {
@@ -109,6 +119,19 @@ func runExcludesRepo(cmd *cobra.Command, args []string) {
 		fail(err)
 	}
 	fmt.Printf("Excluded packages from repo %s:\n%s\n", args[0], strings.Join(args[1:], "\n"))
+}
+
+func runPriorityRepo(cmd *cobra.Command, args []string) {
+	b, err := builder.NewFromConfig(configFile)
+	if err != nil {
+		fail(err)
+	}
+
+	err = b.SetPriorityRepo(args[0], args[1])
+	if err != nil {
+		fail(err)
+	}
+	fmt.Printf("Setting repo %s with priority %s\n", args[0], args[1])
 }
 
 func runAddRepo(cmd *cobra.Command, args []string) {

--- a/mixin/repo.go
+++ b/mixin/repo.go
@@ -119,7 +119,7 @@ func runAddRepo(cmd *cobra.Command, args []string) {
 		fail(err)
 	}
 
-	err = b.AddRepo(args[0], args[1])
+	err = b.AddRepo(args[0], args[1], "1")
 	if err != nil {
 		fail(err)
 	}


### PR DESCRIPTION
Fixes #691 

Changes proposed in this pull request:
* Add set-priority to repo command: `mixer repo set-priority <repo> <priority>`
* Increase code re-use for repo commands
