### PR TITLE
Skip delta creation for pure rename case

### DIFF
--- a/swupd/delta.go
+++ b/swupd/delta.go
@@ -341,6 +341,11 @@ func findDeltas(c *config, oldManifest, newManifest *Manifest) ([]Delta, error) 
 			continue
 		}
 
+		// If from/to hashes are equal, this a pure rename case, so skip delta creation
+		if from.Hash == to.Hash {
+			continue
+		}
+
 		seen[path] = true
 		deltas = append(deltas, Delta{
 			Path: path,


### PR DESCRIPTION
The change in 73bf833128 resulted in "pure rename" deltas not being
added to packs, but we can go one step further by not queuing these
deltas to be created in the first place, saving some cycles.