### PR TITLE
Initialize local yum repo

### DIFF
--- a/builder/build_validate.go
+++ b/builder/build_validate.go
@@ -126,6 +126,10 @@ func (b *Builder) CheckManifestCorrectness(fromVer, toVer, downloadRetries, tabl
 		os.Stdout = stdOut
 	}()
 
+	if err := b.NewDNFConfIfNeeded(); err != nil {
+		return err
+	}
+
 	// Load initial repo map
 	if err := b.ListRepos(); err != nil {
 		return err


### PR DESCRIPTION
Newer versions of DNF require that yum repos are initialized, so Mixer
must initialize the local repo, even when it's empty.

Fixes #731

Signed-off-by: John Akre <john.w.akre@intel.com>