### PR TITLE
Update man page to include `format` flag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ GO_PACKAGE_PREFIX := github.com/clearlinux/mixer-tools
 GOPATH ?= ${HOME}/go
 gopath = $(shell go env GOPATH)
 
-.PHONY: build install clean check
+.PHONY: build install clean check man
 
 .DEFAULT_GOAL := build
 
-build:
+build: man
 	go install -mod=vendor -ldflags="-X ${GO_PACKAGE_PREFIX}/builder.Version=${VERSION}" ${GO_PACKAGE_PREFIX}/mixer
 	go install -mod=vendor ${GO_PACKAGE_PREFIX}/swupd-extract
 	go install -mod=vendor ${GO_PACKAGE_PREFIX}/swupd-inspector
@@ -79,6 +79,6 @@ MANPAGES = \
 
 man: $(MANPAGES)
 
-% : %.rst
+$(MANPAGES): %: %.rst
 	mkdir -p "$$(dirname $@)"
 	rst2man.py "$<" > "$@.tmp" && mv -f "$@.tmp" "$@"

--- a/docs/mixer.init.1
+++ b/docs/mixer.init.1
@@ -59,6 +59,10 @@ Upstream version used to compose the mix. It must be either an integer or \(aqla
 .sp
 Supply a specific configuration file at \fIpath\fP to use for mixing.
 .IP \(bu 2
+\fB\-\-format {format}\fP
+.sp
+Supply the format version for the mix.
+.IP \(bu 2
 \fB\-\-git\fP
 .sp
 Track mixer\(aqs internal work directory with git.

--- a/docs/mixer.init.1.rst
+++ b/docs/mixer.init.1.rst
@@ -44,6 +44,10 @@ more details), the following options are recognized.
 
    Supply a specific configuration file at `path` to use for mixing.
 
+-  ``--format {format}``
+
+   Supply the format version for the mix.
+
 -  ``--git``
 
    Track mixer's internal work directory with git.


### PR DESCRIPTION
Update man page to include `format` flag.

Also, update Makefile to build man pages as a prerequisite for the `build` target.

Fixes #557

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>