### PR TITLE
Fix generated warning for delta packs

### DIFF
--- a/builder/deltapacks.go
+++ b/builder/deltapacks.go
@@ -84,7 +84,7 @@ func createDeltaPacks(fromMoM *swupd.Manifest, toMoM *swupd.Manifest, printRepor
 
 				if len(info.Warnings) > 0 {
 					for _, w := range info.Warnings {
-						log.Warning(log.Mixer, "    Bundle %s: %s", b.Name, w)
+						log.Warning(log.Mixer, "Bundle %s: %s", b.Name, w)
 					}
 				}
 				report := fmt.Sprintf("  Finished delta pack for bundle %q from %d to %d\n", b.Name, b.FromVersion, b.ToVersion)

--- a/swupd/packs.go
+++ b/swupd/packs.go
@@ -294,7 +294,10 @@ func WritePack(w io.Writer, fromManifest, toManifest *Manifest, outputDir, chroo
 
 func copyFromDelta(tw *tar.Writer, delta *Delta) (fallback bool, err error) {
 	f, err := os.Open(delta.Path)
-	if err != nil {
+	if os.IsNotExist(err) {
+		log.Debug(log.Mixer, err.Error())
+		return true, nil
+	} else if err != nil {
 		return true, err
 	}
 	defer func() {


### PR DESCRIPTION
While creating delta packs, only possible delta files are found.
If delta file is not found, log the error in debug mode instead
of generating warning, as delta might not have been
created for valid reason.

fixes #628
Signed-off-by: Ashlesha Atrey ashlesha.atrey@intel.com