### PR TITLE
Fix setting of log location with custom config

### DIFF
--- a/mixer/cmd/root.go
+++ b/mixer/cmd/root.go
@@ -49,6 +49,15 @@ var RootCmd = &cobra.Command{
 			}
 		}
 
+		// When the logFile flag is not specified, try to initialize it
+		// from the config when available.
+		if rootCmdFlags.logFile == "" {
+			b, err := builder.NewFromConfig(configFile)
+			if err == nil {
+				rootCmdFlags.logFile = b.Config.Mixer.LogFilePath
+			}
+		}
+
 		if rootCmdFlags.logFile != "" {
 			// Configure logger
 			_, err := log.SetOutputFilename(rootCmdFlags.logFile)
@@ -109,15 +118,9 @@ func Execute() {
 }
 
 func init() {
-	defaultFile := ""
-	b, err := builder.NewFromConfig(configFile)
-	if err == nil {
-		defaultFile = b.Config.Mixer.LogFilePath
-	}
-
 	RootCmd.PersistentFlags().StringVar(&rootCmdFlags.cpuProfile, "cpu-profile", "", "write CPU profile to a file")
 	_ = RootCmd.PersistentFlags().MarkHidden("cpu-profile")
-	RootCmd.PersistentFlags().StringVar(&rootCmdFlags.logFile, "log", defaultFile, "Write logs to a file")
+	RootCmd.PersistentFlags().StringVar(&rootCmdFlags.logFile, "log", "", "Write logs to a file")
 	RootCmd.PersistentFlags().IntVar(&rootCmdFlags.logLevel, "log-level", 4, "Set the log level between 1-5")
 	// TODO: Remove this once we migrate to new implementation.
 	unusedBoolFlag := false


### PR DESCRIPTION
When mixer's -c/--config option was used, the referenced config was read
too late to set a default log location. As a result, the log location
was always set to the empty string (disabling logging), that is, unless
--log VALUE was specified, or if mixer's current working directory
contained a builder.conf with LOG defined.

The root cause of this bug is an order-of-operations issue with cobra
integration; fix the issue by setting the log location in
PersistentPreRunE() instead of init(), ensuring that the command line
arguments have been processed, with `configFile` being set to the
-c/--config value if specified.