### PR TITLE
Reset name from manifest based on modifiers

### DIFF
--- a/swupd/files.go
+++ b/swupd/files.go
@@ -82,6 +82,17 @@ const (
 	AVX512_3
 )
 
+var modifierPrefixes = map[ModifierFlag]string{
+	SSE_0:    "",
+	SSE_1:    "",
+	SSE_2:    "",
+	SSE_3:    "",
+	AVX2_1:   "/V3",
+	AVX2_3:   "/V3",
+	AVX512_2: "/V4",
+	AVX512_3: "/V4",
+}
+
 // The three maps below were generated using the following:
 // a := ".acdefghijklmnopqrtuvwxyzABDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#^*"
 

--- a/swupd/heuristics.go
+++ b/swupd/heuristics.go
@@ -31,6 +31,10 @@ func (f *File) setModifierFromPathname() {
 	}
 }
 
+func (f *File) setPrefixFromModifier() {
+	f.Name = modifierPrefixes[f.Modifier] + f.Name
+}
+
 func (f *File) setFullModifier(bits uint64) {
 	switch f.Modifier {
 	case SSE_0:


### PR DESCRIPTION
If the modifiers of a file indicate it came from a chroot path, reset the filename to use the chroot path when reading the file information from a manifest.

Also ensure the only case files are marked as deleted is when it is the SSE file. Other optimized files marked as deleted will be skipped from being output in the manifest (and if the delete is new, the other files with the same post processed path will be marked as new in the version being built to ensure the deleted file is replaced).