### PR TITLE
Remove the --no-publish flag

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -76,8 +76,6 @@ type UpdateParameters struct {
 	MinVersion int
 	// Format version used in this update
 	Format string
-	// Update latest format version and image version files to current mix
-	Publish bool
 	// Skip signing Manifest.MoM
 	SkipSigning bool
 	// Skip fullfiles generation
@@ -370,11 +368,6 @@ func (b *Builder) BuildUpdate(params UpdateParameters) error {
 		if err != nil {
 			return errors.Wrapf(err, "couldn't write upstreamver file")
 		}
-	}
-
-	// Publish. Update the latest version file in various locations.
-	if !params.Publish {
-		return nil
 	}
 
 	fmt.Printf("Setting latest version to %s\n", b.MixVer)

--- a/docs/mixer.build.1
+++ b/docs/mixer.build.1
@@ -108,16 +108,6 @@ tells \fBmixer\fP to regenerate all mix content starting from a certain
 version. \fBmixer\fP will not use any OS content from a version older than
 the min\-version passed here.
 .IP \(bu 2
-\fB\-\-no\-publish\fP
-.sp
-Do not update the LAST_VER file after the update. Any \fBswupd\fP client
-configured to update from the mix will not be made aware of the new mix
-version and will therefore not attempt an update.
-.UNINDENT
-.UNINDENT
-.UNINDENT
-.INDENT 0.0
-.IP \(bu 2
 \fB\-\-no\-signing\fP
 .sp
 Do not generate a certificate and do not sign the Manifest.MoM
@@ -305,16 +295,6 @@ Supply minimum version for \fBmixer\fP to use old content from. This option
 tells \fBmixer\fP to regenerate all mix content starting from a certain
 version. \fBmixer\fP will not use any OS content from a version older than
 the min\-version passed here.
-.IP \(bu 2
-\fB\-\-no\-publish\fP
-.sp
-Do not update the LAST_VER file after the update. Any \fBswupd\fP client
-configured to update from the mix will not be made aware of the new mix
-version and will therefore not attempt an update.
-.UNINDENT
-.UNINDENT
-.UNINDENT
-.INDENT 0.0
 .IP \(bu 2
 \fB\-\-no\-signing\fP
 .sp

--- a/docs/mixer.build.1.rst
+++ b/docs/mixer.build.1.rst
@@ -92,12 +92,6 @@ SUBCOMMANDS
       version. ``mixer`` will not use any OS content from a version older than
       the min-version passed here.
 
-    - ``--no-publish``
-
-      Do not update the LAST_VER file after the update. Any ``swupd`` client
-      configured to update from the mix will not be made aware of the new mix
-      version and will therefore not attempt an update.
-
    - ``--no-signing``
 
      Do not generate a certificate and do not sign the Manifest.MoM
@@ -252,12 +246,6 @@ SUBCOMMANDS
       tells ``mixer`` to regenerate all mix content starting from a certain
       version. ``mixer`` will not use any OS content from a version older than
       the min-version passed here.
-
-    - ``--no-publish``
-
-      Do not update the LAST_VER file after the update. Any ``swupd`` client
-      configured to update from the mix will not be made aware of the new mix
-      version and will therefore not attempt an update.
 
    - ``--no-signing``
 

--- a/mixer/cmd/build.go
+++ b/mixer/cmd/build.go
@@ -42,7 +42,6 @@ type buildCmdFlags struct {
 	minVersion      int
 	noSigning       bool
 	downloadRetries int
-	noPublish       bool
 	template        string
 	skipFullfiles   bool
 	skipPacks       bool
@@ -364,7 +363,6 @@ var buildFormatOldCmd = &cobra.Command{
 		params := builder.UpdateParameters{
 			MinVersion:    buildFlags.minVersion,
 			Format:        b.State.Mix.Format,
-			Publish:       !buildFlags.noPublish,
 			SkipSigning:   buildFlags.noSigning,
 			SkipFullfiles: buildFlags.skipFullfiles,
 			SkipPacks:     buildFlags.skipPacks,
@@ -442,7 +440,6 @@ var buildFormatNewCmd = &cobra.Command{
 		params := builder.UpdateParameters{
 			MinVersion:    minver,
 			Format:        buildFlags.newFormat,
-			Publish:       !buildFlags.noPublish,
 			SkipSigning:   buildFlags.noSigning,
 			SkipFullfiles: buildFlags.skipFullfiles,
 			SkipPacks:     buildFlags.skipPacks,
@@ -482,7 +479,6 @@ var buildUpdateCmd = &cobra.Command{
 		params := builder.UpdateParameters{
 			MinVersion:    buildFlags.minVersion,
 			Format:        buildFlags.format,
-			Publish:       !buildFlags.noPublish,
 			SkipSigning:   buildFlags.noSigning,
 			SkipFullfiles: buildFlags.skipFullfiles,
 			SkipPacks:     buildFlags.skipPacks,
@@ -535,7 +531,6 @@ var buildAllCmd = &cobra.Command{
 		params := builder.UpdateParameters{
 			MinVersion:    buildFlags.minVersion,
 			Format:        buildFlags.format,
-			Publish:       !buildFlags.noPublish,
 			SkipSigning:   buildFlags.noSigning,
 			SkipFullfiles: buildFlags.skipFullfiles,
 			SkipPacks:     buildFlags.skipPacks,
@@ -744,7 +739,6 @@ func setUpdateFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&buildFlags.increment, "increment", false, "Automatically increment the mixversion post build")
 	cmd.Flags().IntVar(&buildFlags.minVersion, "min-version", 0, "Supply minversion to build update with")
 	cmd.Flags().BoolVar(&buildFlags.noSigning, "no-signing", false, "Do not generate a certificate and do not sign the Manifest.MoM")
-	cmd.Flags().BoolVar(&buildFlags.noPublish, "no-publish", false, "Do not update the latest version after update")
 	cmd.Flags().BoolVar(&buildFlags.skipFullfiles, "skip-fullfiles", false, "Do not generate fullfiles")
 	cmd.Flags().BoolVar(&buildFlags.skipPacks, "skip-packs", false, "Do not generate zero packs")
 


### PR DESCRIPTION
Mixer will now always update the LAST_VER file after `build update`.
This file is used by `build validate` (MCA) to determine whether
the version in comparison is a +10.

Fixes #735

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>