### PR TITLE
Use sort with version in setupModifiers

### DIFF
--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -358,7 +358,7 @@ func (m *Manifest) setupModifiers() error {
 			f.setFullModifier(m)
 		}
 	}
-	m.sortFilesName()
+	m.sortFilesVersionName()
 	return nil
 }
 


### PR DESCRIPTION
The codebase uses sortFilesVersionName prior to writing out manifests and that should be used in setupModifiers as well.