### PR TITLE
Pin the from/to versions in the delta filename

### DIFF
--- a/swupd/delta.go
+++ b/swupd/delta.go
@@ -334,7 +334,7 @@ func findDeltas(c *config, oldManifest, newManifest *Manifest) ([]Delta, error) 
 		from := nf.DeltaPeer
 		to := nf
 		dir := filepath.Join(c.outputDir, fmt.Sprint(to.Version), "delta")
-		name := fmt.Sprintf("%d-%d-%s-%s", from.Version, to.Version, from.Hash, to.Hash)
+		name := fmt.Sprintf("%d-%d-%s-%s", 10, 20, from.Hash, to.Hash)
 		path := filepath.Join(dir, name)
 
 		if seen[path] {

--- a/swupd/packs_test.go
+++ b/swupd/packs_test.go
@@ -304,19 +304,19 @@ func TestCreatePackNonConsecutiveDeltas(t *testing.T) {
 	info = ts.createPack("contents", 20, 30, ts.path("image"))
 	mustHaveDeltaCount(t, info, 3)
 	checkFileInPack(t, ts.path("www/30/pack-contents-from-20.tar"),
-		fmt.Sprintf("delta/20-30-%s-%s", hashA1, hashA))
+		fmt.Sprintf("delta/10-20-%s-%s", hashA1, hashA))
 	// note that the from version is 10 since the B file did not change in 20
 	checkFileInPack(t, ts.path("www/30/pack-contents-from-20.tar"),
-		fmt.Sprintf("delta/10-30-%s-%s", hashB, hashB1))
+		fmt.Sprintf("delta/10-20-%s-%s", hashB, hashB1))
 	checkFileInPack(t, ts.path("www/30/pack-contents-from-20.tar"),
-		fmt.Sprintf("delta/20-30-%s-%s", hashC1, hashC2))
+		fmt.Sprintf("delta/10-20-%s-%s", hashC1, hashC2))
 
 	info = ts.createPack("contents", 10, 30, ts.path("image"))
 	mustHaveDeltaCount(t, info, 2)
 	checkFileInPack(t, ts.path("www/30/pack-contents-from-10.tar"),
-		fmt.Sprintf("delta/10-30-%s-%s", hashB, hashB1))
+		fmt.Sprintf("delta/10-20-%s-%s", hashB, hashB1))
 	checkFileInPack(t, ts.path("www/30/pack-contents-from-10.tar"),
-		fmt.Sprintf("delta/10-30-%s-%s", hashC, hashC2))
+		fmt.Sprintf("delta/10-20-%s-%s", hashC, hashC2))
 }
 
 func TestCreatePackWithDelta(t *testing.T) {

--- a/swupd/packs_test.go
+++ b/swupd/packs_test.go
@@ -661,14 +661,14 @@ func TestPackRenames(t *testing.T) {
 	// Pack from 10->30 will contain a delta due to content change (and rename).
 	info = ts.createPack("os-core", 10, 30, ts.path("image"))
 	mustHaveDeltaCount(t, info, 1)
-	checkFileInPack(t, ts.path("www/30/pack-os-core-from-10.tar"), fmt.Sprintf("delta/10-30-%s-%s", hashIn10, hashIn30))
+	checkFileInPack(t, ts.path("www/30/pack-os-core-from-10.tar"), fmt.Sprintf("delta/10-20-%s-%s", hashIn10, hashIn30))
 
 	// Pack from 10->40 will contain a delta due to content change (and rename).
 	info = ts.createPack("os-core", 10, 40, ts.path("image"))
 	mustHaveDeltaCount(t, info, 1)
 
 	// Note that the delta refers to the version of the file, which is still 30.
-	checkFileInPack(t, ts.path("www/40/pack-os-core-from-10.tar"), fmt.Sprintf("delta/10-30-%s-%s", hashIn10, hashIn30))
+	checkFileInPack(t, ts.path("www/40/pack-os-core-from-10.tar"), fmt.Sprintf("delta/10-20-%s-%s", hashIn10, hashIn30))
 }
 
 // TestPackNoDeltas will test cases where there are no delta files

--- a/swupd/packs_test.go
+++ b/swupd/packs_test.go
@@ -656,7 +656,7 @@ func TestPackRenames(t *testing.T) {
 	// Pack from 20->30 will contain a delta due to content change (and rename).
 	info = ts.createPack("os-core", 20, 30, ts.path("image"))
 	mustHaveDeltaCount(t, info, 1)
-	checkFileInPack(t, ts.path("www/30/pack-os-core-from-20.tar"), fmt.Sprintf("delta/20-30-%s-%s", hashIn20, hashIn30))
+	checkFileInPack(t, ts.path("www/30/pack-os-core-from-20.tar"), fmt.Sprintf("delta/10-20-%s-%s", hashIn20, hashIn30))
 
 	// Pack from 10->30 will contain a delta due to content change (and rename).
 	info = ts.createPack("os-core", 10, 30, ts.path("image"))


### PR DESCRIPTION
in https://github.com/clearlinux/mixer-tools/issues/782 a funky issue is found where
we do not use the right versions for delta files in some cases.

A full fix is complicated, but the client IGNORES the versions! so we can just hardcode
the versions to anything (10 and 20 here) and it'll suddenly resolve itself