### PR TITLE
Add linking for optimized prefixes

### DIFF
--- a/swupd/files.go
+++ b/swupd/files.go
@@ -17,6 +17,7 @@ package swupd
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 // TypeFlag describes the file type of a manifest entry.
@@ -457,4 +458,8 @@ func (f *File) isUnsupportedTypeChange() bool {
 // Present tells if a file is present. Returns false if the file is deleted or ghosted.
 func (f *File) Present() bool {
 	return f.Status != StatusDeleted && f.Status != StatusGhosted
+}
+
+func (f *File) hasOptPrefix() bool {
+	return strings.HasPrefix(f.Name, "/V3") || strings.HasPrefix(f.Name, "/V4")
 }

--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -303,7 +303,9 @@ func (m *Manifest) removeOptNonFiles() {
 	seen := make(map[string]bool)
 	i := 0
 	for _, f := range m.Files {
-		if f.Type == TypeFile || f.Type == TypeUnset || !(strings.HasPrefix(f.Name, "/V3") || strings.HasPrefix(f.Name, "/V4")) {
+		if f.Type == TypeFile || f.Type == TypeUnset || !f.hasOptPrefix() {
+			// Looking files files, deleted files or anything else that doesn't have an
+			// optimization prefix.
 			if f.Status == StatusDeleted {
 				if strings.HasPrefix(f.Name, "/V3") || strings.HasPrefix(f.Name, "/V4") {
 					// for non-SSE deleted files the versions on matching files need bumping
@@ -489,8 +491,10 @@ func (m *Manifest) linkPeersAndChange(oldManifest *Manifest, minVersion uint32) 
 				nx++
 				continue
 			}
-			if nf.Hash == of.Hash && of.Version >= minVersion && nf.Misc == of.Misc {
+			if nf.Hash == of.Hash && of.Version >= minVersion && (nf.hasOptPrefix() || nf.Misc == of.Misc) {
 				// same contents, version doesn't change.
+				// misc is ignored for files with an optimization prefix
+				// as that is setup elsewhere to match the base file
 				nf.Version = of.Version
 			} else {
 				// if the file isn't exactly the same, record the change


### PR DESCRIPTION
The optimized prefix doesn't set Misc flags until the last moment during manifest writing so ignore the flags when testing for peers when a prefix is in place.

Also improve some comments and test cases.