### PR TITLE
Handle MCA bundle deletion during format bump

### DIFF
--- a/builder/build_validate.go
+++ b/builder/build_validate.go
@@ -250,7 +250,11 @@ func (b *Builder) mcaManInfo(version int) ([]*swupd.Manifest, error) {
 		if err != nil {
 			return nil, err
 		}
-
+		// skip bundle if bundleInfo is empty for that bundle Manifest, it indicates the bundle is deleted and should
+		// not be added to Manifests list
+		if manifest.BundleInfo.Name == "" {
+			continue
+		}
 		manifests = append(manifests, manifest)
 	}
 


### PR DESCRIPTION
when bundle is deleted from a mix, bundle info file is not generated for that
bundle. When parsing the manifest if bundle info is empty, consider that
bundle to be deleted in the mix and do not resolve packages for that
bundle during build validation process. 

fixes #743

Signed-off-by: Ashlesha Atrey <ashlesha.atrey@intel.com>