### PR TITLE
Fix permission issue in bat test

### DIFF
--- a/bat/tests/content-chroot/run.bats
+++ b/bat/tests/content-chroot/run.bats
@@ -17,14 +17,14 @@ setup() {
   sudo chown root:root "$customDir"/usr
   sudo chown root:root "$customDir"/usr/bin
   mkdir -m 777  "$customDir"/dirPerm
-  chown 1000:1000 "$customDir"/dirPerm
+  sudo chown 1000:1000 "$customDir"/dirPerm
   sudo touch "$customDir"/usr/bin/foo
   sudo chmod 777 "$customDir"/usr/bin/foo
   sudo chown 1000:1000 "$customDir"/usr/bin/foo
   ln -s usr "$customDir"/dirLink
-  chown -h 1000:1000 "$customDir"/dirLink
+  sudo chown -h 1000:1000 "$customDir"/dirLink
   ln -s usr/bin/foo "$customDir"/fileLink
-  chown -h 1000:1000 "$customDir"/fileLink
+  sudo chown -h 1000:1000 "$customDir"/fileLink
 
   # Create a file/dir with setuid, setgid, and sticky perms
   touch "$customDir"/specialPermsFile


### PR DESCRIPTION
Currently, the "content-chroot" bat test is failing even locally due to permission issue. 
This PR fixes the issue for local runs.

It still fails in Travis for other reasons which is still being investigated.

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>