### PR TITLE
Rename rst2man.py to rst2man

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,4 +78,4 @@ man: $(MANPAGES)
 
 $(MANPAGES): %: %.rst
 	mkdir -p "$$(dirname $@)"
-	rst2man.py "$<" > "$@.tmp" && mv -f "$@.tmp" "$@"
+	rst2man "$<" > "$@.tmp" && mv -f "$@.tmp" "$@"


### PR DESCRIPTION
The package has been rst2man for long enough, switch the Makefile to use the "new" name.