### PR TITLE
Revert "skip pure renames"

### DIFF
--- a/swupd/packs.go
+++ b/swupd/packs.go
@@ -220,10 +220,6 @@ func WritePack(w io.Writer, fromManifest, toManifest *Manifest, outputDir, chroo
 			// fallback to use the fullfile later.
 			if fallback {
 				info.Warnings = append(info.Warnings, err.Error())
-				// if the hash has not changed, it's a rename and those don't need to be in the pack
-				if d.to.Hash == d.from.Hash {
-					hasDelta[d.to.Hash] = d
-				}
 				continue
 			}
 			return nil, err


### PR DESCRIPTION
this is triggering a client bug; lets revert until we get to the bottom of that

This reverts commit 73bf833128353c94d1ba44a8e1fc6674318f890b.