### PR TITLE
Update github actions to v2

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -9,9 +9,10 @@ on: [push, pull_request]
 jobs:
   pre-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run linter and unit tests
         uses: ./
         with:
@@ -20,9 +21,10 @@ jobs:
   build-all-delta-packs:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -33,9 +35,10 @@ jobs:
   build-delta-manifests:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -46,9 +49,10 @@ jobs:
   build-multiple-delta-packs:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -59,9 +63,10 @@ jobs:
   bundle-commands:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -72,9 +77,10 @@ jobs:
   clean-rebuild:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -85,9 +91,10 @@ jobs:
   content-chroot:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -98,9 +105,10 @@ jobs:
   config-conversion:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -111,9 +119,10 @@ jobs:
   contentsize-check:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -124,9 +133,10 @@ jobs:
   update-mix-add-remove-bundles:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -137,9 +147,10 @@ jobs:
   create-mix-with-blended-content:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -150,9 +161,10 @@ jobs:
   create-mix-with-custom-content:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -163,9 +175,10 @@ jobs:
   customize-os-release:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -176,9 +189,10 @@ jobs:
   clr-installer-config:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -189,9 +203,10 @@ jobs:
   export-flag:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -202,9 +217,10 @@ jobs:
   manual-format-bump-flow:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -215,9 +231,10 @@ jobs:
   manual-upstream-format-bump-flow:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -228,9 +245,10 @@ jobs:
   no-delta-manifests-over-format-bump:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -241,9 +259,10 @@ jobs:
   no-delta-packs-over-format-bump:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -254,9 +273,10 @@ jobs:
   no-state-variables-in-full:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -267,9 +287,10 @@ jobs:
   state-conversion:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -280,9 +301,10 @@ jobs:
   test-format-bump:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -293,9 +315,10 @@ jobs:
   upstream-format-bump:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -306,9 +329,10 @@ jobs:
   update-mixver-offline:
     needs: pre-check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run bat test
         uses: ./
         env: 
@@ -319,9 +343,10 @@ jobs:
 #  build-validate:
 #    needs: pre-check
 #    runs-on: ubuntu-latest
+#    timeout-minutes: 30
 #    steps:
 #      - name: Checkout
-#        uses: actions/checkout@v1
+#        uses: actions/checkout@v2
 #      - name: Run bat test
 #        uses: ./
 #        env:


### PR DESCRIPTION
Update github actions to v2 to handle re-runs.
Also, introduce a timeout of 30 mins for each job.

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>