### PR TITLE
fix missing files in packs

### DIFF
--- a/swupd/packs.go
+++ b/swupd/packs.go
@@ -296,7 +296,7 @@ func copyFromDelta(tw *tar.Writer, delta *Delta) (fallback bool, err error) {
 	f, err := os.Open(delta.Path)
 	if os.IsNotExist(err) {
 		log.Debug(log.Mixer, err.Error())
-		return true, nil
+		return true, err
 	} else if err != nil {
 		return true, err
 	}


### PR DESCRIPTION
we need to not return "nil" if a delta file is missing, because that causes the caller
to not use the fallback option (which would include the full file)...
and we need the fallback option to have a complete pack

Signed-off-by: Arjan van de Ven <arjan@linux.intel.com>