### PR TITLE
Export flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
 #    - TEST_DIR=build-validate
     - TEST_DIR=bundle-commands
     - TEST_DIR=clean-rebuild
+    - TEST_DIR=content-chroot
     - TEST_DIR=config-conversion
     - TEST_DIR=contentsize-check
 #    - TEST_DIR=create-mix-bump-version-add-remove-bundles
@@ -25,6 +26,7 @@ env:
     - TEST_DIR=create-mix-with-upstream-bundles
     - TEST_DIR=customize-os-release
     - TEST_DIR=clr-installer-config
+    - TEST_DIR=export-flag
     - TEST_DIR=manual-format-bump-flow
     - TEST_DIR=manual-upstream-format-bump-flow
     - TEST_DIR=mixin-repo-commands

--- a/bat/tests/export-flag/Makefile
+++ b/bat/tests/export-flag/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check clean
+
+check:
+	bats ./run.bats
+
+CLEANDIRS = ./update ./test-chroot ./logs ./.repos ./bundles ./update ./mix-bundles ./clr-bundles ./local-yum ./results ./repodata ./local-rpms ./upstream-bundles ./local-bundles ./custom-content
+CLEANFILES = ./*.log ./run.bats.trs ./yum.conf.in ./builder.conf ./mixer.state ./.{c,m}* *.pem .yum-mix.conf mixversion upstreamurl upstreamversion mixbundles
+clean:
+	sudo rm -rf $(CLEANDIRS) $(CLEANFILES)

--- a/bat/tests/export-flag/description.txt
+++ b/bat/tests/export-flag/description.txt
@@ -1,0 +1,4 @@
+export-flag
+====================
+This test simulates the usage of un-export() keyword in a bundle definition file and validates the manifests for correct
+setting of the export flag 'x'.

--- a/bat/tests/export-flag/run.bats
+++ b/bat/tests/export-flag/run.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+# shared test functions
+load ../../lib/mixerlib
+
+setup() {
+  global_setup
+}
+
+@test "Create mix 10 with un-export flag" {
+
+  mixer-init-stripped-down "$CLRVER" 10
+
+  # Create local bundle definition with a package and un-export file path
+  create-empty-local-bundle "bundle1"
+  add-package-to-local-bundle "bsdiff" "bundle1"
+  mixer-bundle-add "bundle1"
+
+  mixer-build-bundles > "$LOGDIR"/build_bundles.log
+  mixer-build-update > "$LOGDIR"/build_update.log
+
+  # Verify that manifest contains the export flags for the bsdiff files
+  grep -P "F..x\t[A-Za-z0-9]*\t10\t/usr/bin/bsdiff" update/www/10/Manifest.bundle1 # should have export flag
+  grep -P "F..x\t[A-Za-z0-9]*\t10\t/usr/bin/bspatch" update/www/10/Manifest.bundle1 # should have export flag
+
+  mixer versions update
+  echo "un-export(/usr/bin/bsdiff)" >> "$LOCAL_BUNDLE_DIR"/bundle1
+  mixer-build-bundles > "$LOGDIR"/build_bundles.log
+  mixer-build-update > "$LOGDIR"/build_update.log
+  grep -P "F..\.\t[A-Za-z0-9]*\t20\t/usr/bin/bsdiff" update/www/20/Manifest.bundle1 # should not have export flag
+  grep -P "F..x\t[A-Za-z0-9]*\t10\t/usr/bin/bspatch" update/www/20/Manifest.bundle1 # should have export flag
+
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/builder/bundle_control.go
+++ b/builder/bundle_control.go
@@ -749,9 +749,10 @@ const bundleTemplateFormat = `# [TITLE]: %s
 # [MAINTAINER]: 
 # 
 # List packages one per line.
-# includes have format:        include(bundle)
-# also-adds have format:       also-add(bundle)
-# content chroots have format: content(path) 
+# includes have format:            include(bundle)
+# also-adds have format:           also-add(bundle)
+# content chroots have format:     content(path)
+# un-exportable files have format: un-export(path)
 `
 
 func createBundleFile(bundle string, path string) error {

--- a/builder/bundles_test.go
+++ b/builder/bundles_test.go
@@ -84,12 +84,12 @@ func TestAddContentChroots(t *testing.T) {
 			expectedSet: &bundleSet{
 				"bundle1": &bundle{
 					Files: map[string]bool{
-						"/usr": true, "/usr/unique": true, "/file": true, "/uniqueFile": true,
-						"/fileLink": true, "/dirLink": true, "/usr/unique2": true,
+						"/usr": false, "/usr/unique": false, "/file": false, "/uniqueFile": false,
+						"/fileLink": false, "/dirLink": false, "/usr/unique2": false,
 					},
 				},
 				"bundle2": &bundle{
-					Files: map[string]bool{"/usr": true, "/usr/unique3": true},
+					Files: map[string]bool{"/usr": false, "/usr/unique3": false},
 				},
 			},
 			shouldFail: false,

--- a/builder/bundleset.go
+++ b/builder/bundleset.go
@@ -34,6 +34,7 @@ type bundle struct {
 	/* hidden property, not to be included in file usr/share/clear/allbundles */
 	AllRpms        map[string]packageMetadata `json:"-"`
 	ContentChroots map[string]bool            `json:"-"`
+	UnExport       map[string]bool            `json:"-"`
 }
 
 type bundleSet map[string]*bundle
@@ -311,6 +312,7 @@ func parseBundle(contents []byte) (*bundle, error) {
 	var includes, packages, optional []string
 
 	b.ContentChroots = make(map[string]bool)
+	b.UnExport = make(map[string]bool)
 
 	line := 0
 	for scanner.Scan() {
@@ -374,6 +376,12 @@ func parseBundle(contents []byte) (*bundle, error) {
 				return nil, fmt.Errorf("Invalid content path %q in line %d", text, line)
 			}
 			b.ContentChroots[text] = true
+		} else if strings.HasPrefix(text, "un-export(") {
+			if !strings.HasSuffix(text, ")") {
+				return nil, fmt.Errorf("Missing end parenthesis in line %d: %q", line, text)
+			}
+			text = text[10 : len(text)-1]
+			b.UnExport[text] = true
 		} else {
 			if !validPackageNameRegex.MatchString(text) {
 				return nil, fmt.Errorf("Invalid package name %q in line %d", text, line)

--- a/mixin/build.go
+++ b/mixin/build.go
@@ -102,7 +102,7 @@ func mergeMoMs(mixWS string, mixVer, lastVer int) error {
 		}
 		// remove overlapping bundle names including os-core
 		excludeName(upstreamMoM, mixerMoM.Files[i].Name)
-		mixerMoM.Files[i].Rename = swupd.MixManifest
+		mixerMoM.Files[i].Misc = swupd.MiscMixManifest
 		upstreamMoM.Files = append(upstreamMoM.Files, mixerMoM.Files[i])
 	}
 

--- a/swupd-inspector/diff.go
+++ b/swupd-inspector/diff.go
@@ -194,13 +194,13 @@ func runDiff(cacheDir string, flags *diffFlags, urlA, urlB string) {
 				if flagString(a) != flagString(b) {
 					fmt.Printf("%s-%s %s%s\n", RED, flagString(a), a.Name, RESET)
 					fmt.Printf("%s+%s %s%s\n", GREEN, flagString(b), b.Name, RESET)
-				} else if a.Rename != b.Rename || a.Hash != b.Hash || (flags.strict && a.Version != b.Version) {
+				} else if a.Misc != b.Misc || a.Hash != b.Hash || (flags.strict && a.Version != b.Version) {
 					fmt.Printf(" %s %s", flagString(a), a.Name)
 					if flags.strict && a.Version != b.Version {
 						fmt.Printf(" (VERSION: %s-%d%s / %s+%d%s)", RED, a.Version, RESET, GREEN, b.Version, RESET)
 					}
-					if a.Rename != b.Rename {
-						fmt.Printf(" (RENAME: %s-%d%s / %s+%d%s)", RED, a.Rename, RESET, GREEN, b.Rename, RESET)
+					if a.Misc != b.Misc {
+						fmt.Printf(" (RENAME: %s-%d%s / %s+%d%s)", RED, a.Misc, RESET, GREEN, b.Misc, RESET)
 					}
 					if a.Hash != b.Hash {
 						fmt.Printf(" (HASH: %s-%s%s / %s+%s%s)", RED, a.Hash.String()[:7], RESET, GREEN, b.Hash.String()[:7], RESET)

--- a/swupd/bundleinfo.go
+++ b/swupd/bundleinfo.go
@@ -50,7 +50,7 @@ func (m *Manifest) GetBundleInfo(stateDir, path string) error {
 	var err error
 	if _, err = os.Stat(path); os.IsNotExist(err) {
 		basePath := filepath.Dir(path)
-		err = m.getBundleInfoFromChroot(filepath.Join(filepath.Dir(path), m.Name))
+		err = m.getBundleInfoFromChroot(filepath.Join(basePath, m.Name))
 		if err != nil {
 			return err
 		}
@@ -91,7 +91,12 @@ func (m *Manifest) GetBundleInfo(stateDir, path string) error {
 			if !strings.HasPrefix(f, "/") {
 				return fmt.Errorf("invalid extra file %s in %s, must start with '/'", f, extraFilesPath)
 			}
-			m.BundleInfo.Files[f] = true
+
+			// NOTE: The export flag is always set to false here and builder.isExportable() is intentionally not called.
+			// This is done to avoid dependency of 'build update' to any steps/artifacts prior to 'build bundles'.
+			// Ideally, 'build update' should work from the output of 'build bundles' and should not use artifacts
+			// like bundle definitions directly.
+			m.BundleInfo.Files[f] = false
 		}
 	}
 
@@ -108,7 +113,13 @@ func (m *Manifest) getBundleInfoFromChroot(rootPath string) error {
 
 	err := filepath.Walk(rootPath, func(path string, fi os.FileInfo, err error) error {
 		fname := strings.TrimPrefix(path, rootPath)
-		m.BundleInfo.Files[fname] = true
+
+		// NOTE: The export flag is always set to false here and builder.isExportable() is intentionally not called.
+		// This is done to avoid dependency of 'build update' to any steps/artifacts prior to 'build bundles'.
+		// Ideally, 'build update' should work from the output of 'build bundles' and should not use artifacts
+		// like bundle definitions directly.
+		m.BundleInfo.Files[fname] = false
+
 		return nil
 	})
 

--- a/swupd/files.go
+++ b/swupd/files.go
@@ -90,6 +90,7 @@ const (
 	MiscUnset       MiscFlag = iota
 	MiscRename               // deprecated
 	MiscMixManifest          // indicates manifest from mixer integrated swupd-client so that swupd-client can hardlink instead of curling
+	MiscExportFile           // indicates file that can be exported in swupd-client
 )
 
 // File represents an entry in a manifest
@@ -201,6 +202,8 @@ func miscFromFlag(flag byte) (MiscFlag, error) {
 		return MiscUnset, nil
 	case 'm':
 		return MiscMixManifest, nil
+	case 'x':
+		return MiscExportFile, nil
 	default:
 		return MiscUnset, fmt.Errorf("invalid file rename flag: %v", flag)
 	}
@@ -241,11 +244,12 @@ func (f *File) GetFlagString() (string, error) {
 		return "", fmt.Errorf("no flags are set on file %s", f.Name)
 	}
 
-	// only write a '.' or 'm' to a manifest
 	// the 'r' flag is deprecated
 	miscByte := byte('.')
 	if f.Misc == MiscMixManifest {
 		miscByte = 'm'
+	} else if f.Misc == MiscExportFile {
+		miscByte = 'x'
 	}
 
 	flagBytes := []byte{

--- a/swupd/files_test.go
+++ b/swupd/files_test.go
@@ -119,25 +119,25 @@ func TestModifierFromFlag(t *testing.T) {
 	})
 }
 
-func TestRenameFromFlag(t *testing.T) {
+func TestMiscFromFlag(t *testing.T) {
 	testCases := []struct {
 		flag     byte
-		expected RenameFlag
+		expected MiscFlag
 	}{
-		{'r', RenameSet},
-		{'.', RenameUnset},
+		{'r', MiscRename},
+		{'.', MiscUnset},
 	}
 
 	for _, tc := range testCases {
 		t.Run(string(tc.flag), func(t *testing.T) {
 			f := File{}
 			var err error
-			if f.Rename, err = renameFromFlag(tc.flag); err != nil {
+			if f.Misc, err = miscFromFlag(tc.flag); err != nil {
 				t.Errorf("failed to set %v rename flag on file", tc.flag)
 			}
 
-			if f.Rename != tc.expected {
-				t.Errorf("file rename was set to %v from %v flag", f.Rename, tc.flag)
+			if f.Misc != tc.expected {
+				t.Errorf("file rename was set to %v from %v flag", f.Misc, tc.flag)
 			}
 		})
 	}
@@ -146,11 +146,11 @@ func TestRenameFromFlag(t *testing.T) {
 	t.Run("' '", func(t *testing.T) {
 		f := File{}
 		var err error
-		if f.Rename, err = renameFromFlag(' '); err == nil {
-			t.Error("setRenameFromFlag did not fail with invalid input")
+		if f.Misc, err = miscFromFlag(' '); err == nil {
+			t.Error("setMiscFromFlag did not fail with invalid input")
 		}
 
-		if f.Rename != RenameUnset {
+		if f.Misc != MiscUnset {
 			t.Error("file rename was set to true from invalid flag")
 		}
 	})

--- a/swupd/filesystem.go
+++ b/swupd/filesystem.go
@@ -41,6 +41,15 @@ func (m *Manifest) createFileRecord(rootPath, path, removePrefix string, fi os.F
 		return nil
 	}
 
+	if flag, ok := m.BundleInfo.Files[path]; ok {
+		if flag == true {
+			// set Misc flag
+			if file.Misc, err = miscFromFlag('x'); err != nil {
+				return err
+			}
+		}
+	}
+
 	m.AppendFile(file)
 
 	return nil

--- a/swupd/helpers_test.go
+++ b/swupd/helpers_test.go
@@ -454,7 +454,7 @@ func (fs *testFileSystem) addToBundleInfo(version uint32, bundle, file string) {
 		fs.t.Fatal(err)
 	}
 
-	bi.Files[file] = true
+	bi.Files[file] = false
 
 	b, err := json.Marshal(&bi)
 	if err != nil {

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -389,7 +389,7 @@ func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, minVersion uint32) 
 				nx++
 				continue
 			}
-			if nf.Hash == of.Hash && of.Version >= minVersion {
+			if nf.Hash == of.Hash && of.Version >= minVersion && nf.Misc == of.Misc {
 				// same contents, version doesn't change.
 				nf.Version = of.Version
 			} else {
@@ -650,7 +650,7 @@ func (m *Manifest) addManifestFiles(ui UpdateInfo, c config) error {
 		for f := range m.BundleInfo.Files {
 			isIncluded := false
 			for _, inc := range includes {
-				if inc.BundleInfo.Files[f] {
+				if _, ok := inc.BundleInfo.Files[f]; ok {
 					isIncluded = true
 					break
 				}

--- a/swupd/manifest_test.go
+++ b/swupd/manifest_test.go
@@ -183,7 +183,7 @@ func TestReadManifestFileEntry(t *testing.T) {
 		}
 
 		for _, f := range m.Files {
-			if f.Type == 0 || f.Status == 0 || f.Modifier == 0 || f.Rename == RenameUnset {
+			if f.Type == 0 || f.Status == 0 || f.Modifier == 0 || f.Misc == MiscUnset {
 				t.Error("failed to set flag from manifest line")
 			}
 		}

--- a/swupd/rename.go
+++ b/swupd/rename.go
@@ -97,8 +97,8 @@ func renameDetection(manifest *Manifest, added []*File, removed []*File, c confi
 func linkRenamePair(renameTo, renameFrom *File) {
 	renameTo.DeltaPeer = renameFrom
 	renameFrom.DeltaPeer = renameTo
-	renameTo.Rename = RenameSet
-	renameFrom.Rename = RenameSet
+	renameTo.Misc = MiscRename
+	renameFrom.Misc = MiscRename
 }
 
 // trimRenamed returns an slice which has had files with DeltaPeers purged


### PR DESCRIPTION
- Change RenameFlag to MiscFlag
    Change RenameFlag to MiscFlag since "rename" has been deprecated and
    this flag will be used as a placeholder for various other flags.

- Introduce new export flag in manifests
    By default, files with the prefix "/bin/", "/usr/bin/" and "/usr/local/bin/"
    will have a new export flag "x" in the 4th byte of the flag section of the Manifest.
    The user can override this by using a new keyword "un-export()" in
    the bundle definition file.
    E.g. un-export(/usr/bin/file2)
    Fixes #708