### PR TITLE
Handle optional bundles

### DIFF
--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -409,7 +409,7 @@ func resolvePackages(numWorkers int, set bundleSet, packagerCmd []string, emptyD
 			// fail in the actual install to the full chroot.
 			outBuf, _ := helpers.RunCommandOutputEnv(queryString[0], queryString[1:], []string{"LC_ALL=en_US.UTF-8"})
 			rpm, e := repoPkgFromNoopInstall(outBuf.String())
-			if !isEmptyBundle(bundle) && e != nil {
+			if len(bundle.AllPackages) != 0 && e != nil {
 				e = errors.Wrapf(e, bundle.Name)
 				fmt.Println(e)
 				errorCh <- e

--- a/builder/bundleset.go
+++ b/builder/bundleset.go
@@ -408,14 +408,3 @@ func parseBundle(contents []byte) (*bundle, error) {
 
 	return &b, nil
 }
-
-func isEmptyBundle(bundle *bundle) bool {
-	if len(bundle.DirectIncludes) == 0 &&
-		len(bundle.OptionalIncludes) == 0 &&
-		len(bundle.DirectPackages) == 0 &&
-		len(bundle.AllPackages) == 0 &&
-		len(bundle.Files) == 0 {
-		return true
-	}
-	return false
-}


### PR DESCRIPTION
Currently, build bundles generates an error if one of the mix bundles
has only an 'also-add()' entry in its definition.

Instead, build bundles should not error out and must process such
bundles.

Fixes #718

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>