### PR TITLE
Don't follow symlinks when comparing content/full chroots

### DIFF
--- a/builder/bundles.go
+++ b/builder/bundles.go
@@ -894,7 +894,7 @@ func addBundleContentChroots(set *bundleSet, fullDir string) error {
 
 				// When the content chroot file exists in the full chroot verify that they
 				// are the same.
-				if fullInfo, err := os.Stat(fullChrootFile); err == nil {
+				if fullInfo, err := os.Lstat(fullChrootFile); err == nil {
 					if fullInfo.IsDir() && fi.IsDir() {
 						if fullInfo.Mode() != fi.Mode() {
 							return errors.Errorf("Directory permission mismatch: %s, %s", fullChrootFile, path)


### PR DESCRIPTION
When comparing files between content and full chroots, do not follow
symlinks so that the links can be compared.

Fixes #739

Signed-off-by: John Akre <john.w.akre@intel.com>