### PR TITLE
Reset prefix after manifest is written

### DIFF
--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -401,6 +401,11 @@ func (m *Manifest) WriteManifest(w io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("couldn't write Manifest.%s: %s", m.Name, err)
 	}
+	for _, f := range m.Files {
+		// Reset the prefix as the manifest struct might be used by other
+		// mixer processes and needs to have the path prefix in those cases.
+		f.setPrefixFromModifier()
+	}
 	return nil
 }
 


### PR DESCRIPTION
As other mixer processes might use the manifests after they are written, reset the path to include the prefix once the manifest write is complete.