### PR TITLE
Always clean mix workspace before building bundles

### DIFF
--- a/bat/tests/clean-rebuild/description.txt
+++ b/bat/tests/clean-rebuild/description.txt
@@ -1,4 +1,4 @@
 clean-rebuild
 ================
-This test rebuilds version 20 with the --clean flag. It confirms that the current
-and previous versions are correctly maintained when performing a clean build.
+This test rebuilds version 20 and confirms that the current/previous versions are correctly
+maintained when a build is cleaned.

--- a/bat/tests/clean-rebuild/run.bats
+++ b/bat/tests/clean-rebuild/run.bats
@@ -7,14 +7,20 @@ setup() {
   global_setup
 }
 
-@test "Perform build with --clean flag" {
+@test "Verify mixer builds clean the workspace" {
   mixer-init-stripped-down 25740 10
   mixer-build-all
   mixer-mixversion-update 20
   mixer-build-all
 
-  # Rebuild v20 with --clean
-  run sudo mixer build all --clean
+  # Rebuild v20
+  run sudo mixer build bundles
+  [[ $status -eq 0 ]]
+
+  # Check v20 output directory cleaned
+  [[ ! -d "$BATS_TEST_DIRNAME"/update/www/20 ]]
+
+  run sudo mixer build update
   [[ $status -eq 0 ]]
 
   mom="$BATS_TEST_DIRNAME"/update/www/20/Manifest.MoM
@@ -30,7 +36,7 @@ setup() {
   # LAST_VER which will lead to an incorrectly generated manifest.
   sed -i "/PREVIOUS_MIX_VERSION/d" mixer.state
 
-  run sudo mixer build all --clean
+  run sudo mixer build all
   [[ $status -eq 0 ]]
 
   # Verify that previous is incorrect

--- a/mixin/build.go
+++ b/mixin/build.go
@@ -69,9 +69,7 @@ func buildBundles(b *builder.Builder) error {
 		}
 		template = helpers.CreateCertTemplate()
 	}
-	// Always wipe /image and /www because mixver will only be incremented if the last
-	// build was valid, so the user may end up using bad data if it's not cleaned.
-	return errors.Wrap(b.BuildBundles(template, privkey, false, true, retriesDefault), "Error building bundles")
+	return errors.Wrap(b.BuildBundles(template, privkey, false, retriesDefault), "Error building bundles")
 }
 
 func mergeMoMs(mixWS string, mixVer, lastVer int) error {


### PR DESCRIPTION
Existing image and output directories for the current mix version will
be removed when building a mix. This prevents mixer from building on top
of directories contaminated by a prior mix.

Fixes #669