### PR TITLE
Add BUILD_ID field in os-release file

### DIFF
--- a/bat/tests/customize-os-release/files/my-os-release
+++ b/bat/tests/customize-os-release/files/my-os-release
@@ -9,3 +9,5 @@ HOME_URL="https://clearlinux.org"
 SUPPORT_URL="https://clearlinux.org"
 BUG_REPORT_URL="mailto:dev@lists.clearlinux.org"
 PRIVACY_POLICY_URL="http://www.intel.com/privacy"
+BUILD_ID=1
+

--- a/bat/tests/customize-os-release/run.bats
+++ b/bat/tests/customize-os-release/run.bats
@@ -19,13 +19,15 @@ setup() {
   mixer-build-bundles > $LOGDIR/build_bundles.log
 
   #Compare the diff between customized os-release file and output of mixer build
-  #bundle. The only difference should be VERSION_ID 
+  #bundle. The only difference should be VERSION_ID and BUILD_ID
   run bash -c "diff files/my-os-release update/image/10/full/usr/lib/os-release | wc -l "
-  [ "$output" -eq  4 ]
+  [ "$output" -eq  8 ]
 
   run bash -c "diff files/my-os-release update/image/10/full/usr/lib/os-release"
   [[ ${lines[1]} =~ "VERSION_ID" ]]
   [[ ${lines[3]} =~ "VERSION_ID" ]]
+  [[ ${lines[5]} =~ "BUILD_ID" ]]
+  [[ ${lines[7]} =~ "BUILD_ID" ]]
 }
 
 # vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
BUILD_ID field in os-release file specifies the upstream Clear
Linux version from which the mix is being created.
If upstream Clear Linux is not found, BUILD_ID is empty.

fixes #706

Signed-off-by: Ashlesha Atrey <ashlesha.atrey@intel.com>